### PR TITLE
Implementation of a purely chunk based level format

### DIFF
--- a/TombEditor/FormMain.cs
+++ b/TombEditor/FormMain.cs
@@ -1083,14 +1083,16 @@ namespace TombEditor
             if (openFileDialogPRJ2.ShowDialog(this) != DialogResult.OK)
                 return;
 
-            Level level = Prj2Loader.LoadFromPrj2(openFileDialogPRJ2.FileName, new ProgressReporterSimple(this));
-            if (level == null)
+            try
             {
-                DarkUI.Forms.DarkMessageBox.ShowError(
-                    "There was an error while opening project file. File may be in use or may be corrupted", "Error");
-                return;
+                _editor.Level = Prj2Loader.LoadFromPrj2(openFileDialogPRJ2.FileName, new ProgressReporterSimple(this));
             }
-            _editor.Level = level;
+            catch (Exception exc)
+            {
+                logger.Error(exc, "Unable to open \"" + openFileDialogPRJ2.FileName + "\"");
+                DarkUI.Forms.DarkMessageBox.ShowError(
+                    "There was an error while opening project file. File may be in use or may be corrupted. Exception: " + exc, "Error");
+            }
         }
         
         private void importTRLEPRJToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1133,15 +1135,17 @@ namespace TombEditor
             }
             if (saveFileDialogPRJ2.ShowDialog(this) != DialogResult.OK)
                 return;
-
-            if (Prj2Writer.SaveToPrj2(saveFileDialogPRJ2.FileName, _editor.Level))
+            
+            try
             {
+                Prj2Writer.SaveToPrj2(saveFileDialogPRJ2.FileName, _editor.Level);
                 _editor.Level.Settings.LevelFilePath = saveFileDialogPRJ2.FileName;
                 _editor.LevelFileNameChange();
             }
-            else
+            catch (Exception exc)
             {
-                DarkUI.Forms.DarkMessageBox.ShowError("There was an error while saving project file", "Error");
+                logger.Error(exc, "Unable to save to \"" + saveFileDialogPRJ2.FileName + "\".");
+                DarkUI.Forms.DarkMessageBox.ShowError("There was an error while saving project file. Exception: " + exc, "Error");
             }
         }
         private void butRoomUp_Click(object sender, EventArgs e)

--- a/TombEditor/Geometry/IO/Prj2Chunks.cs
+++ b/TombEditor/Geometry/IO/Prj2Chunks.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TombLib.IO;
+
+namespace TombEditor.Geometry.IO
+{
+    // TODO Add documentation for binary offsets of the chunks
+    internal static class Prj2Chunks
+    {
+        public static readonly byte[] MagicNumber = new byte[] { 0x50, 0x52, 0x4A, 0x32 };
+        public const uint Version = 3;
+        public const uint VersionCompressed = Version ^ 0x80000000;
+
+        public static readonly ChunkID Settings = ChunkID.FromString("TeSettings");
+        /**/public static readonly ChunkID WadFilePath = ChunkID.FromString("TeWadFilePath");
+        /**/public static readonly ChunkID FontTextureFilePath = ChunkID.FromString("TeFontTextureFilePath");
+        /**/public static readonly ChunkID SkyTextureFilePath = ChunkID.FromString("TeSkyTextureFilePath");
+        /**/public static readonly ChunkID SoundPaths = ChunkID.FromString("TeSoundPaths");
+        /******/public static readonly ChunkID SoundPath = ChunkID.FromString("TeSoundPath"); //String
+        /**/public static readonly ChunkID GameDirectory = ChunkID.FromString("TeGameDirectory");
+        /**/public static readonly ChunkID GameLevelFilePath = ChunkID.FromString("TeGameLevelFilePath");
+        /**/public static readonly ChunkID GameExecutableFilePath = ChunkID.FromString("TeGameExecutableFilePath");
+        /**/public static readonly ChunkID GameExecutableSuppressAskingForOptions = ChunkID.FromString("TeGameExecutableSuppressAskingForOptions");
+        /**/public static readonly ChunkID IgnoreMissingSounds = ChunkID.FromString("TeIgnoreMissingSounds");
+        /**/public static readonly ChunkID Textures = ChunkID.FromString("TeTextures");
+        /******/public static readonly ChunkID Texture = ChunkID.FromString("TeTexture");
+        /**********/public static readonly ChunkID TexturePath = ChunkID.FromString("TePath");
+        /**********/public static readonly ChunkID TextureConvert512PixelsToDoubleRows = ChunkID.FromString("Te512C");
+        /**********/public static readonly ChunkID TextureReplaceMagentaWithTransparency = ChunkID.FromString("TeMagentaR");
+        public static readonly ChunkID Rooms = ChunkID.FromString("TeRooms");
+        /**/public static readonly ChunkID Room = ChunkID.FromString("TeRoom"); // Contains X, Y sectors, Name, Position directly
+        /******/public static readonly ChunkID Sectors = ChunkID.FromString("TeSectors");
+        /**********/public static readonly ChunkID Sector = ChunkID.FromString("TeS");
+        /**************/public static readonly ChunkID SectorGeometry = ChunkID.FromString("TeG"); //EDFaces, QAFaces, WSFaces, RFFaces, [*]SplitDirectionToggled, 
+        /**************/public static readonly ChunkID SectorProperties = ChunkID.FromString("TeP"); //Flags, Opacitiy, ...
+        /******/public static readonly ChunkID RoomProperties = ChunkID.FromString("TeRoomP"); // Ambient, Flags, ...
+        /******/public static readonly ChunkID Objects = ChunkID.FromString("TeObjects");
+        /**********/public static readonly ChunkID Camera = ChunkID.FromString("TeCam");
+        /**************/public static readonly ChunkID CameraData = ChunkID.FromString("TeDat");
+        /**************/public static readonly ChunkID Pos = ChunkID.FromString("TePos");
+        /**********/public static readonly ChunkID FlybyCamera = ChunkID.FromString("TeFlyBy");
+        /**************///public static readonly ChunkID Pos = ChunkID.FromString("TePos"); // Used here too
+        /**************/public static readonly ChunkID FlyCameraData = ChunkID.FromString("TeDat");
+        /**********/public static readonly ChunkID Light = ChunkID.FromString("TeLight");
+        /**************///public static readonly ChunkID Pos = ChunkID.FromString("TePos"); // Used here too
+        /**************/public static readonly ChunkID LightData = ChunkID.FromString("TeDat");
+        // ...
+    }
+}

