### PR TITLE
General fixes + dynamic texture allocation

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -10,6 +10,7 @@ Tomb Editor:
  * Add some missing global sounds for TR1 sound catalog.
  * Reconnect all resources from level settings window.
  * Fix quick start feature for new FLEP workflow.
+ * Fix rendering bugs when editing very large levels in "Draw all rooms" mode.
  * Fix rendering in imported geometry browser preview.
  * Fix occasional object ID changes when clicking around script controls in trigger window.
  * Fix block arrows not displaying on diagonal faces.

--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -12,6 +12,7 @@ Tomb Editor:
  * Fix quick start feature for new FLEP workflow.
  * Fix rendering in imported geometry browser preview.
  * Fix occasional object ID changes when clicking around script controls in trigger window.
+ * Fix block arrows not displaying on diagonal faces.
  
 WadTool:
  * Add ability to rename meshes in mesh editor.

--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -9,7 +9,6 @@ Tomb Editor:
  * Add option to always display memo text.
  * Add some missing global sounds for TR1 sound catalog.
  * Reconnect all resources from level settings window.
- * Search all subdirectories when compiling sound samples.
  * Fix quick start feature for new FLEP workflow.
  * Fix rendering in imported geometry browser preview.
  * Fix occasional object ID changes when clicking around script controls in trigger window.

--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -23,6 +23,7 @@ WadTool:
  * Jump to currently selected object when opening mesh editor from main window.
  * Don't steal focus to item preview in main window.
  * Fix persistent issues with disjointed MQO vertices on mesh import.
+ * Fix orphaned textures not showing on texture list after delete and redo.
  * Fix UI brightness not affecting tree list views.
  * Fix occasional incorrect end frame values when importing compiled levels.
  

--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -3,8 +3,8 @@ Version 1.4.7
 
 Tomb Editor:
  * Add different types of texture search (untextured, broken, full match, partial match).
- * Add sniper camera type for TR5.
  * Add room normals calculation for TR5.
+ * Add sniper camera type for TR5.
  * Add glide out camera flag to be used together with glidecam FLEP patch.
  * Add option to always display memo text.
  * Add some missing global sounds for TR1 sound catalog.

--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -9,6 +9,7 @@ Tomb Editor:
  * Add option to always display memo text.
  * Add some missing global sounds for TR1 sound catalog.
  * Reconnect all resources from level settings window.
+ * Search all subdirectories when compiling sound samples.
  * Fix quick start feature for new FLEP workflow.
  * Fix rendering in imported geometry browser preview.
  * Fix occasional object ID changes when clicking around script controls in trigger window.

--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -12,11 +12,13 @@ Tomb Editor:
  * Fix quick start feature for new FLEP workflow.
  * Fix rendering bugs when editing very large levels in "Draw all rooms" mode.
  * Fix rendering in imported geometry browser preview.
+ * Fix crash when reconnecting duplicated resources.
  * Fix occasional object ID changes when clicking around script controls in trigger window.
  * Fix block arrows not displaying on diagonal faces.
  
 WadTool:
  * Add ability to rename meshes in mesh editor.
+ * Add ability to replace any texture in mesh editor.
  * Add context menus for editing currently selected object mesh in main window.
  * Jump to currently selected object when opening mesh editor from main window.
  * Don't steal focus to item preview in main window.

--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -4353,7 +4353,7 @@ namespace TombEditor
                     else
                     {
                         searchForOthers = false; // Unset flag so we don't prompt again
-                        list.Add(item, settings.MakeRelative(newPath, VariableType.LevelDirectory));
+                        list.TryAdd(item, settings.MakeRelative(newPath, VariableType.LevelDirectory));
                     }
                 }
 

--- a/TombEditor/Forms/FormAnimatedTextures.Designer.cs
+++ b/TombEditor/Forms/FormAnimatedTextures.Designer.cs
@@ -257,7 +257,7 @@ namespace TombEditor.Forms
             this.numericUpDownFPS.Size = new System.Drawing.Size(71, 23);
             this.numericUpDownFPS.TabIndex = 18;
             this.numericUpDownFPS.Value = new decimal(new int[] {
-            15,
+            16,
             0,
             0,
             0});

--- a/TombLib/TombLib.Rendering/Rendering/DirectX11/Dx11RenderingDevice.cs
+++ b/TombLib/TombLib.Rendering/Rendering/DirectX11/Dx11RenderingDevice.cs
@@ -361,19 +361,11 @@ namespace TombLib.Rendering.DirectX11
             logger.Info("Trying to reserve " + size.Z + " " + size.X + "x" + size.Y + " pages of texture memory...");
 
             var dx11Description = CreateTextureDescription(size);