--- a/TombEditor/Geometry/IO/Prj2Loader.cs
+++ b/TombEditor/Geometry/IO/Prj2Loader.cs
@@ -18,280 +18,198 @@ namespace TombEditor.Geometry.IO
         
         public static Level LoadFromPrj2(string filename, IProgressReporter progressReporter)
         {
-          //  throw new NotSupportedException();
-            
-            var level = new Level();
+            using (Stream stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                var reader = new BinaryReaderEx(stream);
 
+                // Check file type
+                byte[] magicNumber = reader.ReadBytes(Prj2Chunks.MagicNumber.Length);
+                if (!magicNumber.SequenceEqual(Prj2Chunks.MagicNumber))
+                    throw new NotSupportedException("The header of the *.prj2 file was unrecognizable. Most likely it is not a *.prj2 file.");
+                    
+                // Check file version
+                uint version = reader.ReadUInt32();
+                switch (version)
+                {
+                    case Prj2Chunks.Version:
+                        return LoadLevel(reader, filename);
+                    case Prj2Chunks.VersionCompressed:
+                        // zlib compressed
+                        int compressedSize = reader.ReadInt32();
+                        var projectData = reader.ReadBytes(compressedSize);
+                        projectData = ZLib.DecompressData(projectData);
+
+                        using (var uncompressedStream = new MemoryStream(projectData))
+                            return LoadLevel(new BinaryReaderEx(uncompressedStream), filename);
+                    default:
+                        throw new NotSupportedException("File version " + version + " is not supported.");
+                }
+            }
+        }
+
+        public static Level LoadLevel(BinaryReaderEx streamOuter, string thisPath)
+        {
+            Level level = new Level();
+            ChunkProcessing.ParseChunks(streamOuter, (stream, id, chunkSize) =>
+            {
+                if (LoadLevelSettings(stream, id, level, thisPath))
+                    return true;
+                else if (LoadRooms(stream, id, level))
+                    return true;
+                return false;
+            });
+            return level;
+        }
+
+        public static bool LoadLevelSettings(BinaryReaderEx streamOuter, ChunkID idOuter, Level level, string thisPath)
+        {
+            if (idOuter != Prj2Chunks.Settings)
+                return false;
+
+            LevelSettings settings = new LevelSettings { LevelFilePath = thisPath };
+            ChunkProcessing.ParseChunks(streamOuter, (stream, id, chunkSize) =>
+            {
+                if (id == Prj2Chunks.WadFilePath)
+                    settings.WadFilePath = stream.ReadStringUTF8();
+                else if (id == Prj2Chunks.FontTextureFilePath)
+                    settings.FontTextureFilePath = stream.ReadStringUTF8();
+                else if (id == Prj2Chunks.SkyTextureFilePath)
+                    settings.SkyTextureFilePath = stream.ReadStringUTF8();
+                else if (id == Prj2Chunks.GameDirectory)
+                    settings.GameDirectory = stream.ReadStringUTF8();
+                else if (id == Prj2Chunks.GameLevelFilePath)
+                    settings.GameLevelFilePath = stream.ReadStringUTF8();
+                else if (id == Prj2Chunks.GameExecutableFilePath)
+                    settings.GameExecutableFilePath = stream.ReadStringUTF8();
+                else if (id == Prj2Chunks.GameExecutableSuppressAskingForOptions)
+                    settings.GameExecutableSuppressAskingForOptions = stream.ReadBoolean();
+                else if (id == Prj2Chunks.IgnoreMissingSounds)
+                    settings.IgnoreMissingSounds = stream.ReadBoolean();
+                else if (LoadLevelTextures(stream, id, settings))
+                    return true;
+                else
+                    return false;
+                return true;
+            });
+            level.Settings = settings;
+            level.ReloadObjectsTry();
+            return true;
+        }
+
+        public static bool LoadLevelTextures(BinaryReaderEx streamOuter, ChunkID idOuter, LevelSettings settings)
+        {
+            if (idOuter != Prj2Chunks.Textures)
+                return false;
+            
+            ChunkProcessing.ParseChunks(streamOuter, (stream, id, chunkSize) => LoadLevelTexture(stream, id, settings));
+            return true;
+        }
+
+        public static bool LoadLevelTexture(BinaryReaderEx streamOuter, ChunkID idOuter, LevelSettings settings)
+        {
+            if (idOuter != Prj2Chunks.Texture)
+                return false;
+
+            string path = "";
+            bool convert512PixelsToDoubleRows = false;
+            bool replaceMagentaWithTransparency = false;
+            ChunkProcessing.ParseChunks(streamOuter, (stream, id, chunkSize) =>
+            {
+                if (id == Prj2Chunks.TexturePath)
+                    path = stream.ReadStringUTF8();
+                else if (id == Prj2Chunks.TextureConvert512PixelsToDoubleRows)
+                    convert512PixelsToDoubleRows = stream.ReadBoolean();
+                else if (id == Prj2Chunks.TextureReplaceMagentaWithTransparency)
+                    replaceMagentaWithTransparency = stream.ReadBoolean();
+                else
+                    return false;
+                return true;
+            });
+            settings.Textures.Add(new LevelTexture(settings, path, convert512PixelsToDoubleRows, replaceMagentaWithTransparency));
+            return true;
+        }
+
+        public static bool LoadRooms(BinaryReaderEx reader, ChunkID idOuter, Level level)
+        {
+            if (idOuter != Prj2Chunks.Rooms)
+                return true;
+            
             var portalsList = new List<Portal>();
             var triggersList = new List<TriggerInstance>();
             var objectsList = new List<ObjectInstance>();
             var modelsList = new Dictionary<uint, string>();
 
             Prj2ChunkType chunkType;
-
-            try
+            
+            // Read imported geometry
+            uint numImportedGeometry = reader.ReadUInt32();
+            for (int i = 0; i < numImportedGeometry; i++)
             {
-                using (var reader = CreatePrjReader(filename))
+                var modelFileName = reader.ReadStringUTF8();
+                var scale = reader.ReadSingle();
+
+                if (File.Exists(modelFileName))
                 {
-                    level.Settings.LevelFilePath = filename;
-
-                    // Read version code (in the future it can be used to have multiple PRJ versions)
-                    int versionCode = reader.ReadInt32();
-
-                    // Read resource files
-                    var texturePath = reader.ReadStringUTF8();
-                    level.Settings.WadFilePath = reader.ReadStringUTF8();
-                    level.Settings.FontTextureFilePath = reader.ReadStringUTF8();
-                    level.Settings.SkyTextureFilePath = reader.ReadStringUTF8();
-                    level.Settings.GameDirectory = reader.ReadStringUTF8();
-                    level.Settings.GameLevelFilePath = reader.ReadStringUTF8();
-                    level.Settings.GameExecutableFilePath = reader.ReadStringUTF8();
-                    level.Settings.SoundPaths.Clear();
-                    int soundPathCount = reader.ReadInt32();
-                    for (int i = 0; i < soundPathCount; ++i)
-                        level.Settings.SoundPaths.Add(new SoundPath(reader.ReadStringUTF8()));
-                    level.Settings.IgnoreMissingSounds = reader.ReadBoolean();
-
-                    ResourceLoader.TryLoadingObjects(level, progressReporter);
-
-                    LevelTexture texture;
-                    if (string.IsNullOrEmpty(texturePath))
-                        texture = new LevelTexture();
-                    else
-                        texture = new LevelTexture(level.Settings, texturePath, true);
-                    if (texture.Image.Width != 256)
-                        texture.SetConvert512PixelsToDoubleRows(level.Settings, false); // Only use this compatibility thing if actually needed
-                    level.Settings.Textures.Add(texture);
-
-                    // Read fillers
-                    reader.ReadBytes(16);
-
-                    // Read imported geometry
-                    uint numImportedGeometry = reader.ReadUInt32();
-                    for (int i = 0; i < numImportedGeometry; i++)
+                    if (GeometryImporterExporter.LoadModel(modelFileName, scale) != null)
                     {
-                        var modelFileName = reader.ReadStringUTF8();
-                        var scale = reader.ReadSingle();
-
-                        if (File.Exists(modelFileName))
-                        {
-                            if (GeometryImporterExporter.LoadModel(modelFileName, scale) != null)
-                            {
-                                modelsList.Add((uint)i, modelFileName);
-                            }
-                        }
+                        modelsList.Add((uint)i, modelFileName);
                     }
+                }
+            }
 
-                    // Read portals
-                    uint numPortals = reader.ReadUInt32();
-                    for (int i = 0; i < numPortals; i++)
-                    {
-                        var roomIndex = reader.ReadUInt16();
-                        var adjoiningRoomIndex = reader.ReadUInt16();
+            // Read portals
+            uint numPortals = reader.ReadUInt32();
+            for (int i = 0; i < numPortals; i++)
+            {
+                var roomIndex = reader.ReadUInt16();
+                var adjoiningRoomIndex = reader.ReadUInt16();
 
-                        var direction = (PortalDirection)reader.ReadUInt16();
+                var direction = (PortalDirection)reader.ReadUInt16();
 
-                        var left = reader.ReadInt32();
-                        var top = reader.ReadInt32();
-                        var right = reader.ReadInt32();
-                        var bottom = reader.ReadInt32();
-                        var area = new Rectangle(left, top, right, bottom);
+                var left = reader.ReadInt32();
+                var top = reader.ReadInt32();
+                var right = reader.ReadInt32();
+                var bottom = reader.ReadInt32();
+                var area = new Rectangle(left, top, right, bottom);
 
-                        reader.ReadBytes(16);
+                reader.ReadBytes(16);
 
-                        // Check for other chunks
-                        chunkType = (Prj2ChunkType)reader.ReadUInt16();
-                        if (chunkType != Prj2ChunkType.NoExtraChunk)
-                        {
-                            // TODO: logic for reading in the future other chunks
-                        }
+                // Check for other chunks
+                chunkType = (Prj2ChunkType)reader.ReadUInt16();
+                if (chunkType != Prj2ChunkType.NoExtraChunk)
+                {
+                    // TODO: logic for reading in the future other chunks
+                }
 
-                        var portal = new Portal(area, direction, null);
-                        portal.RoomIndex = roomIndex;
-                        portal.AdjoiningRoomIndex = adjoiningRoomIndex;
+                var portal = new Portal(area, direction, null);
+                portal.RoomIndex = roomIndex;
+                portal.AdjoiningRoomIndex = adjoiningRoomIndex;
 
-                        portalsList.Add(portal);
-                    }
+                portalsList.Add(portal);
+            }
 
-                    // Read objects
-                    uint numObjects = reader.ReadUInt32();
-                    for (int i = 0; i < numObjects; i++)
-                    {
-                        var objType = (Prj2ObjectType)reader.ReadUInt16();
-                        var roomIndex = reader.ReadUInt16();
+            // Read objects
+            uint numObjects = reader.ReadUInt32();
+            for (int i = 0; i < numObjects; i++)
+            {
+                var objType = (Prj2ObjectType)reader.ReadUInt16();
+                var roomIndex = reader.ReadUInt16();
 
-                        switch (objType)
-                        {
-                            case Prj2ObjectType.Moveable:
-                                var moveable = new MoveableInstance();
+                switch (objType)
+                {
+                    case Prj2ObjectType.Moveable:
+                        var moveable = new MoveableInstance();
 
-                                moveable.RoomIndex = roomIndex;
-                                moveable.WadObjectId = reader.ReadUInt32();
-                                moveable.Position = reader.ReadVector3();
-                                moveable.RotationY = reader.ReadSingle();
-                                moveable.RotationYRadians = reader.ReadSingle();
-                                moveable.Ocb = reader.ReadInt16();
-                                moveable.Invisible = reader.ReadBoolean();
-                                moveable.ClearBody = reader.ReadBoolean();
-                                moveable.CodeBits = reader.ReadByte();
-                                moveable.Color = reader.ReadVector4();
-
-                                reader.ReadBytes(8);
-
-                                // Check for other chunks
-                                chunkType = (Prj2ChunkType)reader.ReadUInt16();
-                                if (chunkType != Prj2ChunkType.NoExtraChunk)
-                                {
-                                    // TODO: logic for reading in the future other chunks
-                                }
-
-                                objectsList.Add(moveable);
-
-                                break;
-
-                            case Prj2ObjectType.Static:
-                                var staticMesh = new StaticInstance();
-
-                                staticMesh.RoomIndex = roomIndex;
-                                staticMesh.WadObjectId = reader.ReadUInt32();
-                                staticMesh.Position = reader.ReadVector3();
-                                staticMesh.RotationY = reader.ReadSingle();
-                                staticMesh.RotationYRadians = reader.ReadSingle();
-                                staticMesh.Ocb = reader.ReadInt16();
-                                staticMesh.Color = reader.ReadVector4();
-
-                                reader.ReadBytes(8);
-
-                                // Check for other chunks
-                                chunkType = (Prj2ChunkType)reader.ReadUInt16();
-                                if (chunkType != Prj2ChunkType.NoExtraChunk)
-                                {
-                                    // TODO: logic for reading in the future other chunks
-                                }
-
-                                objectsList.Add(staticMesh);
-
-                                break;
-
-                            case Prj2ObjectType.Camera:
-                                var camera = new CameraInstance();
-
-                                camera.RoomIndex = roomIndex;
-                                camera.Position = reader.ReadVector3();
-                                camera.Flags = reader.ReadUInt16();
-                                camera.Number = reader.ReadUInt16();
-                                camera.Sequence = reader.ReadUInt16();
-                                camera.Roll = reader.ReadSingle();
-                                camera.Speed = reader.ReadSingle();
-                                camera.Timer = reader.ReadInt16();
-                                camera.Fov = reader.ReadSingle();
-                                camera.Fixed = reader.ReadBoolean();
-
-                                reader.ReadBytes(8);
-
-                                // Check for other chunks
-                                chunkType = (Prj2ChunkType)reader.ReadUInt16();
-                                if (chunkType != Prj2ChunkType.NoExtraChunk)
-                                {
-                                    // TODO: logic for reading in the future other chunks
-                                }
-
-                                objectsList.Add(camera);
-
-                                break;
-
-                            case Prj2ObjectType.FlybyCamera:
-                                var flybyCamera = new FlybyCameraInstance();
-
-                                flybyCamera.RoomIndex = roomIndex;
-                                flybyCamera.Position = reader.ReadVector3();
-                                flybyCamera.Flags = reader.ReadUInt16();
-                                flybyCamera.Number = reader.ReadUInt16();
-                                flybyCamera.Sequence = reader.ReadUInt16();
-                                flybyCamera.Roll = reader.ReadSingle();
-                                flybyCamera.Speed = reader.ReadSingle();
-                                flybyCamera.Timer = reader.ReadInt16();
-                                flybyCamera.Fov = reader.ReadSingle();
-                                flybyCamera.RotationX = reader.ReadSingle();
-                                flybyCamera.RotationY = reader.ReadSingle();
-
-                                reader.ReadBytes(8);
-
-                                // Check for other chunks
-                                chunkType = (Prj2ChunkType)reader.ReadUInt16();
-                                if (chunkType != Prj2ChunkType.NoExtraChunk)
-                                {
-                                    // TODO: logic for reading in the future other chunks
-                                }
-
-                                objectsList.Add(flybyCamera);
-
-                                break;
-
-                            case Prj2ObjectType.Sink:
-                                var sink = new SinkInstance();
-
-                                sink.RoomIndex = roomIndex;
-                                sink.Position = reader.ReadVector3();
-                                sink.Strength = reader.ReadInt16();
-
-                                reader.ReadBytes(8);
-
-                                // Check for other chunks
-                                chunkType = (Prj2ChunkType)reader.ReadUInt16();
-                                if (chunkType != Prj2ChunkType.NoExtraChunk)
-                                {
-                                    // TODO: logic for reading in the future other chunks
-                                }
-
-                                objectsList.Add(sink);
-
-                                break;
-
-                            case Prj2ObjectType.SoundSource:
-                                var sound = new SoundSourceInstance();
-
-                                sound.RoomIndex = roomIndex;
-                                sound.Position = reader.ReadVector3();
-                                sound.SoundId = reader.ReadInt16();
-                                sound.Flags = reader.ReadInt16();
-                                sound.CodeBits = reader.ReadByte();
-
-                                reader.ReadBytes(8);
-
-                                // Check for other chunks
-                                chunkType = (Prj2ChunkType)reader.ReadUInt16();
-                                if (chunkType != Prj2ChunkType.NoExtraChunk)
-                                {
-                                    // TODO: logic for reading in the future other chunks
-                                }
-
-                                objectsList.Add(sound);
-
-                                break;
-                        }
-                    }
-
-                    // Read triggers
-                    uint numTriggers = reader.ReadUInt32();
-                    for (int i = 0; i < numTriggers; i++)
-                    {
-                        var roomIndex = reader.ReadUInt16();
-                        var trigger = new TriggerInstance(new Rectangle(reader.ReadInt32(),
-                                                                        reader.ReadInt32(),
-                                                                        reader.ReadInt32(),
-                                                                        reader.ReadInt32()));
-                        trigger.RoomIndex = roomIndex;
-                        trigger.TriggerType = (TriggerType)reader.ReadUInt16();
-                        trigger.TargetType = (TriggerTargetType)reader.ReadUInt16();
-                        trigger.TargetData = reader.ReadInt16();
-
-                        var targetObject = reader.ReadInt32();
-                        if (targetObject != -1) trigger.TargetObj = objectsList[targetObject];
-
-                        trigger.Timer = reader.ReadInt16();
-                        trigger.CodeBits = reader.ReadByte();
-                        trigger.OneShot = reader.ReadBoolean();
+                        moveable.RoomIndex = roomIndex;
+                        moveable.WadObjectId = reader.ReadUInt32();
+                        moveable.Position = reader.ReadVector3();
+                        moveable.RotationY = reader.ReadSingle();
+                        moveable.RotationYRadians = reader.ReadSingle();
+                        moveable.Ocb = reader.ReadInt16();
+                        moveable.Invisible = reader.ReadBoolean();
+                        moveable.ClearBody = reader.ReadBoolean();
+                        moveable.CodeBits = reader.ReadByte();
+                        moveable.Color = reader.ReadVector4();
 
                         reader.ReadBytes(8);
 
@@ -302,188 +220,22 @@ namespace TombEditor.Geometry.IO
                             // TODO: logic for reading in the future other chunks
                         }
 
-                        triggersList.Add(trigger);
-                    }
+                        objectsList.Add(moveable);
 
-                    // Read rooms
-                    uint numRooms = reader.ReadUInt32();
-                    for (int i = 0; i < numRooms; i++)
-                    {
-                        bool defined = reader.ReadBoolean();
-                        if (!defined) continue;
+                        break;
 
-                        var roomName = reader.ReadStringUTF8();
-                        var position = reader.ReadVector3();
-                        var numXsectors = reader.ReadByte();
-                        var numZsectors = reader.ReadByte();
+                    case Prj2ObjectType.Static:
+                        var staticMesh = new StaticInstance();
 
-                        var room = new Room(level, numXsectors, numZsectors, roomName);
-                        room.Position = position;
+                        staticMesh.RoomIndex = roomIndex;
+                        staticMesh.WadObjectId = reader.ReadUInt32();
+                        staticMesh.Position = reader.ReadVector3();
+                        staticMesh.RotationY = reader.ReadSingle();
+                        staticMesh.RotationYRadians = reader.ReadSingle();
+                        staticMesh.Ocb = reader.ReadInt16();
+                        staticMesh.Color = reader.ReadVector4();
 
-                        for (int z = 0; z < numZsectors; z++)
-                        {
-                            for (int x = 0; x < numXsectors; x++)
-                            {
-                                var b = new Block(0, 12);
-
-                                b.Type = (BlockType)reader.ReadUInt16();
-                                b.Flags = (BlockFlags)reader.ReadUInt16();
-
-                                for (int j = 0; j < 4; j++) b.QAFaces[j] = reader.ReadInt16();
-                                for (int j = 0; j < 4; j++) b.EDFaces[j] = reader.ReadInt16();
-                                for (int j = 0; j < 4; j++) b.WSFaces[j] = reader.ReadInt16();
-                                for (int j = 0; j < 4; j++) b.RFFaces[j] = reader.ReadInt16();
-
-                                var floorPortal = reader.ReadInt32();
-                                b.TempFloorOpacity = (PortalOpacity)reader.ReadUInt16();
-
-                                var ceilingPortal = reader.ReadInt32();
-                                b.TempCeilingOpacity = (PortalOpacity)reader.ReadUInt16();
-
-                                var wallPortal = reader.ReadInt32();
-                                b.TempWallOpacity = (PortalOpacity)reader.ReadUInt16();
-
-                                b.NoCollisionFloor = reader.ReadBoolean();
-                                b.NoCollisionCeiling = reader.ReadBoolean();
-
-                                b.FloorDiagonalSplit = (DiagonalSplit)reader.ReadUInt16();
-                                b.CeilingDiagonalSplit = (DiagonalSplit)reader.ReadUInt16();
-                                b.FloorSplitDirectionToggled = reader.ReadBoolean();
-                                b.CeilingSplitDirectionToggled = reader.ReadBoolean();
-
-                                for (int f = 0; f < 29; f++)
-                                {
-                                    Prj2FaceTextureMode mode = (Prj2FaceTextureMode)reader.ReadUInt16();
-
-                                    if (mode == Prj2FaceTextureMode.Texture)
-                                    {
-                                        var textureArea = new TextureArea();
-
-                                        textureArea.TexCoord0 = reader.ReadVector2();
-                                        textureArea.TexCoord1 = reader.ReadVector2();
-                                        textureArea.TexCoord2 = reader.ReadVector2();
-                                        textureArea.TexCoord3 = reader.ReadVector2();
-                                        textureArea.BlendMode = (BlendMode)reader.ReadUInt16();
-                                        textureArea.DoubleSided = reader.ReadBoolean();
-
-                                        reader.ReadBytes(8);
-
-                                        // Check for other chunks
-                                        chunkType = (Prj2ChunkType)reader.ReadUInt16();
-                                        if (chunkType != Prj2ChunkType.NoExtraChunk)
-                                        {
-                                            // TODO: logic for reading in the future other chunks
-                                        }
-
-                                        textureArea.Texture = level.Settings.Textures[0];
-
-                                        b.SetFaceTexture((BlockFace)f, textureArea);
-                                    }
-                                    else if (mode == Prj2FaceTextureMode.InvisibleColor)
-                                    {
-                                        b.SetFaceTexture((BlockFace)f, new TextureArea { Texture = TextureInvisible.Instance });
-                                    }
-                                }
-
-                                reader.ReadBytes(32);
-
-                                // Check for other chunks
-                                chunkType = (Prj2ChunkType)reader.ReadUInt16();
-                                if (chunkType != Prj2ChunkType.NoExtraChunk)
-                                {
-                                    // TODO: logic for reading in the future other chunks
-                                }
-
-                                room.Blocks[x, z] = b;
-                            }
-                        }
-
-                        uint numLights = reader.ReadUInt32();
-                        for (int j = 0; j < numLights; j++)
-                        {
-                            var l = new Light((LightType)reader.ReadUInt16());
-
-                            l.Position = reader.ReadVector3();
-                            l.Intensity = reader.ReadSingle();
-                            l.Color = reader.ReadVector3();
-                            l.In = reader.ReadSingle();
-                            l.Out = reader.ReadSingle();
-                            l.Len = reader.ReadSingle();
-                            l.Cutoff = reader.ReadSingle();
-                            var rotationX = reader.ReadSingle();
-                            var rotationY = reader.ReadSingle();
-                            l.SetArbitaryRotationsYX(rotationY, rotationX);
-                            l.Enabled = reader.ReadBoolean();
-                            l.CastsShadows = reader.ReadBoolean();
-                            l.IsDynamicallyUsed = reader.ReadBoolean();
-                            l.IsStaticallyUsed = reader.ReadBoolean();
-
-                            reader.ReadBytes(8);
-
-                            // Check for other chunks
-                            chunkType = (Prj2ChunkType)reader.ReadUInt16();
-                            if (chunkType != Prj2ChunkType.NoExtraChunk)
-                            {
-                                // TODO: logic for reading in the future other chunks
-                            }
-
-                            room.AddObject(level, l);
-                        }
-
-                        uint numImportedGeometryForThisRoom = reader.ReadUInt32();
-                        for (int j = 0; j < numImportedGeometryForThisRoom; j++)
-                        {
-                            var pos = reader.ReadVector3();
-                            var model = reader.ReadUInt32();
-
-                            // If model is not present in the file system, ignore it
-                            if (!modelsList.ContainsKey(model)) continue;
-
-                            var importedGeometry = new RoomGeometryInstance();
-                            importedGeometry.Position = pos;
-                            importedGeometry.Model = GeometryImporterExporter.Models[modelsList[model]];
-
-                            reader.ReadBytes(8);
-
-                            // Check for other chunks
-                            chunkType = (Prj2ChunkType)reader.ReadUInt16();
-                            if (chunkType != Prj2ChunkType.NoExtraChunk)
-                            {
-                                // TODO: logic for reading in the future other chunks
-                            }
-
-                            room.AddObject(level, importedGeometry);
-                        }
-
-                        uint numPortalsForThisRoom = reader.ReadUInt32();
-                        for (int j = 0; j < numPortalsForThisRoom; j++)
-                            room.Prj2Portals.Add(reader.ReadUInt32());
-
-                        uint numTriggersForThisRoom = reader.ReadUInt32();
-                        for (int j = 0; j < numTriggersForThisRoom; j++)
-                            room.Prj2Triggers.Add(reader.ReadUInt32());
-
-                        room.AmbientLight = reader.ReadVector4();
-                        room.AlternateGroup = reader.ReadInt16();
-                        room.Prj2AlternateRoomIndex = reader.ReadInt32();
-                        room.Prj2AlternateBaseRoomIndex = reader.ReadInt32();
-                        room.FlagCold = reader.ReadBoolean();
-                        room.FlagDamage = reader.ReadBoolean();
-                        room.FlagHorizon = reader.ReadBoolean();
-                        room.FlagMist = reader.ReadBoolean();
-                        room.FlagOutside = reader.ReadBoolean();
-                        room.FlagRain = reader.ReadBoolean();
-                        room.FlagReflection = reader.ReadBoolean();
-                        room.FlagSnow = reader.ReadBoolean();
-                        room.FlagWater = reader.ReadBoolean();
-                        room.FlagQuickSand = reader.ReadBoolean();
-                        room.ExcludeFromPathFinding = reader.ReadBoolean();
-                        room.WaterLevel = reader.ReadInt16();
-                        room.MistLevel = reader.ReadInt16();
-                        room.ReflectionLevel = reader.ReadInt16();
-                        room.Reverberation = (Reverberation)reader.ReadUInt16();
-
-                        reader.ReadBytes(64);
+                        reader.ReadBytes(8);
 
                         // Check for other chunks
                         chunkType = (Prj2ChunkType)reader.ReadUInt16();
@@ -492,13 +244,262 @@ namespace TombEditor.Geometry.IO
                             // TODO: logic for reading in the future other chunks
                         }
 
-                        level.Rooms[i] = room;
+                        objectsList.Add(staticMesh);
+
+                        break;
+
+                    case Prj2ObjectType.Camera:
+                        var camera = new CameraInstance();
+
+                        camera.RoomIndex = roomIndex;
+                        camera.Position = reader.ReadVector3();
+                        camera.Flags = reader.ReadUInt16();
+                        camera.Number = reader.ReadUInt16();
+                        camera.Sequence = reader.ReadUInt16();
+                        camera.Roll = reader.ReadSingle();
+                        camera.Speed = reader.ReadSingle();
+                        camera.Timer = reader.ReadInt16();
+                        camera.Fov = reader.ReadSingle();
+                        camera.Fixed = reader.ReadBoolean();
+
+                        reader.ReadBytes(8);
+
+                        // Check for other chunks
+                        chunkType = (Prj2ChunkType)reader.ReadUInt16();
+                        if (chunkType != Prj2ChunkType.NoExtraChunk)
+                        {
+                            // TODO: logic for reading in the future other chunks
+                        }
+
+                        objectsList.Add(camera);
+
+                        break;
+
+                    case Prj2ObjectType.FlybyCamera:
+                        var flybyCamera = new FlybyCameraInstance();
+
+                        flybyCamera.RoomIndex = roomIndex;
+                        flybyCamera.Position = reader.ReadVector3();
+                        flybyCamera.Flags = reader.ReadUInt16();
+                        flybyCamera.Number = reader.ReadUInt16();
+                        flybyCamera.Sequence = reader.ReadUInt16();
+                        flybyCamera.Roll = reader.ReadSingle();
+                        flybyCamera.Speed = reader.ReadSingle();
+                        flybyCamera.Timer = reader.ReadInt16();
+                        flybyCamera.Fov = reader.ReadSingle();
+                        flybyCamera.RotationX = reader.ReadSingle();
+                        flybyCamera.RotationY = reader.ReadSingle();
+
+                        reader.ReadBytes(8);
+
+                        // Check for other chunks
+                        chunkType = (Prj2ChunkType)reader.ReadUInt16();
+                        if (chunkType != Prj2ChunkType.NoExtraChunk)
+                        {
+                            // TODO: logic for reading in the future other chunks
+                        }
+
+                        objectsList.Add(flybyCamera);
+
+                        break;
+
+                    case Prj2ObjectType.Sink:
+                        var sink = new SinkInstance();
+
+                        sink.RoomIndex = roomIndex;
+                        sink.Position = reader.ReadVector3();
+                        sink.Strength = reader.ReadInt16();
+
+                        reader.ReadBytes(8);
+
+                        // Check for other chunks
+                        chunkType = (Prj2ChunkType)reader.ReadUInt16();
+                        if (chunkType != Prj2ChunkType.NoExtraChunk)
+                        {
+                            // TODO: logic for reading in the future other chunks
+                        }
+
+                        objectsList.Add(sink);
+
+                        break;
+
+                    case Prj2ObjectType.SoundSource:
+                        var sound = new SoundSourceInstance();
+
+                        sound.RoomIndex = roomIndex;
+                        sound.Position = reader.ReadVector3();
+                        sound.SoundId = reader.ReadInt16();
+                        sound.Flags = reader.ReadInt16();
+                        sound.CodeBits = reader.ReadByte();
+
+                        reader.ReadBytes(8);
+
+                        // Check for other chunks
+                        chunkType = (Prj2ChunkType)reader.ReadUInt16();
+                        if (chunkType != Prj2ChunkType.NoExtraChunk)
+                        {
+                            // TODO: logic for reading in the future other chunks
+                        }
+
+                        objectsList.Add(sound);
+
+                        break;
+                }
+            }
+
+            // Read triggers
+            uint numTriggers = reader.ReadUInt32();
+            for (int i = 0; i < numTriggers; i++)
+            {
+                var roomIndex = reader.ReadUInt16();
+                var trigger = new TriggerInstance(new Rectangle(reader.ReadInt32(),
+                                                                reader.ReadInt32(),
+                                                                reader.ReadInt32(),
+                                                                reader.ReadInt32()));
+                trigger.RoomIndex = roomIndex;
+                trigger.TriggerType = (TriggerType)reader.ReadUInt16();
+                trigger.TargetType = (TriggerTargetType)reader.ReadUInt16();
+                trigger.TargetData = reader.ReadInt16();
+
+                var targetObject = reader.ReadInt32();
+                if (targetObject != -1)
+                    trigger.TargetObj = objectsList[targetObject];
+
+                trigger.Timer = reader.ReadInt16();
+                trigger.CodeBits = reader.ReadByte();
+                trigger.OneShot = reader.ReadBoolean();
+
+                reader.ReadBytes(8);
+
+                // Check for other chunks
+                chunkType = (Prj2ChunkType)reader.ReadUInt16();
+                if (chunkType != Prj2ChunkType.NoExtraChunk)
+                {
+                    // TODO: logic for reading in the future other chunks
+                }
+
+                triggersList.Add(trigger);
+            }
+
+            // Read rooms
+            uint numRooms = reader.ReadUInt32();
+            for (int i = 0; i < numRooms; i++)
+            {
+                bool defined = reader.ReadBoolean();
+                if (!defined)
+                    continue;
+
+                var roomName = reader.ReadStringUTF8();
+                var position = reader.ReadVector3();
+                var numXsectors = reader.ReadByte();
+                var numZsectors = reader.ReadByte();
+
+                var room = new Room(level, numXsectors, numZsectors, roomName);
+                room.Position = position;
+
+                for (int z = 0; z < numZsectors; z++)
+                {
+                    for (int x = 0; x < numXsectors; x++)
+                    {
+                        var b = new Block(0, 12);
+
+                        b.Type = (BlockType)reader.ReadUInt16();
+                        b.Flags = (BlockFlags)reader.ReadUInt16();
+
+                        for (int j = 0; j < 4; j++)
+                            b.QAFaces[j] = reader.ReadInt16();
+                        for (int j = 0; j < 4; j++)
+                            b.EDFaces[j] = reader.ReadInt16();
+                        for (int j = 0; j < 4; j++)
+                            b.WSFaces[j] = reader.ReadInt16();
+                        for (int j = 0; j < 4; j++)
+                            b.RFFaces[j] = reader.ReadInt16();
+
+                        var floorPortal = reader.ReadInt32();
+                        b.TempFloorOpacity = (PortalOpacity)reader.ReadUInt16();
+
+                        var ceilingPortal = reader.ReadInt32();
+                        b.TempCeilingOpacity = (PortalOpacity)reader.ReadUInt16();
+
+                        var wallPortal = reader.ReadInt32();
+                        b.TempWallOpacity = (PortalOpacity)reader.ReadUInt16();
+
+                        b.NoCollisionFloor = reader.ReadBoolean();
+                        b.NoCollisionCeiling = reader.ReadBoolean();
+
+                        b.FloorDiagonalSplit = (DiagonalSplit)reader.ReadUInt16();
+                        b.CeilingDiagonalSplit = (DiagonalSplit)reader.ReadUInt16();
+                        b.FloorSplitDirectionToggled = reader.ReadBoolean();
+                        b.CeilingSplitDirectionToggled = reader.ReadBoolean();
+
+                        for (int f = 0; f < 29; f++)
+                        {
+                            Prj2FaceTextureMode mode = (Prj2FaceTextureMode)reader.ReadUInt16();
+
+                            if (mode == Prj2FaceTextureMode.Texture)
+                            {
+                                var textureArea = new TextureArea();
+
+                                textureArea.TexCoord0 = reader.ReadVector2();
+                                textureArea.TexCoord1 = reader.ReadVector2();
+                                textureArea.TexCoord2 = reader.ReadVector2();
+                                textureArea.TexCoord3 = reader.ReadVector2();
+                                textureArea.BlendMode = (BlendMode)reader.ReadUInt16();
+                                textureArea.DoubleSided = reader.ReadBoolean();
+
+                                reader.ReadBytes(8);
+
+                                // Check for other chunks
+                                chunkType = (Prj2ChunkType)reader.ReadUInt16();
+                                if (chunkType != Prj2ChunkType.NoExtraChunk)
+                                {
+                                    // TODO: logic for reading in the future other chunks
+                                }
+
+                                textureArea.Texture = level.Settings.Textures[0];
+
+                                b.SetFaceTexture((BlockFace)f, textureArea);
+                            }
+                            else if (mode == Prj2FaceTextureMode.InvisibleColor)
+                            {
+                                b.SetFaceTexture((BlockFace)f, new TextureArea { Texture = TextureInvisible.Instance });
+                            }
+                        }
+
+                        reader.ReadBytes(32);
+
+                        // Check for other chunks
+                        chunkType = (Prj2ChunkType)reader.ReadUInt16();
+                        if (chunkType != Prj2ChunkType.NoExtraChunk)
+                        {
+                            // TODO: logic for reading in the future other chunks
+                        }
+
+                        room.Blocks[x, z] = b;
                     }
+                }
 
-                    uint numAnimatedTextures = reader.ReadUInt32();
-                    uint numTextureSounds = reader.ReadUInt32();
+                uint numLights = reader.ReadUInt32();
+                for (int j = 0; j < numLights; j++)
+                {
+                    var l = new Light((LightType)reader.ReadUInt16());
 
-                    reader.ReadBytes(256);
+                    l.Position = reader.ReadVector3();
+                    l.Intensity = reader.ReadSingle();
+                    l.Color = reader.ReadVector3();
+                    l.In = reader.ReadSingle();
+                    l.Out = reader.ReadSingle();
+                    l.Len = reader.ReadSingle();
+                    l.Cutoff = reader.ReadSingle();
+                    var rotationX = reader.ReadSingle();
+                    var rotationY = reader.ReadSingle();
+                    l.SetArbitaryRotationsYX(rotationY, rotationX);
+                    l.Enabled = reader.ReadBoolean();
+                    l.CastsShadows = reader.ReadBoolean();
+                    l.IsDynamicallyUsed = reader.ReadBoolean();
+                    l.IsStaticallyUsed = reader.ReadBoolean();
+
+                    reader.ReadBytes(8);
 
                     // Check for other chunks
                     chunkType = (Prj2ChunkType)reader.ReadUInt16();
@@ -506,111 +507,161 @@ namespace TombEditor.Geometry.IO
                     {
                         // TODO: logic for reading in the future other chunks
                     }
+
+                    room.AddObject(level, l);
                 }
 
-                // Now link everything
-                for (int i = 0; i < level.Rooms.Length; i++)
+                uint numImportedGeometryForThisRoom = reader.ReadUInt32();
+                for (int j = 0; j < numImportedGeometryForThisRoom; j++)
                 {
-                    if (level.Rooms[i] == null) continue;
-                    if (level.Rooms[i].Prj2AlternateRoomIndex != -1) level.Rooms[i].AlternateRoom = level.Rooms[level.Rooms[i].Prj2AlternateRoomIndex];
-                    if (level.Rooms[i].Prj2AlternateBaseRoomIndex != -1) level.Rooms[i].AlternateBaseRoom = level.Rooms[level.Rooms[i].Prj2AlternateBaseRoomIndex];
-                }
+                    var pos = reader.ReadVector3();
+                    var model = reader.ReadUInt32();
 
-                foreach (var obj in objectsList)
-                {
-                    obj.Room = level.Rooms[obj.RoomIndex];
-                    obj.Room.AddObject(level, obj);
-                }
+                    // If model is not present in the file system, ignore it
+                    if (!modelsList.ContainsKey(model))
+                        continue;
 
-                foreach (var trigger in triggersList)
-                {
-                    trigger.Room = level.Rooms[trigger.RoomIndex];
-                    trigger.Room.AddObject(level, trigger);
-                }
+                    var importedGeometry = new RoomGeometryInstance();
+                    importedGeometry.Position = pos;
+                    importedGeometry.Model = GeometryImporterExporter.Models[modelsList[model]];
 
-                foreach (var portal in portalsList)
-                {
-                    portal.AdjoiningRoom = level.Rooms[portal.AdjoiningRoomIndex];
-                }
+                    reader.ReadBytes(8);
 
-                for (int i = 0; i < level.Rooms.Length; i++)
-                {
-                    if (level.Rooms[i] == null) continue;
-
-                    var room = level.Rooms[i];
-                    foreach (var portalIndex in room.Prj2Portals)
+                    // Check for other chunks
+                    chunkType = (Prj2ChunkType)reader.ReadUInt16();
+                    if (chunkType != Prj2ChunkType.NoExtraChunk)
                     {
-                        var portal = portalsList[(int)portalIndex];
-                        portal.AddPortalToRoom(level, room, true);
+                        // TODO: logic for reading in the future other chunks
                     }
+
+                    room.AddObject(level, importedGeometry);
                 }
 
-                foreach (var portal in portalsList)
+                uint numPortalsForThisRoom = reader.ReadUInt32();
+                for (int j = 0; j < numPortalsForThisRoom; j++)
+                    room.Prj2Portals.Add(reader.ReadUInt32());
+
+                uint numTriggersForThisRoom = reader.ReadUInt32();
+                for (int j = 0; j < numTriggersForThisRoom; j++)
+                    room.Prj2Triggers.Add(reader.ReadUInt32());
+
+                room.AmbientLight = reader.ReadVector4();
+                room.AlternateGroup = reader.ReadInt16();
+                room.Prj2AlternateRoomIndex = reader.ReadInt32();
+                room.Prj2AlternateBaseRoomIndex = reader.ReadInt32();
+                room.FlagCold = reader.ReadBoolean();
+                room.FlagDamage = reader.ReadBoolean();
+                room.FlagHorizon = reader.ReadBoolean();
+                room.FlagMist = reader.ReadBoolean();
+                room.FlagOutside = reader.ReadBoolean();
+                room.FlagRain = reader.ReadBoolean();
+                room.FlagReflection = reader.ReadBoolean();
+                room.FlagSnow = reader.ReadBoolean();
+                room.FlagWater = reader.ReadBoolean();
+                room.FlagQuickSand = reader.ReadBoolean();
+                room.ExcludeFromPathFinding = reader.ReadBoolean();
+                room.WaterLevel = reader.ReadInt16();
+                room.MistLevel = reader.ReadInt16();
+                room.ReflectionLevel = reader.ReadInt16();
+                room.Reverberation = (Reverberation)reader.ReadUInt16();
+
+                reader.ReadBytes(64);
+
+                // Check for other chunks
+                chunkType = (Prj2ChunkType)reader.ReadUInt16();
+                if (chunkType != Prj2ChunkType.NoExtraChunk)
                 {
-                    portal.AddPortalToRoom(level, portal.Room, true);
-                    if (portal.Room.AlternateRoom != null) portal.AddPortalToRoom(level, portal.AdjoiningRoom, true);
+                    // TODO: logic for reading in the future other chunks
                 }
 
-                for (int i = 0; i < level.Rooms.Length; i++)
-                {
-                    if (level.Rooms[i] == null) continue;
-
-                    var room = level.Rooms[i];
-                    for (int x = 0; x < room.NumXSectors; x++)
-                    {
-                        for (int z = 0; z < room.NumZSectors; z++)
-                        {
-                            room.Blocks[x, z].FloorOpacity = room.Blocks[x, z].TempFloorOpacity;
-                            room.Blocks[x, z].CeilingOpacity = room.Blocks[x, z].TempCeilingOpacity;
-                            room.Blocks[x, z].WallOpacity = room.Blocks[x, z].TempWallOpacity;
-                        }
-                    }
-                }
+                level.Rooms[i] = room;
             }
-            catch (Exception ex)
+
+            uint numAnimatedTextures = reader.ReadUInt32();
+            uint numTextureSounds = reader.ReadUInt32();
+
+            reader.ReadBytes(256);
+
+            // Check for other chunks
+            chunkType = (Prj2ChunkType)reader.ReadUInt16();
+            if (chunkType != Prj2ChunkType.NoExtraChunk)
             {
-                logger.Error(ex);
-                return null;
+                // TODO: logic for reading in the future other chunks
             }
-            
+
+            // Now link everything
+            for (int i = 0; i < level.Rooms.Length; i++)
+            {
+                if (level.Rooms[i] == null)
+                    continue;
+                if (level.Rooms[i].Prj2AlternateRoomIndex != -1)
+                    level.Rooms[i].AlternateRoom = level.Rooms[level.Rooms[i].Prj2AlternateRoomIndex];
+                if (level.Rooms[i].Prj2AlternateBaseRoomIndex != -1)
+                    level.Rooms[i].AlternateBaseRoom = level.Rooms[level.Rooms[i].Prj2AlternateBaseRoomIndex];
+            }
+
+            foreach (var obj in objectsList)
+            {
+                obj.Room = level.Rooms[obj.RoomIndex];
+                obj.Room.AddObject(level, obj);
+            }
+
+            foreach (var trigger in triggersList)
+            {
+                trigger.Room = level.Rooms[trigger.RoomIndex];
+                trigger.Room.AddObject(level, trigger);
+            }
+
+            foreach (var portal in portalsList)
+            {
+                portal.AdjoiningRoom = level.Rooms[portal.AdjoiningRoomIndex];
+            }
+
+            for (int i = 0; i < level.Rooms.Length; i++)
+            {
+                if (level.Rooms[i] == null)
+                    continue;
+
+                var room = level.Rooms[i];
+                foreach (var portalIndex in room.Prj2Portals)
+                {
+                    var portal = portalsList[(int)portalIndex];
+                    portal.AddPortalToRoom(level, room, true);
+                }
+            }
+
+            foreach (var portal in portalsList)
+            {
+                portal.AddPortalToRoom(level, portal.Room, true);
+                if (portal.Room.AlternateRoom != null)
+                    portal.AddPortalToRoom(level, portal.AdjoiningRoom, true);
+            }
+
+            for (int i = 0; i < level.Rooms.Length; i++)
+            {
+                if (level.Rooms[i] == null)
+                    continue;
+
+                var room = level.Rooms[i];
+                for (int x = 0; x < room.NumXSectors; x++)
+                {
+                    for (int z = 0; z < room.NumZSectors; z++)
+                    {
+                        room.Blocks[x, z].FloorOpacity = room.Blocks[x, z].TempFloorOpacity;
+                        room.Blocks[x, z].CeilingOpacity = room.Blocks[x, z].TempCeilingOpacity;
+                        room.Blocks[x, z].WallOpacity = room.Blocks[x, z].TempWallOpacity;
+                    }
+                }
+            }
+
             // Now build the real geometry and update DirectX buffers
             foreach (var room in level.Rooms.Where(room => room != null))
                 room.UpdateCompletely();
 