-            bool outOfMemory = false;
 
-            while (dx11Description.ArraySize > 0)
+            while (dx11Description.ArraySize >= RenderingTextureAllocator.MinimumPageCount)
             {
                 try
                 {
-                    if (outOfMemory) // Previous test failed?
-                    {
-                        outOfMemory = false;
-                        if (dx11Description.ArraySize > RenderingTextureAllocator.MinimumPageCount)
-                            dx11Description.ArraySize--; // Remove one extra page to fit potential other textures, if page count is still above minimum.
-                    }
-
                     // Try to allocate texture space and immediately dispose it.
                     var test = new Texture2D(Device, dx11Description);
                     test.Dispose();
@@ -386,8 +378,7 @@ namespace TombLib.Rendering.DirectX11
                 {
                     // Test failed, try to dispose texture, decrease page count and try again.
                     logger.Warn("Not enough memory to allocate " + dx11Description.ArraySize + " texture pages. Trying to reduce page count...");
-                    dx11Description.ArraySize--;
-                    outOfMemory = true;
+                    dx11Description.ArraySize -= 2;
                 }
             }
 

--- a/TombLib/TombLib.Rendering/Rendering/DirectX11/Dx11RenderingTextureAllocator.cs
+++ b/TombLib/TombLib.Rendering/Rendering/DirectX11/Dx11RenderingTextureAllocator.cs
@@ -8,8 +8,6 @@ namespace TombLib.Rendering.DirectX11
 {
     public class Dx11RenderingTextureAllocator : RenderingTextureAllocator
     {
-        private const int MipLevelCount = 1; // TODO Perhaps we can align the texture and allow mip levels?
-
         public readonly DeviceContext Context;
         public readonly Texture2D Texture;
         public readonly ShaderResourceView TextureView;
@@ -18,19 +16,7 @@ namespace TombLib.Rendering.DirectX11
             : base(device, description)
         {
             Context = device.Context;
-
-            Texture2DDescription dx11Description;
-            dx11Description.ArraySize = description.Size.Z;
-            dx11Description.BindFlags = BindFlags.ShaderResource;
-            dx11Description.CpuAccessFlags = CpuAccessFlags.None;
-            dx11Description.Format = SharpDX.DXGI.Format.B8G8R8A8_UNorm;
-            dx11Description.Height = description.Size.X;
-            dx11Description.MipLevels = MipLevelCount;
-            dx11Description.OptionFlags = ResourceOptionFlags.None;
-            dx11Description.SampleDescription = new SharpDX.DXGI.SampleDescription(1, 0);
-            dx11Description.Usage = ResourceUsage.Default; // Perhaps dynamic could be used?
-            dx11Description.Width = description.Size.Y;
-            Texture = new Texture2D(device.Device, dx11Description);
+            Texture = new Texture2D(device.Device, device.CreateTextureDescription(description.Size));
             TextureView = new ShaderResourceView(device.Device, Texture);
         }
 
@@ -62,7 +48,7 @@ namespace TombLib.Rendering.DirectX11
             originalImage.GetIntPtr(ptr =>
             {
                 const int mipLevelToUpload = 0;
-                int subresourceIndex = MipLevelCount * pos.Z + mipLevelToUpload;
+                int subresourceIndex = pos.Z + mipLevelToUpload;
                 ResourceRegion region;
                 region.Left = pos.X;
                 region.Right = pos.X + originalImage.Width;
@@ -123,7 +109,7 @@ namespace TombLib.Rendering.DirectX11
                 byte[] result = new byte[bytesPerSlice * Size.Z];
                 for (int z = 0; z < Size.Z; ++z)
                 {
-                    int subresourceIndex = MipLevelCount * z + mipLevelToRetrieve;
+                    int subresourceIndex = z + mipLevelToRetrieve;
                     Context.CopySubresourceRegion(Texture, subresourceIndex, null, tempTexture, 0);
                     DataBox mappedBuffer = Context.MapSubresource(tempTexture, 0, MapMode.Read, MapFlags.None);
                     try

--- a/TombLib/TombLib.Rendering/Rendering/RenderingTextureAllocator.cs
+++ b/TombLib/TombLib.Rendering/Rendering/RenderingTextureAllocator.cs
@@ -13,7 +13,7 @@ namespace TombLib.Rendering
     {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
-        public const int MinimumPageCount = 8;
+        public const int MinimumPageCount = 4;
         public const int MaximumPageCount = 32;
         public const int PageSize = 2048;
 

--- a/TombLib/TombLib.Rendering/Rendering/RenderingTextureAllocator.cs
+++ b/TombLib/TombLib.Rendering/Rendering/RenderingTextureAllocator.cs
@@ -12,9 +12,14 @@ namespace TombLib.Rendering
     public abstract class RenderingTextureAllocator : IDisposable
     {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
+        public const int MinimumPageCount = 8;
+        public const int MaximumPageCount = 32;
+        public const int PageSize = 2048;
+
         public class Description
         {
-            public VectorInt3 Size { get; set; } = new VectorInt3(2048, 2048, 16); // 256 MB
+            public VectorInt3 Size { get; set; } = new VectorInt3(PageSize, PageSize, MaximumPageCount);
             public Func<VectorInt2, RectPacker> CreateRectPacker = size => new RectPackerTree(size);
         }
 

--- a/TombLib/TombLib.Rendering/Rendering/RenderingTextureAllocator.cs
+++ b/TombLib/TombLib.Rendering/Rendering/RenderingTextureAllocator.cs
@@ -14,7 +14,7 @@ namespace TombLib.Rendering
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
         public class Description
         {
-            public VectorInt3 Size { get; set; } = new VectorInt3(2048, 2048, 8); // 128 MB
+            public VectorInt3 Size { get; set; } = new VectorInt3(2048, 2048, 16); // 256 MB
             public Func<VectorInt2, RectPacker> CreateRectPacker = size => new RectPackerTree(size);
         }
 

--- a/TombLib/TombLib.Rendering/Rendering/SectorTextures.cs
+++ b/TombLib/TombLib.Rendering/Rendering/SectorTextures.cs
@@ -449,6 +449,8 @@ namespace TombLib.Rendering
                     // West faces ------------------------------------------------------------------------------
                     case BlockFace.PositiveX_QA:
                     case BlockFace.PositiveX_ED:
+                    case BlockFace.DiagonalQA:
+                    case BlockFace.DiagonalED:
                         switch (SelectionArrow)
                         {
                             case ArrowType.EdgeN: SectorTexture = SectorTexture.arrow_ne; break;
@@ -464,6 +466,8 @@ namespace TombLib.Rendering
 
                     case BlockFace.PositiveX_WS:
                     case BlockFace.PositiveX_RF:
+                    case BlockFace.DiagonalWS:
+                    case BlockFace.DiagonalRF:
                         switch (SelectionArrow)
                         {
                             case ArrowType.EdgeN: SectorTexture = SectorTexture.arrow_se; break;
@@ -478,6 +482,7 @@ namespace TombLib.Rendering
                         break;
 
                     case BlockFace.PositiveX_Middle:
+                    case BlockFace.DiagonalMiddle:
                         switch (SelectionArrow)
                         {
                             case ArrowType.EdgeN: SectorTexture = SectorTexture.arrow_ne_se; break;

--- a/TombLib/TombLib/Wad/WadSounds.cs
+++ b/TombLib/TombLib/Wad/WadSounds.cs
@@ -88,19 +88,10 @@ namespace TombLib.Wad
                 if (newPath == null)
                     continue;
 
-                // Search root directory
-                var rootPath = Path.Combine(newPath, name);
+                newPath = Path.Combine(newPath, name);
 
-                if (File.Exists(rootPath))
-                    return rootPath;
-
-                // Search subdirectories
-                if (Directory.Exists(newPath))
-                {
-                    var files = Directory.GetFiles(newPath, name, SearchOption.AllDirectories).ToList();
-                    if (files.Count > 0)
-                        return files[0];
-                }
+                if (File.Exists(newPath))
+                    return newPath;
             }
 
             return null;

--- a/TombLib/TombLib/Wad/WadSounds.cs
+++ b/TombLib/TombLib/Wad/WadSounds.cs
@@ -88,10 +88,19 @@ namespace TombLib.Wad
                 if (newPath == null)
                     continue;
 
-                newPath = Path.Combine(newPath, name);
+                // Search root directory
+                var rootPath = Path.Combine(newPath, name);
 
-                if (File.Exists(newPath))
-                    return newPath;
+                if (File.Exists(rootPath))
+                    return rootPath;
+
+                // Search subdirectories
+                if (Directory.Exists(newPath))
+                {
+                    var files = Directory.GetFiles(newPath, name, SearchOption.AllDirectories).ToList();
+                    if (files.Count > 0)
+                        return files[0];
+                }
             }
 
             return null;

--- a/WadTool/Controls/PanelRenderingMesh.cs
+++ b/WadTool/Controls/PanelRenderingMesh.cs
@@ -32,7 +32,7 @@ namespace WadTool.Controls
                     return;
 
                 _mesh = value;
-                _previewMesh = _mesh.Clone();
+                _previewMesh = _mesh == null ? null : _mesh.Clone();
                 InitializeVertexBuffer();
 
                 if (ResetCameraOnMeshChange)
@@ -954,7 +954,7 @@ namespace WadTool.Controls
 
         public void InitializeVertexBuffer()
         {
-            if (_mesh.Polys.Count > 0)
+            if (_mesh?.Polys.Count > 0)
             {
                 var vertexCount = 0;
                 foreach (var poly in _mesh.Polys)

--- a/WadTool/Forms/FormMeshEditor.Designer.cs
+++ b/WadTool/Forms/FormMeshEditor.Designer.cs
@@ -92,6 +92,7 @@
             this.panelTexturing = new DarkUI.Controls.DarkSectionPanel();
             this.panelTextureMap = new WadTool.Controls.PanelTextureMap();
             this.panelTexturingTools = new DarkUI.Controls.DarkPanel();
+            this.butReplaceTexture = new DarkUI.Controls.DarkButton();
             this.butAllTextures = new DarkUI.Controls.DarkButton();
             this.butExportTexture = new DarkUI.Controls.DarkButton();
             this.butAddTexture = new DarkUI.Controls.DarkButton();
@@ -227,7 +228,7 @@
             this.cbTexture.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cbTexture.Location = new System.Drawing.Point(7, 34);
             this.cbTexture.Name = "cbTexture";
-            this.cbTexture.Size = new System.Drawing.Size(63, 17);
+            this.cbTexture.Size = new System.Drawing.Size(62, 17);
             this.cbTexture.TabIndex = 15;
             this.cbTexture.Text = "Texture";
             this.toolTip.SetToolTip(this.cbTexture, "Apply textures to faces");
@@ -370,7 +371,7 @@
             this.darkLabel1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.darkLabel1.Location = new System.Drawing.Point(3, 6);
             this.darkLabel1.Name = "darkLabel1";
-            this.darkLabel1.Size = new System.Drawing.Size(85, 13);
+            this.darkLabel1.Size = new System.Drawing.Size(84, 13);
             this.darkLabel1.TabIndex = 1;
             this.darkLabel1.Text = "Vertex number:";
             // 
@@ -462,7 +463,7 @@
             this.darkLabel7.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.darkLabel7.Location = new System.Drawing.Point(3, 35);
             this.darkLabel7.Name = "darkLabel7";
-            this.darkLabel7.Size = new System.Drawing.Size(111, 13);
+            this.darkLabel7.Size = new System.Drawing.Size(110, 13);
             this.darkLabel7.TabIndex = 21;
             this.darkLabel7.Text = "Vertex shade (color):";
             // 
@@ -1141,6 +1142,7 @@
             // 
             // panelTexturingTools
             // 
+            this.panelTexturingTools.Controls.Add(this.butReplaceTexture);
             this.panelTexturingTools.Controls.Add(this.butAllTextures);
             this.panelTexturingTools.Controls.Add(this.butExportTexture);
             this.panelTexturingTools.Controls.Add(this.butAddTexture);
@@ -1151,6 +1153,20 @@
             this.panelTexturingTools.Name = "panelTexturingTools";
             this.panelTexturingTools.Size = new System.Drawing.Size(324, 30);
             this.panelTexturingTools.TabIndex = 1;
+            // 
+            // butReplaceTexture
+            // 
+            this.butReplaceTexture.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.butReplaceTexture.Checked = false;
+            this.butReplaceTexture.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.butReplaceTexture.Image = global::WadTool.Properties.Resources.actions_refresh_16;
+            this.butReplaceTexture.Location = new System.Drawing.Point(244, 3);
+            this.butReplaceTexture.Name = "butReplaceTexture";
+            this.butReplaceTexture.Size = new System.Drawing.Size(24, 23);
+            this.butReplaceTexture.TabIndex = 9;
+            this.butReplaceTexture.Tag = "";
+            this.toolTip.SetToolTip(this.butReplaceTexture, "Replace current texture");
+            this.butReplaceTexture.Click += new System.EventHandler(this.butReplaceTexture_Click);
             // 
             // butAllTextures
             // 
@@ -1171,7 +1187,7 @@
             this.butExportTexture.Checked = false;
             this.butExportTexture.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.butExportTexture.Image = global::WadTool.Properties.Resources.general_Export_16;
-            this.butExportTexture.Location = new System.Drawing.Point(270, 3);
+            this.butExportTexture.Location = new System.Drawing.Point(272, 3);
             this.butExportTexture.Name = "butExportTexture";
             this.butExportTexture.Size = new System.Drawing.Size(24, 23);
             this.butExportTexture.TabIndex = 7;
@@ -1185,7 +1201,7 @@
             this.butAddTexture.Checked = false;
             this.butAddTexture.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.butAddTexture.Image = global::WadTool.Properties.Resources.general_plus_math_16;
-            this.butAddTexture.Location = new System.Drawing.Point(240, 3);
+            this.butAddTexture.Location = new System.Drawing.Point(216, 3);
             this.butAddTexture.Name = "butAddTexture";
             this.butAddTexture.Size = new System.Drawing.Size(24, 23);
             this.butAddTexture.TabIndex = 5;
@@ -1212,7 +1228,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboCurrentTexture.Location = new System.Drawing.Point(30, 3);
             this.comboCurrentTexture.Name = "comboCurrentTexture";
-            this.comboCurrentTexture.Size = new System.Drawing.Size(204, 23);
+            this.comboCurrentTexture.Size = new System.Drawing.Size(181, 23);
             this.comboCurrentTexture.TabIndex = 4;
             this.comboCurrentTexture.SelectedValueChanged += new System.EventHandler(this.comboCurrentTexture_SelectedValueChanged);
             // 
@@ -1377,5 +1393,6 @@
         private System.Windows.Forms.ToolStripButton butTbFindSelectedTexture;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripButton butTbRename;
+        private DarkUI.Controls.DarkButton butReplaceTexture;
     }
 }

--- a/WadTool/Forms/FormMeshEditor.cs
+++ b/WadTool/Forms/FormMeshEditor.cs
@@ -586,6 +586,12 @@ namespace WadTool
             return true;
         }
 
+        private bool CheckTextureExistence()
+        {
+            var textures = new HashSet<WadTexture>(panelMesh.Mesh.TextureAreas.Select(t => t.Texture as WadTexture).Distinct());
+            return _tool.DestinationWad.MeshTexturesUnique.SetEquals(textures);
+        }
+
         private void ShowSelectedMesh()
         {
             if (lstMeshes.SelectedNodes.Count == 0)
@@ -808,7 +814,13 @@ namespace WadTool
             panelTextureMap.SelectedTexture = tr;
         }
 
-        private void RepopulateTextureList(bool force = false)
+        private void RepopulateTextureListIfChanged()
+        {
+            if (!CheckTextureExistence())
+                RepopulateTextureList();
+        }
+
+        private void RepopulateTextureList()
         {
             bool wholeWad = butAllTextures.Checked;
 
@@ -836,7 +848,7 @@ namespace WadTool
             // If count is the same it means no changes were made in texture list
             // and there's no need to actually repopulate.
 
-            if (!force && wholeWad && comboCurrentTexture.Items.Count == list.Count)
+            if (wholeWad && comboCurrentTexture.Items.Count == list.Count)
                 return;
 
             comboCurrentTexture.Items.Clear();
@@ -1339,7 +1351,7 @@ namespace WadTool
             }
 
             // Visually update
-            RepopulateTextureList(true);
+            RepopulateTextureList();
             UpdateUI();
 
             if (panelTextureMap.SelectedTexture == TextureArea.None)
@@ -1424,11 +1436,13 @@ namespace WadTool
         private void butTbUndo_Click(object sender, EventArgs e)
         {
             _tool.UndoManager.Undo();
+            RepopulateTextureListIfChanged();
         }
 
         private void butTbRedo_Click(object sender, EventArgs e)
         {
             _tool.UndoManager.Redo();
+            RepopulateTextureListIfChanged();
         }
 
         private void butTbWireframe_Click(object sender, EventArgs e)


### PR DESCRIPTION
Instead of assigning 8 2048x2048 texture pages, this code allows to dynamically assign from 32 to 4 texture pages, according to actual video RAM size. This solves 2 problems: corruption of textures with huge levels which dont fit into 8 pages, and also allows users with lower RAM also to run TE which wasn't possible before.

Additionally, this PR introduces texture replacement feature and several fixes.