-            return level;
+            return true;
         }
-        
-        private static BinaryReaderEx CreatePrjReader(string filename)
-        {
-            var reader = new BinaryReaderEx(new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read));
 
-            // Check file version
-            var buffer = reader.ReadBytes(4);
-            if (buffer[0] == 0x50 && buffer[1] == 0x52 && buffer[2] == 0x4A && buffer[3] == 0x32)
-            {
-                // PRJ2 senza compressione
-                return reader;
-            }
-            else if (buffer[0] == 0x5A && buffer[1] == 0x52 && buffer[2] == 0x4A && buffer[3] == 0x32)
-            {
-                // PRJ2 compresso
-                int uncompressedSize = reader.ReadInt32();
-                int compressedSize = reader.ReadInt32();
-                var projectData = reader.ReadBytes(compressedSize);
-                projectData = ZLib.DecompressData(projectData);
 
-                var ms = new MemoryStream(projectData);
-                ms.Seek(0, SeekOrigin.Begin);
-
-                reader = new BinaryReaderEx(ms);
-                reader.ReadInt32();
-                return reader;
-            }
-            else
-            {
-                throw new NotSupportedException("The header of the *.prj2 file was unrecognizable.");
-            }
-        }
 
         private class IdResolver<T> where T : class
         {

--- a/TombEditor/Geometry/IO/Prj2Writer.cs
+++ b/TombEditor/Geometry/IO/Prj2Writer.cs
@@ -36,472 +36,512 @@ namespace TombEditor.Geometry.IO
     {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
-        public static bool SaveToPrj2(string filename, Level level)
+        public static void SaveToPrj2(string filename, Level level)
         {
-            // First collect all shared lists so we can save references as indices
-            var portalsList = new List<Portal>();
-            var triggersList = new List<TriggerInstance>();
-            var objectsList = new List<ObjectInstance>();
-            var modelsList = new List<string>();
-
-            foreach(var room in level.Rooms)
+            using (var stream = new MemoryStream())
             {
-                if (room == null) continue;
+                var writer = new BinaryWriterEx(stream);
 
-                foreach (var trigger in room.Triggers)
-                    if (!triggersList.Contains(trigger))
-                        triggersList.Add(trigger);
+                // Write version
+                writer.Write(Prj2Chunks.MagicNumber);
+                writer.Write(Prj2Chunks.Version);
 
-                foreach (var portal in room.Portals)
-                    if (!portalsList.Contains(portal))
-                        portalsList.Add(portal);
+                // Write level data
+                WriteLevel(writer, level);
 
-                foreach (var obj in room.Objects)
-                    if (!objectsList.Contains(obj) && 
-                        obj.GetType() != typeof(Light) && 
-                        obj.GetType() != typeof(RoomGeometryInstance))
-                        objectsList.Add(obj);
+                // Write file
+                byte[] projectData = stream.ToArray();
+                using (var fileStream = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None))
+                    fileStream.Write(projectData, 0, projectData.Length);
             }
+        }
 
-            for (int m = 0; m < GeometryImporterExporter.Models.Count; m++)
-                modelsList.Add(GeometryImporterExporter.Models.ElementAt(m).Key);
+        public static void WriteLevel(BinaryWriterEx writer, Level level)
+        {
+            // Write settings
+            WriteLevelSettings(writer, level.Settings);
 
-            try
+            // Write rooms
+            WriteRooms(writer, level.Rooms);
+
+            ChunkProcessing.WriteChunkEnd(writer);
+        }
+
+        public static void WriteLevelSettings(BinaryWriterEx streamOuter, LevelSettings settings)
+        {
+            ChunkProcessing.WriteChunk(streamOuter, Prj2Chunks.Settings, (stream, id) =>
             {
-                var ms = new MemoryStream();
-                byte[] projectData;
-                using (var writer = new BinaryWriterEx(ms))
+                ChunkProcessing.WriteChunk(stream, Prj2Chunks.WadFilePath,
+                    (writer, id2) => writer.WriteStringUTF8(settings.WadFilePath ?? ""));
+                ChunkProcessing.WriteChunk(stream, Prj2Chunks.FontTextureFilePath,
+                    (writer, id2) => writer.WriteStringUTF8(settings.FontTextureFilePath ?? ""));
+                ChunkProcessing.WriteChunk(stream, Prj2Chunks.SkyTextureFilePath,
+                    (writer, id2) => writer.WriteStringUTF8(settings.SkyTextureFilePath ?? ""));
+                ChunkProcessing.WriteChunk(stream, Prj2Chunks.GameDirectory,
+                    (writer, id2) => writer.WriteStringUTF8(settings.GameDirectory ?? ""));
+                ChunkProcessing.WriteChunk(stream, Prj2Chunks.GameLevelFilePath,
+                    (writer, id2) => writer.WriteStringUTF8(settings.GameLevelFilePath ?? ""));
+                ChunkProcessing.WriteChunk(stream, Prj2Chunks.GameExecutableFilePath,
+                    (writer, id2) => writer.WriteStringUTF8(settings.GameExecutableFilePath ?? ""));
+                ChunkProcessing.WriteChunk(stream, Prj2Chunks.GameExecutableSuppressAskingForOptions,
+                    (writer, id2) => writer.Write(settings.GameExecutableSuppressAskingForOptions));
+                ChunkProcessing.WriteChunk(stream, Prj2Chunks.IgnoreMissingSounds,
+                    (writer, id2) => writer.Write(settings.IgnoreMissingSounds));
+                WriteLevelTextures(stream, settings.Textures);
+                ChunkProcessing.WriteChunkEnd(stream);
+            }, long.MaxValue);
+        }
+
+        public static void WriteLevelTextures(BinaryWriterEx streamOuter, List<LevelTexture> textures)
+        {
+            ChunkProcessing.WriteChunk(streamOuter, Prj2Chunks.Textures, (stream, id) =>
+            {
+                foreach (LevelTexture texture in textures)
+                    WriteLevelTexture(stream, texture);
+                ChunkProcessing.WriteChunkEnd(stream);
+            });
+        }
+
+        public static void WriteLevelTexture(BinaryWriterEx streamOuter, LevelTexture texture)
+        {
+            ChunkProcessing.WriteChunk(streamOuter, Prj2Chunks.Texture, (stream, id) =>
+            {
+                ChunkProcessing.WriteChunk(stream, Prj2Chunks.TexturePath,
+                    (writer, id2) => writer.WriteStringUTF8(texture.Path ?? ""));
+                ChunkProcessing.WriteChunk(stream, Prj2Chunks.TextureConvert512PixelsToDoubleRows,
+                    (writer, id2) => writer.Write(texture.Convert512PixelsToDoubleRows));
+                ChunkProcessing.WriteChunk(stream, Prj2Chunks.TextureReplaceMagentaWithTransparency,
+                    (writer, id2) => writer.Write(texture.ReplaceMagentaWithTransparency));
+                ChunkProcessing.WriteChunkEnd(stream);
+            });
+        }
+
+        public static void WriteRooms(BinaryWriterEx streamOuter, IList<Room> rooms)
+        {
+            ChunkProcessing.WriteChunk(streamOuter, Prj2Chunks.Rooms, (writer, id) =>
+            {
+                // Collect all shared lists so we can save references as indices
+                var portalsList = new List<Portal>();
+                var triggersList = new List<TriggerInstance>();
+                var objectsList = new List<ObjectInstance>();
+                var modelsList = new List<string>();
+
+                foreach (var room in rooms.Where(room => room != null))
                 {
-                    // Write version
-                    var version = new byte[] { 0x50, 0x52, 0x4A, 0x32 };
-                    writer.Write(version);
+                    foreach (var trigger in room.Triggers)
+                        if (!triggersList.Contains(trigger))
+                            triggersList.Add(trigger);
 
-                    const int versionCode = 2;
-                    writer.Write(versionCode);
+                    foreach (var portal in room.Portals)
+                        if (!portalsList.Contains(portal))
+                            portalsList.Add(portal);
 
-                    // Write settings
-                    writer.WriteStringUTF8(level.Settings.TextureFilePath ?? "");
-                    writer.WriteStringUTF8(level.Settings.WadFilePath ?? "");
-                    writer.WriteStringUTF8(level.Settings.FontTextureFilePath ?? "");
-                    writer.WriteStringUTF8(level.Settings.SkyTextureFilePath ?? "");
-                    writer.WriteStringUTF8(level.Settings.GameDirectory ?? "");
-                    writer.WriteStringUTF8(level.Settings.GameLevelFilePath ?? "");
-                    writer.WriteStringUTF8(level.Settings.GameExecutableFilePath ?? "");
-                    writer.Write(level.Settings.SoundPaths.Count);
-                    foreach (SoundPath path in level.Settings.SoundPaths)
-                        writer.WriteStringUTF8(path.Path ?? "");
-                    writer.Write(level.Settings.IgnoreMissingSounds);
+                    foreach (var obj in room.Objects)
+                        if (!objectsList.Contains(obj) &&
+                            obj.GetType() != typeof(Light) &&
+                            obj.GetType() != typeof(RoomGeometryInstance))
+                            objectsList.Add(obj);
+                }
+
+                for (int m = 0; m < GeometryImporterExporter.Models.Count; m++)
+                    modelsList.Add(GeometryImporterExporter.Models.ElementAt(m).Key);
+                // Write imported references
+                uint numModels = (uint)GeometryImporterExporter.Models.Count;
+                writer.Write(numModels);
+                for (int i = 0; i < numModels; i++)
+                {
+                    writer.WriteStringUTF8(GeometryImporterExporter.Models.ElementAt(i).Key);
+                    writer.Write(GeometryImporterExporter.Models.ElementAt(i).Value.Scale);
+                }
+
+                // Write portals
+                writer.Write(portalsList.Count);
+                foreach (var p in portalsList)
+                {
+                    writer.Write((ushort)rooms.ReferenceIndexOf(p.Room));
+                    writer.Write((ushort)rooms.ReferenceIndexOf(p.AdjoiningRoom));
+                    writer.Write((ushort)p.Direction);
+                    writer.Write(p.Area.Left);
+                    writer.Write(p.Area.Top);
+                    writer.Write(p.Area.Right);
+                    writer.Write(p.Area.Bottom);
 
                     writer.WriteFiller(0x00, 16);
 
-                    // Write imported references
-                    uint numModels = (uint)GeometryImporterExporter.Models.Count;
-                    writer.Write(numModels);
-                    for (int i = 0; i < numModels; i++)
+                    // No more data, in future we can expand the structure using chunks
+                    writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
+                }
+
+                // Write objects: moveables, static meshes, cameras, sinks, sound sources
+                int numObjects = 0;
+                foreach (var o in objectsList)
+                    if (o.GetType() != typeof(Light))
+                        numObjects++;
+
+                writer.Write(numObjects);
+                foreach (var o in objectsList)
+                {
+                    if (o.GetType() == typeof(MoveableInstance))
                     {
-                        writer.WriteStringUTF8(GeometryImporterExporter.Models.ElementAt(i).Key);
-                        writer.Write(GeometryImporterExporter.Models.ElementAt(i).Value.Scale);
-                    }
+                        MoveableInstance instance = (MoveableInstance)o;
 
-                    // Write portals
-                    writer.Write(portalsList.Count);
-                    foreach (var p in portalsList)
-                    {
-                        writer.Write((ushort)level.Rooms.ReferenceIndexOf(p.Room));
-                        writer.Write((ushort)level.Rooms.ReferenceIndexOf(p.AdjoiningRoom));
-                        writer.Write((ushort)p.Direction);
-                        writer.Write(p.Area.Left);
-                        writer.Write(p.Area.Top);
-                        writer.Write(p.Area.Right);
-                        writer.Write(p.Area.Bottom);
-
-                        writer.WriteFiller(0x00, 16);
-
-                        // No more data, in future we can expand the structure using chunks
-                        writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
-                    }
-
-                    // Write objects: moveables, static meshes, cameras, sinks, sound sources
-                    int numObjects = 0;
-                    foreach (var o in objectsList)
-                        if (o.GetType() != typeof(Light))
-                            numObjects++;
-
-                    writer.Write(numObjects);
-                    foreach (var o in objectsList)
-                    {
-                        if (o.GetType() == typeof(MoveableInstance))
-                        {
-                            MoveableInstance instance = (MoveableInstance)o;
-
-                            writer.Write((ushort)Prj2ObjectType.Moveable);
-                            writer.Write((ushort)level.Rooms.ReferenceIndexOf(o.Room));
-                            writer.Write(instance.ItemType.Id);
-                            writer.Write(instance.Position);
-                            writer.Write(instance.RotationY);
-                            writer.Write(instance.RotationYRadians);
-                            writer.Write(instance.Ocb);
-                            writer.Write(instance.Invisible);
-                            writer.Write(instance.ClearBody);
-                            writer.Write(instance.CodeBits);
-                            writer.Write(instance.Color);
-
-                            writer.WriteFiller(0x00, 8);
-
-                            // No more data, in future we can expand the structure using chunks
-                            writer.Write((ushort)Prj2ChunkType.NoExtraChunk); 
-                        }
-                        else if (o.GetType() == typeof(StaticInstance))
-                        {
-                            StaticInstance instance = (StaticInstance)o;
-
-                            writer.Write((ushort)Prj2ObjectType.Static);
-                            writer.Write((ushort)level.Rooms.ReferenceIndexOf(o.Room));
-                            writer.Write(instance.ItemType.Id);
-                            writer.Write(instance.Position);
-                            writer.Write(instance.RotationY);
-                            writer.Write(instance.RotationYRadians);
-                            writer.Write(instance.Ocb);
-                            writer.Write(instance.Color);
-
-                            writer.WriteFiller(0x00, 8);
-
-                            // No more data, in future we can expand the structure using chunks
-                            writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
-                        }
-                        else if (o.GetType() == typeof(CameraInstance))
-                        {
-                            CameraInstance instance = (CameraInstance)o;
-
-                            writer.Write((ushort)Prj2ObjectType.Camera);
-                            writer.Write((ushort)level.Rooms.ReferenceIndexOf(o.Room));
-                            writer.Write(instance.Position);
-                            writer.Write(instance.Flags);
-                            writer.Write(instance.Number);
-                            writer.Write(instance.Sequence);
-                            writer.Write(instance.Roll);
-                            writer.Write(instance.Speed);
-                            writer.Write(instance.Timer);
-                            writer.Write(instance.Fov);
-                            writer.Write(instance.Fixed);
-
-                            writer.WriteFiller(0x00, 8);
-
-                            // No more data, in future we can expand the structure using chunks
-                            writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
-                        }
-                        else if (o.GetType() == typeof(FlybyCameraInstance))
-                        {
-                            FlybyCameraInstance instance = (FlybyCameraInstance)o;
-
-                            writer.Write((ushort)Prj2ObjectType.FlybyCamera);
-                            writer.Write((ushort)level.Rooms.ReferenceIndexOf(o.Room));
-                            writer.Write(instance.Position);
-                            writer.Write(instance.Flags);
-                            writer.Write(instance.Number);
-                            writer.Write(instance.Sequence);
-                            writer.Write(instance.Roll);
-                            writer.Write(instance.Speed);
-                            writer.Write(instance.Timer);
-                            writer.Write(instance.Fov);
-                            writer.Write(instance.RotationX);
-                            writer.Write(instance.RotationY);
-
-                            writer.WriteFiller(0x00, 8);
-
-                            // No more data, in future we can expand the structure using chunks
-                            writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
-                        }
-                        else if (o.GetType() == typeof(SinkInstance))
-                        {
-                            SinkInstance instance = (SinkInstance)o;
-
-                            writer.Write((ushort)Prj2ObjectType.Sink);
-                            writer.Write((ushort)level.Rooms.ReferenceIndexOf(o.Room));
-                            writer.Write(instance.Position);
-                            writer.Write(instance.Strength);
-
-                            writer.WriteFiller(0x00, 8);
-
-                            // No more data, in future we can expand the structure using chunks
-                            writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
-                        }
-                        else if (o.GetType() == typeof(SoundSourceInstance))
-                        {
-                            SoundSourceInstance instance = (SoundSourceInstance)o;
-
-                            writer.Write((ushort)Prj2ObjectType.SoundSource);
-                            writer.Write((ushort)level.Rooms.ReferenceIndexOf(o.Room));
-                            writer.Write(instance.Position);
-                            writer.Write(instance.SoundId);
-                            writer.Write(instance.Flags);
-                            writer.Write(instance.CodeBits);
-
-                            writer.WriteFiller(0x00, 8);
-
-                            // No more data, in future we can expand the structure using chunks
-                            writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
-                        }
-                    }
-
-                    // Write triggers
-                    int numTriggers = triggersList.Count;
-                    writer.Write(numTriggers);
-                    foreach (var t in triggersList)
-                    {
-                        writer.Write((ushort)level.Rooms.ReferenceIndexOf(t.Room));
-                        writer.Write(t.Area.Left);
-                        writer.Write(t.Area.Top);
-                        writer.Write(t.Area.Right);
-                        writer.Write(t.Area.Bottom);
-                        writer.Write((ushort)t.TriggerType);
-                        writer.Write((ushort)t.TargetType);
-                        writer.Write(t.TargetData);
-                        writer.Write((t.TargetObj != null ? (int)objectsList.IndexOf(t.TargetObj) : (int)-1));
-                        writer.Write(t.Timer);
-                        writer.Write(t.CodeBits);
-                        writer.Write(t.OneShot);
+                        writer.Write((ushort)Prj2ObjectType.Moveable);
+                        writer.Write((ushort)rooms.ReferenceIndexOf(o.Room));
+                        writer.Write(instance.ItemType.Id);
+                        writer.Write(instance.Position);
+                        writer.Write(instance.RotationY);
+                        writer.Write(instance.RotationYRadians);
+                        writer.Write(instance.Ocb);
+                        writer.Write(instance.Invisible);
+                        writer.Write(instance.ClearBody);
+                        writer.Write(instance.CodeBits);
+                        writer.Write(instance.Color);
 
                         writer.WriteFiller(0x00, 8);
 
                         // No more data, in future we can expand the structure using chunks
                         writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
                     }
-
-                    // Write rooms
-                    int numRooms = level.Rooms.Length;
-                    writer.Write(numRooms);
-                    for (int i = 0; i < numRooms; i++)
+                    else if (o.GetType() == typeof(StaticInstance))
                     {
-                        var r = level.Rooms[i];
-                        writer.Write(r != null);
-                        if (r == null)
-                            continue;
-                        
-                        writer.WriteStringUTF8(r.Name);
-                        writer.Write(r.Position);
-                        writer.Write(r.NumXSectors);
-                        writer.Write(r.NumZSectors);
+                        StaticInstance instance = (StaticInstance)o;
 
-                        for (int z = 0; z < r.NumZSectors; z++)
-                        {
-                            for (int x = 0; x < r.NumXSectors; x++)
-                            {
-                                var b = r.Blocks[x, z];
+                        writer.Write((ushort)Prj2ObjectType.Static);
+                        writer.Write((ushort)rooms.ReferenceIndexOf(o.Room));
+                        writer.Write(instance.ItemType.Id);
+                        writer.Write(instance.Position);
+                        writer.Write(instance.RotationY);
+                        writer.Write(instance.RotationYRadians);
+                        writer.Write(instance.Ocb);
+                        writer.Write(instance.Color);
 
-                                writer.Write((ushort)b.Type);
-                                writer.Write((ushort)b.Flags);
-
-                                for (int n = 0; n < 4; n++)
-                                    writer.Write(b.QAFaces[n]);
-                                for (int n = 0; n < 4; n++)
-                                    writer.Write(b.EDFaces[n]);
-                                for (int n = 0; n < 4; n++)
-                                    writer.Write(b.WSFaces[n]);
-                                for (int n = 0; n < 4; n++)
-                                    writer.Write(b.RFFaces[n]);
-
-                                writer.Write((b.FloorPortal!=null ? (int)portalsList.IndexOf(b.FloorPortal) : (int)-1));
-                                writer.Write((ushort)b.FloorOpacity);
-                                writer.Write((b.CeilingPortal != null ? (int)portalsList.IndexOf(b.CeilingPortal) : (int)-1));
-                                writer.Write((ushort)b.CeilingOpacity);
-                                writer.Write((b.WallPortal != null ? (int)portalsList.IndexOf(b.WallPortal) : (int)-1));
-                                writer.Write((ushort)b.WallOpacity);
-                                writer.Write(b.NoCollisionFloor);
-                                writer.Write(b.NoCollisionCeiling);
-                                writer.Write((ushort)b.FloorDiagonalSplit);
-                                writer.Write((ushort)b.CeilingDiagonalSplit);
-                                writer.Write(b.FloorSplitDirectionToggled);
-                                writer.Write(b.CeilingSplitDirectionToggled);
-
-                                for (int f = 0; f < 29; f++)
-                                {
-                                    var texture = b.GetFaceTexture((BlockFace)f);
-
-                                    var mode = Prj2FaceTextureMode.NoTexture;
-                                    if (texture.TextureIsInvisble)
-                                    {
-                                        mode = Prj2FaceTextureMode.InvisibleColor;
-                                    }
-                                    else
-                                    {
-                                        if (!texture.TextureIsUnavailable)
-                                            mode = Prj2FaceTextureMode.Texture;
-                                        else
-                                            mode = Prj2FaceTextureMode.NoTexture;
-                                    }
-
-                                    writer.Write((ushort)mode);
-
-                                    if (mode == Prj2FaceTextureMode.Texture)
-                                    {
-                                        writer.Write(texture.TexCoord0);
-                                        writer.Write(texture.TexCoord1);
-                                        writer.Write(texture.TexCoord2);
-                                        writer.Write(texture.TexCoord3);
-                                        writer.Write((ushort)texture.BlendMode);
-                                        writer.Write(texture.DoubleSided);
-
-                                        writer.WriteFiller(0x00, 8);
-
-                                        // No more data, in future we can expand the structure using chunks
-                                        writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
-                                    }
-                                }
-
-                                writer.WriteFiller(0x00, 32);
-
-                                // No more data, in future we can expand the structure using chunks
-                                writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
-                            }
-                        }
-
-                        // Write lights
-                        uint numLights = 0;
-                        foreach (var o in r.Objects)
-                            if (o.GetType() == typeof(Light))
-                                numLights++;
-                        writer.Write(numLights);
-
-                        foreach (var o in r.Objects)
-                        {
-                            if (o.GetType() == typeof(Light))
-                            {
-                                var l = (Light)o;
-
-                                writer.Write((ushort)l.Type);
-                                writer.Write(l.Position);
-                                writer.Write(l.Intensity);
-                                writer.Write(l.Color);
-                                writer.Write(l.In);
-                                writer.Write(l.Out);
-                                writer.Write(l.Len);
-                                writer.Write(l.Cutoff);
-                                writer.Write(l.RotationX);
-                                writer.Write(l.RotationY);
-                                writer.Write(l.Enabled);
-                                writer.Write(l.CastsShadows);
-                                writer.Write(l.IsDynamicallyUsed);
-                                writer.Write(l.IsStaticallyUsed);
-
-                                writer.WriteFiller(0x00, 8);
-
-                                // No more data, in future we can expand the structure using chunks
-                                writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
-                            }
-                        }
-
-                        // Write imported geometry
-                        uint numImportedGeometry = 0;
-                        foreach (var o in r.Objects)
-                            if (o.GetType() == typeof(RoomGeometryInstance))
-                                numImportedGeometry++;
-                        writer.Write(numImportedGeometry);
-
-                        foreach (var o in r.Objects)
-                        {
-                            if (o.GetType() == typeof(RoomGeometryInstance))
-                            {
-                                RoomGeometryInstance instance = (RoomGeometryInstance)o;
-
-                                writer.Write(instance.Position);
-                                writer.Write((uint)modelsList.IndexOf(instance.Model.Name));
-
-                                writer.WriteFiller(0x00, 8);
-
-                                // No more data, in future we can expand the structure using chunks
-                                writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
-                            }
-                        }
-
-                        // Write some references
-                        uint numPortalsForThisRoom = (uint)r.Portals.Count();
-                        writer.Write(numPortalsForThisRoom);
-                        foreach (var portalInRoom in r.Portals)
-                            writer.Write((uint)portalsList.IndexOf(portalInRoom));
-
-                        uint numTriggersForThisRoom = (uint)r.Triggers.Count();
-                        writer.Write(numTriggersForThisRoom);
-                        foreach (var triggerInRoom in r.Triggers)
-                            writer.Write((uint)triggersList.IndexOf(triggerInRoom));
-
-                        writer.Write(r.AmbientLight);
-                        writer.Write(r.AlternateGroup);
-                        writer.Write((r.AlternateRoom != null ? (int)level.Rooms.ReferenceIndexOf(r.AlternateRoom) : (int)-1));
-                        writer.Write((r.AlternateBaseRoom != null ? (int)level.Rooms.ReferenceIndexOf(r.AlternateBaseRoom) : (int)-1));
-                        writer.Write(r.FlagCold);
-                        writer.Write(r.FlagDamage);
-                        writer.Write(r.FlagHorizon);
-                        writer.Write(r.FlagMist);
-                        writer.Write(r.FlagOutside);
-                        writer.Write(r.FlagRain);
-                        writer.Write(r.FlagReflection);
-                        writer.Write(r.FlagSnow);
-                        writer.Write(r.FlagWater);
-                        writer.Write(r.FlagQuickSand);
-                        writer.Write(r.ExcludeFromPathFinding);
-                        writer.Write(r.WaterLevel);
-                        writer.Write(r.MistLevel);
-                        writer.Write(r.ReflectionLevel);
-                        writer.Write((ushort)r.Reverberation);
-
-                        writer.WriteFiller(0x00, 64);
+                        writer.WriteFiller(0x00, 8);
 
                         // No more data, in future we can expand the structure using chunks
                         writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
                     }
-
-                    // Write animated textures
-                    /*int numAnimatedTextures = level.AnimatedTextures.Count;
-                    writer.Write(numAnimatedTextures);
-                    foreach (var textureSet in level.AnimatedTextures)
+                    else if (o.GetType() == typeof(CameraInstance))
                     {
-                        writer.Write((byte)textureSet.Effect);
+                        CameraInstance instance = (CameraInstance)o;
 
-                        int numTexturesInSet = textureSet.Textures.Count;
-                        writer.Write(numTexturesInSet);
+                        writer.Write((ushort)Prj2ObjectType.Camera);
+                        writer.Write((ushort)rooms.ReferenceIndexOf(o.Room));
+                        writer.Write(instance.Position);
+                        writer.Write(instance.Flags);
+                        writer.Write(instance.Number);
+                        writer.Write(instance.Sequence);
+                        writer.Write(instance.Roll);
+                        writer.Write(instance.Speed);
+                        writer.Write(instance.Timer);
+                        writer.Write(instance.Fov);
+                        writer.Write(instance.Fixed);
 
-                        foreach (var texture in textureSet.Textures)
-                        {
-                            writer.Write(texture.Page);
-                            writer.Write(texture.X);
-                            writer.Write(texture.Y);
-                        }
+                        writer.WriteFiller(0x00, 8);
+
+                        // No more data, in future we can expand the structure using chunks
+                        writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
                     }
-                    */
-
-                    // TODO: waiting for final animated textures code
-                    uint numAnimatedTextures = 0;
-                    writer.Write(numAnimatedTextures);
-
-                    uint numTextureSounds = 0; // level.TextureSounds.Count;
-                    writer.Write(numTextureSounds);
-                    /*foreach (var sound in level.TextureSounds)
+                    else if (o.GetType() == typeof(FlybyCameraInstance))
                     {
-                        writer.Write(sound.X);
-                        writer.Write(sound.Y);
-                        writer.Write(sound.Page);
-                        writer.Write((byte)sound.Sound);
-                    }*/
+                        FlybyCameraInstance instance = (FlybyCameraInstance)o;
 
-                    writer.WriteFiller(0x00, 256);
+                        writer.Write((ushort)Prj2ObjectType.FlybyCamera);
+                        writer.Write((ushort)rooms.ReferenceIndexOf(o.Room));
+                        writer.Write(instance.Position);
+                        writer.Write(instance.Flags);
+                        writer.Write(instance.Number);
+                        writer.Write(instance.Sequence);
+                        writer.Write(instance.Roll);
+                        writer.Write(instance.Speed);
+                        writer.Write(instance.Timer);
+                        writer.Write(instance.Fov);
+                        writer.Write(instance.RotationX);
+                        writer.Write(instance.RotationY);
+
+                        writer.WriteFiller(0x00, 8);
+
+                        // No more data, in future we can expand the structure using chunks
+                        writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
+                    }
+                    else if (o.GetType() == typeof(SinkInstance))
+                    {
+                        SinkInstance instance = (SinkInstance)o;
+
+                        writer.Write((ushort)Prj2ObjectType.Sink);
+                        writer.Write((ushort)rooms.ReferenceIndexOf(o.Room));
+                        writer.Write(instance.Position);
+                        writer.Write(instance.Strength);
+
+                        writer.WriteFiller(0x00, 8);
+
+                        // No more data, in future we can expand the structure using chunks
+                        writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
+                    }
+                    else if (o.GetType() == typeof(SoundSourceInstance))
+                    {
+                        SoundSourceInstance instance = (SoundSourceInstance)o;
+
+                        writer.Write((ushort)Prj2ObjectType.SoundSource);
+                        writer.Write((ushort)rooms.ReferenceIndexOf(o.Room));
+                        writer.Write(instance.Position);
+                        writer.Write(instance.SoundId);
+                        writer.Write(instance.Flags);
+                        writer.Write(instance.CodeBits);
+
+                        writer.WriteFiller(0x00, 8);
+
+                        // No more data, in future we can expand the structure using chunks
+                        writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
+                    }
+                }
+
+                // Write triggers
+                int numTriggers = triggersList.Count;
+                writer.Write(numTriggers);
+                foreach (var t in triggersList)
+                {
+                    writer.Write((ushort)rooms.ReferenceIndexOf(t.Room));
+                    writer.Write(t.Area.Left);
+                    writer.Write(t.Area.Top);
+                    writer.Write(t.Area.Right);
+                    writer.Write(t.Area.Bottom);
+                    writer.Write((ushort)t.TriggerType);
+                    writer.Write((ushort)t.TargetType);
+                    writer.Write(t.TargetData);
+                    writer.Write((t.TargetObj != null ? (int)objectsList.IndexOf(t.TargetObj) : (int)-1));
+                    writer.Write(t.Timer);
+                    writer.Write(t.CodeBits);
+                    writer.Write(t.OneShot);
+
+                    writer.WriteFiller(0x00, 8);
 
                     // No more data, in future we can expand the structure using chunks
                     writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
-
-                    projectData = ms.ToArray();
                 }
 
-                using (var writer = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None))
-                    writer.Write(projectData, 0, projectData.Length);
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex);
-                return false;
-            }
+                // Write rooms
+                int numRooms = rooms.Count;
+                writer.Write(numRooms);
+                for (int i = 0; i < numRooms; i++)
+                {
+                    var r = rooms[i];
+                    writer.Write(r != null);
+                    if (r == null)
+                        continue;
 
-            return true;
+                    writer.WriteStringUTF8(r.Name);
+                    writer.Write(r.Position);
+                    writer.Write(r.NumXSectors);
+                    writer.Write(r.NumZSectors);
+
+                    for (int z = 0; z < r.NumZSectors; z++)
+                    {
+                        for (int x = 0; x < r.NumXSectors; x++)
+                        {
+                            var b = r.Blocks[x, z];
+
+                            writer.Write((ushort)b.Type);
+                            writer.Write((ushort)b.Flags);
+
+                            for (int n = 0; n < 4; n++)
+                                writer.Write(b.QAFaces[n]);
+                            for (int n = 0; n < 4; n++)
+                                writer.Write(b.EDFaces[n]);
+                            for (int n = 0; n < 4; n++)
+                                writer.Write(b.WSFaces[n]);
+                            for (int n = 0; n < 4; n++)
+                                writer.Write(b.RFFaces[n]);
+
+                            writer.Write((b.FloorPortal != null ? (int)portalsList.IndexOf(b.FloorPortal) : (int)-1));
+                            writer.Write((ushort)b.FloorOpacity);
+                            writer.Write((b.CeilingPortal != null ? (int)portalsList.IndexOf(b.CeilingPortal) : (int)-1));
+                            writer.Write((ushort)b.CeilingOpacity);
+                            writer.Write((b.WallPortal != null ? (int)portalsList.IndexOf(b.WallPortal) : (int)-1));
+                            writer.Write((ushort)b.WallOpacity);
+                            writer.Write(b.NoCollisionFloor);
+                            writer.Write(b.NoCollisionCeiling);
+                            writer.Write((ushort)b.FloorDiagonalSplit);
+                            writer.Write((ushort)b.CeilingDiagonalSplit);
+                            writer.Write(b.FloorSplitDirectionToggled);
+                            writer.Write(b.CeilingSplitDirectionToggled);
+
+                            for (int f = 0; f < 29; f++)
+                            {
+                                var texture = b.GetFaceTexture((BlockFace)f);
+
+                                var mode = Prj2FaceTextureMode.NoTexture;
+                                if (texture.TextureIsInvisble)
+                                {
+                                    mode = Prj2FaceTextureMode.InvisibleColor;
+                                }
+                                else
+                                {
+                                    if (!texture.TextureIsUnavailable)
+                                        mode = Prj2FaceTextureMode.Texture;
+                                    else
+                                        mode = Prj2FaceTextureMode.NoTexture;
+                                }
+
+                                writer.Write((ushort)mode);
+
+                                if (mode == Prj2FaceTextureMode.Texture)
+                                {
+                                    writer.Write(texture.TexCoord0);
+                                    writer.Write(texture.TexCoord1);
+                                    writer.Write(texture.TexCoord2);
+                                    writer.Write(texture.TexCoord3);
+                                    writer.Write((ushort)texture.BlendMode);
+                                    writer.Write(texture.DoubleSided);
+
+                                    writer.WriteFiller(0x00, 8);
+
+                                    // No more data, in future we can expand the structure using chunks
+                                    writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
+                                }
+                            }
+
+                            writer.WriteFiller(0x00, 32);
+
+                            // No more data, in future we can expand the structure using chunks
+                            writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
+                        }
+                    }
+
+                    // Write lights
+                    uint numLights = 0;
+                    foreach (var o in r.Objects)
+                        if (o.GetType() == typeof(Light))
+                            numLights++;
+                    writer.Write(numLights);
+
+                    foreach (var o in r.Objects)
+                    {
+                        if (o.GetType() == typeof(Light))
+                        {
+                            var l = (Light)o;
+
+                            writer.Write((ushort)l.Type);
+                            writer.Write(l.Position);
+                            writer.Write(l.Intensity);
+                            writer.Write(l.Color);
+                            writer.Write(l.In);
+                            writer.Write(l.Out);
+                            writer.Write(l.Len);
+                            writer.Write(l.Cutoff);
+                            writer.Write(l.RotationX);
+                            writer.Write(l.RotationY);
+                            writer.Write(l.Enabled);
+                            writer.Write(l.CastsShadows);
+                            writer.Write(l.IsDynamicallyUsed);
+                            writer.Write(l.IsStaticallyUsed);
+
+                            writer.WriteFiller(0x00, 8);
+
+                            // No more data, in future we can expand the structure using chunks
+                            writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
+                        }
+                    }
+
+                    // Write imported geometry
+                    uint numImportedGeometry = 0;
+                    foreach (var o in r.Objects)
+                        if (o.GetType() == typeof(RoomGeometryInstance))
+                            numImportedGeometry++;
+                    writer.Write(numImportedGeometry);
+
+                    foreach (var o in r.Objects)
+                    {
+                        if (o.GetType() == typeof(RoomGeometryInstance))
+                        {
+                            RoomGeometryInstance instance = (RoomGeometryInstance)o;
+
+                            writer.Write(instance.Position);
+                            writer.Write((uint)modelsList.IndexOf(instance.Model.Name));
+
+                            writer.WriteFiller(0x00, 8);
+
+                            // No more data, in future we can expand the structure using chunks
+                            writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
+                        }
+                    }
+
+                    // Write some references
+                    uint numPortalsForThisRoom = (uint)r.Portals.Count();
+                    writer.Write(numPortalsForThisRoom);
+                    foreach (var portalInRoom in r.Portals)
+                        writer.Write((uint)portalsList.IndexOf(portalInRoom));
+
+                    uint numTriggersForThisRoom = (uint)r.Triggers.Count();
+                    writer.Write(numTriggersForThisRoom);
+                    foreach (var triggerInRoom in r.Triggers)
+                        writer.Write((uint)triggersList.IndexOf(triggerInRoom));
+
+                    writer.Write(r.AmbientLight);
+                    writer.Write(r.AlternateGroup);
+                    writer.Write((r.AlternateRoom != null ? (int)rooms.ReferenceIndexOf(r.AlternateRoom) : (int)-1));
+                    writer.Write((r.AlternateBaseRoom != null ? (int)rooms.ReferenceIndexOf(r.AlternateBaseRoom) : (int)-1));
+                    writer.Write(r.FlagCold);
+                    writer.Write(r.FlagDamage);
+                    writer.Write(r.FlagHorizon);
+                    writer.Write(r.FlagMist);
+                    writer.Write(r.FlagOutside);
+                    writer.Write(r.FlagRain);
+                    writer.Write(r.FlagReflection);
+                    writer.Write(r.FlagSnow);
+                    writer.Write(r.FlagWater);
+                    writer.Write(r.FlagQuickSand);
+                    writer.Write(r.ExcludeFromPathFinding);
+                    writer.Write(r.WaterLevel);
+                    writer.Write(r.MistLevel);
+                    writer.Write(r.ReflectionLevel);
+                    writer.Write((ushort)r.Reverberation);
+
+                    writer.WriteFiller(0x00, 64);
+
+                    // No more data, in future we can expand the structure using chunks
+                    writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
+                }
+
+                // Write animated textures
+                /*int numAnimatedTextures = level.AnimatedTextures.Count;
+                writer.Write(numAnimatedTextures);
+                foreach (var textureSet in level.AnimatedTextures)
+                {
+                    writer.Write((byte)textureSet.Effect);
+
+                    int numTexturesInSet = textureSet.Textures.Count;
+                    writer.Write(numTexturesInSet);
+
+                    foreach (var texture in textureSet.Textures)
+                    {
+                        writer.Write(texture.Page);
+                        writer.Write(texture.X);
+                        writer.Write(texture.Y);
+                    }
+                }
+                */
+
+                // TODO: waiting for final animated textures code
+                uint numAnimatedTextures = 0;
+                writer.Write(numAnimatedTextures);
+
+                uint numTextureSounds = 0; // level.TextureSounds.Count;
+                writer.Write(numTextureSounds);
+                /*foreach (var sound in level.TextureSounds)
+                {
+                    writer.Write(sound.X);
+                    writer.Write(sound.Y);
+                    writer.Write(sound.Page);
+                    writer.Write((byte)sound.Sound);
+                }*/
+
+                writer.WriteFiller(0x00, 256);
+
+                // No more data, in future we can expand the structure using chunks
+                writer.Write((ushort)Prj2ChunkType.NoExtraChunk);
+
+                ChunkProcessing.WriteChunkEnd(writer);
+            }, long.MaxValue);
         }
 
         private class IdResolver<T>

--- a/TombEditor/TombEditor.csproj
+++ b/TombEditor/TombEditor.csproj
@@ -14,6 +14,21 @@
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -223,6 +238,7 @@
     <Compile Include="Geometry\CameraInstance.cs" />
     <Compile Include="Geometry\FlybyCameraInstance.cs" />
     <Compile Include="Geometry\GeometryImporter.cs" />
+    <Compile Include="Geometry\IO\Prj2Chunks.cs" />
     <Compile Include="Geometry\LevelSettings.cs" />
     <Compile Include="Geometry\RoomGeometryInstance.cs" />
     <Compile Include="Geometry\TextureSound.cs" />
@@ -649,7 +665,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>del $(TargetDir)TombEditorConfiguration.xml 2&gt;NUL</PostBuildEvent>
+    <PostBuildEvent>del "$(TargetDir)TombEditorConfiguration.xml" 2&gt;NUL</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\AssimpNet.3.3.2\build\AssimpNet.targets" Condition="Exists('..\packages\AssimpNet.3.3.2\build\AssimpNet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/TombLib/IO/Chunk.cs
+++ b/TombLib/IO/Chunk.cs
@@ -1,0 +1,231 @@
+﻿using NLog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TombLib.IO
+{
+    // Chunks represent a hierarchical (so nested) data structure.
+    // Each chunk contains first some data and then potentially more chunks depending on the documentation of each chunk.
+    // When a stream of chunks is encountered, it is continously parsed the following way: 
+    //     (The chunk stream is considered to be ended immediately after a ChunkIdLength of 0 is encountered.)
+    //
+    //     LEB128 unsigned int (up to 5 bytes)   ChunkIdLength
+    //         The length of ChunkId
+    //
+    //     n bytes                               ChunkId
+    //         n bytes that identificate the chunk.
+    //
+    //         Custom ChunkIds can be defined, but they are recommended to ASCII or UTF-8 strings
+    //         to allow easy identification in a hex editor.
+    //
+    //         To avoid Id collisions (different people define the same chunk Ids to different things),
+    //         it is recommended to begin all custom ChunkIds of some software with a unique prefix.
+    //         (0x54, 0x65 ('Te') in case for Tomb Editor)
+    //                                   
+    //     LEB128 unsigned int (up to 9 bytes)   ChunkSize
+    //         The size of the content of the chunk
+    //
+    //     n bytes                               ChunkContent
+    //         n bytes that identificate the chunk.
+    //         The meaning of those byte is entirely dependent on the previously read ChunkId.
+    //         Applications are encouraged to ignore chunk content whose IDs they don't recognize.
+    //
+    //
+    //
+    // Key properties of the format:
+    //     - Unknown chunks can be ignored to enable backwards as well as forwards compability.
+    //     - Old chunk types can be replaced by new ones simply by choosing a new Id.
+    //     - An empty chunks stream is only 1 byte big. (A single 0 byte, so that the process is aborted immediately like described above)
+    //     - The minimal size overhead of introducing a new chunk is only 2 bytes + the byte length of the ChunkID
+    //
+
+
+    public struct ChunkID
+    {
+        public static readonly ChunkID Empty = new ChunkID(new byte[0], 0);
+        private static readonly Encoding _encoding = Encoding.UTF8;
+
+        private byte[] _idBytes; // Actually store the chunk ID as bytes. We don't want fancy Unicode comparison (different id bytes would compare identical, also big overhead)
+        private int _idLength; // Extra field to allow only part of the array
+
+        public ChunkID(byte[] idBytes)
+        {
+            _idBytes = idBytes;
+            _idLength = idBytes.Length;
+        }
+
+        public ChunkID(byte[] idBytes, int idLength)
+        {
+            _idBytes = idBytes;
+            _idLength = idLength;
+        }
+
+        public static ChunkID FromString(string str)
+        {
+            return new ChunkID(_encoding.GetBytes(str));
+        }
+
+        public static ChunkID FromStream(BinaryReaderEx stream)
+        {
+            int idLength = (int)(LEB128.ReadULong(stream));
+            return new ChunkID(stream.ReadBytes(idLength), idLength); // If this turns out to be slow, we might want to kind of caching to reuse an array.
+        }
+
+        public void ToStream(BinaryWriterEx stream)
+        {
+            LEB128.WriteULong(stream, _idLength);
+            stream.Write(_idBytes, 0, _idLength);
+        }
+
+        public static unsafe bool operator ==(ChunkID first, ChunkID second)
+        {
+            if (first._idLength != second._idLength)
+                return false;
+
+            // Compare byte arrays fast
+            fixed (byte* firstPtr = first._idBytes)
+            fixed (byte* secondPtr = second._idBytes)
+                for (int i = 0; i < first._idLength; ++i)
+                    if (firstPtr[i] != secondPtr[i])
+                        return false;
+
+            return true;
+        }
+
+        public static bool operator !=(ChunkID first, ChunkID second)
+        {
+            return !(first == second);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this == (ChunkID)obj;
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = unchecked(_idLength * (int)3239679517); // Random prime
+            for (int i = 0; i < _idLength; ++i)
+                hash = unchecked((hash * 1321196299) + _idBytes[i]); // Random prime
+            return hash;
+        }
+
+        public string Name
+        {
+            get
+            {
+                try
+                {
+                    return _encoding.GetString(_idBytes, 0, _idLength);
+                }
+                catch
+                {
+                    return "Invalid UTF-8 sequence";
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            StringBuilder str = new StringBuilder("Name: \"");
+            str.Append(Name);
+            str.Append("\", Hex: ");
+            for (int i = 0; i < _idLength; ++i)
+            {
+                if (i != 0)
+                    if ((i & 3) == 0)
+                        str.Append("  '  ");
+                    else
+                        str.Append(" ");
+                str.Append(_idBytes[i].ToString("X2"));
+            }
+            return str.ToString();
+        }
+    };
+
+    public static class ChunkProcessing
+    {
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
+        // Raise exceptions if there were any problems
+        private static string GetLocoationStr(long chunkStart, long chunkSize, ChunkID chunkID)
+        {
+            return " at offset " + chunkStart + " with size " + chunkSize + ". " + chunkID;
+        }
+
+        public delegate bool ParseChunkDelegate(BinaryReaderEx stream, ChunkID chunkID, long chunkSize);
+        public static void ParseChunks(BinaryReaderEx stream, ParseChunkDelegate tryParseChunk)
+        {
+            do
+            {
+                ChunkID chunkID = ChunkID.FromStream(stream);
+                if (chunkID == ChunkID.Empty) // End reached
+                    break;
+
+                // Read up to a 64 bit number for the chunk size
+                long chunkSize = LEB128.ReadULong(stream);
+
+                // Try loading chunk content
+                long chunkStart = stream.BaseStream.Position;
+                bool chunkRecognized = false;
+                Exception chunkException = null;
+                try
+                {
+                    chunkRecognized = tryParseChunk(stream, chunkID, chunkSize);
+                }
+                catch (OperationCanceledException)
+                { // Don't actually keep going if it's an 'OperationCanceledException'
+                    throw;
+                }
+                catch (Exception exc)
+                {
+                    chunkException = exc;
+                }
+                long readDataCount = stream.BaseStream.Position - chunkStart;
+
+                // Print messages for various problems that might have occurred while loading
+                if (chunkException != null)
+                    logger.Error(chunkException, "Chunk loading raised an exception" + GetLocoationStr(chunkStart, chunkSize, chunkID));
+                else if (!chunkRecognized)
+                    logger.Warn("Chunk not recognized" + GetLocoationStr(chunkStart, chunkSize, chunkID));
+                else if (readDataCount > chunkSize)
+                    logger.Error("More data was read than available (Read: " + readDataCount + " Available: " + chunkSize + ")" + GetLocoationStr(chunkStart, chunkSize, chunkID));
+                else if (readDataCount < chunkSize)
+                    logger.Warn("Not all the available data was read (Read: " + readDataCount + " Available: " + chunkSize + ")" + GetLocoationStr(chunkStart, chunkSize, chunkID));
+
+                // Adjust stream position if necessaary
+                if (readDataCount != chunkSize)
+                    stream.BaseStream.Position = chunkStart + chunkSize;
+            } while (true);
+        }
+
+        public delegate void WriteChunkDelegate(BinaryWriterEx stream, ChunkID chunkID);
+        public static void WriteChunk(BinaryWriterEx stream, ChunkID chunkID, WriteChunkDelegate writeChunk, long maximumSize = LEB128.MaximumSize4Byte)
+        {
+            // Write chunk ID
+            chunkID.ToStream(stream);
+
+            // Write chunk size (reserved for later)
+            long chunkSizePosition = stream.BaseStream.Position;
+            LEB128.WriteULong(stream, 0, maximumSize);
+
+            // Write chunk content
+            long previousPosition = stream.BaseStream.Position;
+            writeChunk(stream, chunkID);
+            long newPosition = stream.BaseStream.Position;
+
+            // Update chunk size
+            long chunkSize = newPosition - previousPosition;
+            stream.BaseStream.Position = chunkSizePosition;
+            LEB128.WriteULong(stream, chunkSize, maximumSize);
+            stream.BaseStream.Position = newPosition;
+        }
+
+        public static void WriteChunkEnd(BinaryWriterEx stream)
+        {
+            stream.Write((byte)0);
+        }
+    }
+}

--- a/TombLib/IO/LEB128.cs
+++ b/TombLib/IO/LEB128.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+namespace TombLib.IO
+{
+    // https://en.wikipedia.org/wiki/LEB128
+    internal static class LEB128
+    {
+        public const long MaximumSize1Byte = 128L - 1;
+        public const long MaximumSize2Byte = 128L * 128 - 1;
+        public const long MaximumSize3Byte = 128L * 128 * 128 - 1;
+        public const long MaximumSize4Byte = 128L * 128 * 128 * 128 - 1;
+        public const long MaximumSize5Byte = 128L * 128 * 128 * 128 * 128 - 1;
+        public const long MaximumSize6Byte = 128L * 128 * 128 * 128 * 128 * 128 - 1;
+        public const long MaximumSize7Byte = 128L * 128 * 128 * 128 * 128 * 128 * 128 - 1;
+        public const long MaximumSize8Byte = 128L * 128 * 128 * 128 * 128 * 128 * 128 * 128 - 1;
+        public const long MaximumSize9Byte = long.MaxValue;
+
+        public const int MaxLEB128Length = 9;
+
+        public static long ReadULong(BinaryReaderEx stream)
+        {
+            long result = 0;
+            for (int i = 0; i < MaxLEB128Length; ++i)
+            {
+                byte currentByte = stream.ReadByte();
+                result |= ((long)(currentByte & 0x7F)) << (i * 7);
+                if ((currentByte & 0x80) == 0)
+                    break;
+            }
+            return result;
+        }
+
+        public static void WriteULong(BinaryWriterEx stream, long value, long maximumSize)
+        {
+            if ((value < 0) || (value > maximumSize))
+                throw new ArgumentOutOfRangeException("value");
+
+            do
+            {
+                byte currentByte = (byte)(value & 0x7F);
+                value >>= 7;
+                maximumSize >>= 7;
+                if (maximumSize > 0)
+                    currentByte |= 0x80;
+                stream.Write(currentByte);
+            } while (maximumSize > 0);
+        }
+
+        public static void WriteULong(BinaryWriterEx stream, long value)
+        {
+            WriteULong(stream, value, value);
+        }
+    }
+}

--- a/TombLib/TombLib.csproj
+++ b/TombLib/TombLib.csproj
@@ -49,6 +49,10 @@
       <HintPath>..\packages\MiniZ.Net.1.0.0\lib\MiniZ.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.4.12\lib\net45\NLog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="SharpDX">
       <HintPath>..\Libs\SharpDX.dll</HintPath>
     </Reference>
@@ -82,6 +86,8 @@
     <Compile Include="Graphics\ArcBallCamera.cs" />
     <Compile Include="Graphics\Bone.cs" />
     <Compile Include="Graphics\Camera.cs" />
+    <Compile Include="IO\Chunk.cs" />
+    <Compile Include="IO\LEB128.cs" />
     <Compile Include="Utils\Hash.cs" />
     <Compile Include="Utils\ImageC.cs" />
     <Compile Include="Graphics\TextureLoad.cs" />

--- a/TombLib/packages.config
+++ b/TombLib/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MiniZ.Net" version="1.0.0" targetFramework="net45" />
+  <package id="NLog" version="4.4.12" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is the start of such an implementation. Currently it is *only* implemented for the level settings which is not extremely exciting but it shows all required features. Also this basically defined every variable as its own 'Chunk' so the code and size overhead is maximal here. For most other code bits its propably much more realistic, to group code that belongs together.

General information about current implementation choices can be read in [Chunk.cs](https://github.com/MontyTRC89/Tomb-Editor/pull/106/files#diff-c3ccd81c73a7e173156e6cefb0e27f0f).
A partially complete suggestion for the file chunk tree can be found in [Prj2Chunks.cs](https://github.com/MontyTRC89/Tomb-Editor/pull/106/files#diff-68e6c774e2e76cb6d5c89ddac8b89d64). (Its visually structured like a tree, even thought the VS formatter very strongly rebels against that.)

An example of how lists of objects will be handled is given by the 'LevelTextures' which are now actually saved as an area. Currently there is still always only one, but its also a step in the direction of allowing more than one level texture.

While this this version is a prototype, I made sure that it actually works and it actually produces functioning *.prj2 files that can be loaded again.