### PR TITLE
Entity transform

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -2,6 +2,9 @@ Version 1.5.2
 =============
 
 Tomb Editor:
+ * Allow free axis rotation for certain objects in TEN (e. g. teeth spikes).
+ * Allow scaling static meshes for TEN.
+ * Display scaled static meshes according to TRNG OCB value.
  * Fix occasional errors when compiling pathfinding data in TEN levels.
  * Reorganize the way objects which can have Lua name are renamed.
  * Add ability to rename volumes.

--- a/TombEditor/Controls/ContextMenus/MaterialObjectContextMenu.cs
+++ b/TombEditor/Controls/ContextMenus/MaterialObjectContextMenu.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows.Forms;
+using System;
 using TombLib.LevelData;
 
 namespace TombEditor.Controls.ContextMenus
@@ -137,15 +138,7 @@ namespace TombEditor.Controls.ContextMenus
                     EditorActions.ResetObjectRotation((PositionBasedObjectInstance)targetObject);
                 }));
 
-                if (targetObject is IRotateableYX)
-                {
-                    Items.Add(new ToolStripMenuItem("Reset rotation (X axis)", null, (o, e) =>
-                    {
-                        EditorActions.ResetObjectRotation((PositionBasedObjectInstance)targetObject, RotationAxis.X);
-                    }));
-                }
-
-                if (targetObject is IRotateableY)
+                if (targetObject is IRotateableY && (targetObject as IRotateableY).RotationY != 0.0f)
                 {
                     Items.Add(new ToolStripMenuItem("Reset rotation (Y axis)", null, (o, e) =>
                     {
@@ -153,7 +146,15 @@ namespace TombEditor.Controls.ContextMenus
                     }));
                 }
 
-                if (targetObject is IRotateableYXRoll)
+                if (targetObject is IRotateableYX && (targetObject as IRotateableYX).RotationX != 0.0f)
+                {
+                    Items.Add(new ToolStripMenuItem("Reset rotation (X axis)", null, (o, e) =>
+                    {
+                        EditorActions.ResetObjectRotation((PositionBasedObjectInstance)targetObject, RotationAxis.X);
+                    }));
+                }
+
+                if (targetObject is IRotateableYXRoll && (targetObject as IRotateableYXRoll).Roll != 0.0f)
                 {
                     Items.Add(new ToolStripMenuItem("Reset rotation (Roll axis)", null, (o, e) =>
                     {
@@ -162,7 +163,10 @@ namespace TombEditor.Controls.ContextMenus
                 }
             }
 
-            if (targetObject is PositionBasedObjectInstance && (targetObject is IScaleable || targetObject is ISizeable))
+            var size = (targetObject as ISizeable)?.Size.Length();
+            var scale = (targetObject as IScaleable)?.Scale;
+            if (targetObject is PositionBasedObjectInstance &&
+               ((scale.HasValue && scale != 1.0f) || (size.HasValue && size != Math.Sqrt(3))))
             {
                 Items.Add(new ToolStripMenuItem("Reset scale", null, (o, e) =>
                 {

--- a/TombEditor/Controls/PanelRendering3D.cs
+++ b/TombEditor/Controls/PanelRendering3D.cs
@@ -3211,9 +3211,9 @@ namespace TombEditor.Controls
                                 instance.RotationPositionMatrix * _viewProjection,
                                 instance.ItemType.MoveableId.ShortName(_editor.Level.Settings.GameVersion) +
                                 instance.GetScriptIDOrName() + "\n" + 
-                                GetObjectPositionString(instance.Room, instance) +
-                                "\nRotation Y: " + Math.Round(instance.RotationY, 2) +
-                                (instance.Ocb == 0 ? "" : "\nOCB: " + instance.Ocb) +
+                                GetObjectPositionString(instance.Room, instance) + "\n" +
+                                GetObjectRotationString(instance.Room, instance) +
+                                (instance.Ocb == 0 ? string.Empty : "\nOCB: " + instance.Ocb) +
                                 BuildTriggeredByMessage(instance)));
 
                             // Add the line height of the object
@@ -3813,6 +3813,21 @@ namespace TombEditor.Controls
 
             // Get the base floor height
             return room.Blocks[xBlock, zBlock].Floor.Min * Level.HeightUnit;
+        }
+        private static string GetObjectRotationString(Room room, PositionBasedObjectInstance instance)
+        {
+            string message = string.Empty; 
+            
+            if (instance is IRotateableY)
+                message += "Rotation Y: " + Math.Round((instance as IRotateableY).RotationY);
+
+            if (instance is IRotateableYX && (instance as IRotateableYX).RotationX != 0.0f)
+                message += " Rotation X: " + Math.Round((instance as IRotateableYX).RotationX);
+
+            if (instance is IRotateableYXRoll && (instance as IRotateableYXRoll).Roll != 0.0f)
+                message += " Roll: " + Math.Round((instance as IRotateableYXRoll).Roll);
+
+            return message;
         }
 
         private static string GetObjectPositionString(Room room, PositionBasedObjectInstance instance)

--- a/TombEditor/Forms/FormMoveable.Designer.cs
+++ b/TombEditor/Forms/FormMoveable.Designer.cs
@@ -50,7 +50,7 @@ namespace TombEditor.Forms
             // 
             this.butOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.butOK.Checked = false;
-            this.butOK.Location = new System.Drawing.Point(17, 191);
+            this.butOK.Location = new System.Drawing.Point(39, 191);
             this.butOK.Name = "butOK";
             this.butOK.Size = new System.Drawing.Size(80, 23);
             this.butOK.TabIndex = 8;
@@ -63,7 +63,7 @@ namespace TombEditor.Forms
             this.butCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.butCancel.Checked = false;
             this.butCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.butCancel.Location = new System.Drawing.Point(103, 191);
+            this.butCancel.Location = new System.Drawing.Point(127, 191);
             this.butCancel.Name = "butCancel";
             this.butCancel.Size = new System.Drawing.Size(80, 23);
             this.butCancel.TabIndex = 9;
@@ -140,7 +140,7 @@ namespace TombEditor.Forms
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tbOCB.Location = new System.Drawing.Point(39, 135);
             this.tbOCB.Name = "tbOCB";
-            this.tbOCB.Size = new System.Drawing.Size(144, 22);
+            this.tbOCB.Size = new System.Drawing.Size(168, 22);
             this.tbOCB.TabIndex = 0;
             this.tbOCB.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tbOCB_KeyPress);
             // 
@@ -172,7 +172,7 @@ namespace TombEditor.Forms
             this.panelColor.BackColor = System.Drawing.Color.White;
             this.panelColor.Location = new System.Drawing.Point(39, 163);
             this.panelColor.Name = "panelColor";
-            this.panelColor.Size = new System.Drawing.Size(144, 22);
+            this.panelColor.Size = new System.Drawing.Size(168, 22);
             this.panelColor.TabIndex = 16;
             this.panelColor.Click += new System.EventHandler(this.panelColor_Click);
             // 
@@ -182,7 +182,7 @@ namespace TombEditor.Forms
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.butCancel;
-            this.ClientSize = new System.Drawing.Size(212, 221);
+            this.ClientSize = new System.Drawing.Size(213, 221);
             this.Controls.Add(this.panelColor);
             this.Controls.Add(this.lblColor);
             this.Controls.Add(this.cbBit5);

--- a/TombEditor/Forms/FormMoveable.Designer.cs
+++ b/TombEditor/Forms/FormMoveable.Designer.cs
@@ -50,7 +50,7 @@ namespace TombEditor.Forms
             // 
             this.butOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.butOK.Checked = false;
-            this.butOK.Location = new System.Drawing.Point(39, 191);
+            this.butOK.Location = new System.Drawing.Point(17, 191);
             this.butOK.Name = "butOK";
             this.butOK.Size = new System.Drawing.Size(80, 23);
             this.butOK.TabIndex = 8;
@@ -63,7 +63,7 @@ namespace TombEditor.Forms
             this.butCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.butCancel.Checked = false;
             this.butCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.butCancel.Location = new System.Drawing.Point(125, 191);
+            this.butCancel.Location = new System.Drawing.Point(103, 191);
             this.butCancel.Name = "butCancel";
             this.butCancel.Size = new System.Drawing.Size(80, 23);
             this.butCancel.TabIndex = 9;
@@ -77,7 +77,7 @@ namespace TombEditor.Forms
             this.cbInvisible.Location = new System.Drawing.Point(76, 9);
             this.cbInvisible.Name = "cbInvisible";
             this.cbInvisible.Size = new System.Drawing.Size(68, 17);
-            this.cbInvisible.TabIndex = 5;
+            this.cbInvisible.TabIndex = 6;
             this.cbInvisible.Text = "Invisible";
             // 
             // cbBit2
@@ -86,7 +86,7 @@ namespace TombEditor.Forms
             this.cbBit2.Location = new System.Drawing.Point(8, 32);
             this.cbBit2.Name = "cbBit2";
             this.cbBit2.Size = new System.Drawing.Size(48, 17);
-            this.cbBit2.TabIndex = 1;
+            this.cbBit2.TabIndex = 2;
             this.cbBit2.Text = "Bit 2";
             // 
             // cbClearBody
@@ -95,7 +95,7 @@ namespace TombEditor.Forms
             this.cbClearBody.Location = new System.Drawing.Point(76, 32);
             this.cbClearBody.Name = "cbClearBody";
             this.cbClearBody.Size = new System.Drawing.Size(81, 17);
-            this.cbClearBody.TabIndex = 6;
+            this.cbClearBody.TabIndex = 7;
             this.cbClearBody.Text = "Clear body";
             // 
             // cbBit1
@@ -104,7 +104,7 @@ namespace TombEditor.Forms
             this.cbBit1.Location = new System.Drawing.Point(8, 9);
             this.cbBit1.Name = "cbBit1";
             this.cbBit1.Size = new System.Drawing.Size(48, 17);
-            this.cbBit1.TabIndex = 0;
+            this.cbBit1.TabIndex = 1;
             this.cbBit1.Text = "Bit 1";
             // 
             // cbBit3
@@ -113,7 +113,7 @@ namespace TombEditor.Forms
             this.cbBit3.Location = new System.Drawing.Point(8, 55);
             this.cbBit3.Name = "cbBit3";
             this.cbBit3.Size = new System.Drawing.Size(48, 17);
-            this.cbBit3.TabIndex = 2;
+            this.cbBit3.TabIndex = 3;
             this.cbBit3.Text = "Bit 3";
             // 
             // cbBit4
@@ -122,7 +122,7 @@ namespace TombEditor.Forms
             this.cbBit4.Location = new System.Drawing.Point(8, 79);
             this.cbBit4.Name = "cbBit4";
             this.cbBit4.Size = new System.Drawing.Size(48, 17);
-            this.cbBit4.TabIndex = 3;
+            this.cbBit4.TabIndex = 4;
             this.cbBit4.Text = "Bit 4";
             // 
             // cbBit5
@@ -131,21 +131,21 @@ namespace TombEditor.Forms
             this.cbBit5.Location = new System.Drawing.Point(8, 102);
             this.cbBit5.Name = "cbBit5";
             this.cbBit5.Size = new System.Drawing.Size(48, 17);
-            this.cbBit5.TabIndex = 4;
+            this.cbBit5.TabIndex = 5;
             this.cbBit5.Text = "Bit 5";
             // 
             // tbOCB
             // 
-            this.tbOCB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.tbOCB.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tbOCB.Location = new System.Drawing.Point(39, 135);
             this.tbOCB.Name = "tbOCB";
-            this.tbOCB.Size = new System.Drawing.Size(166, 22);
-            this.tbOCB.TabIndex = 7;
+            this.tbOCB.Size = new System.Drawing.Size(144, 22);
+            this.tbOCB.TabIndex = 0;
             this.tbOCB.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tbOCB_KeyPress);
             // 
             // label1
             // 
-            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label1.AutoSize = true;
             this.label1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.label1.Location = new System.Drawing.Point(5, 137);
@@ -172,7 +172,7 @@ namespace TombEditor.Forms
             this.panelColor.BackColor = System.Drawing.Color.White;
             this.panelColor.Location = new System.Drawing.Point(39, 163);
             this.panelColor.Name = "panelColor";
-            this.panelColor.Size = new System.Drawing.Size(166, 22);
+            this.panelColor.Size = new System.Drawing.Size(144, 22);
             this.panelColor.TabIndex = 16;
             this.panelColor.Click += new System.EventHandler(this.panelColor_Click);
             // 

--- a/TombEditor/Forms/FormMoveable.cs
+++ b/TombEditor/Forms/FormMoveable.cs
@@ -48,7 +48,7 @@ namespace TombEditor.Forms
 
             // Disable mesh-specific controls
             var canBeColored = _movable.CanBeColored();
-            Size = new System.Drawing.Size(Size.Width, canBeColored ? 254 : 226);
+            Size = new System.Drawing.Size(Size.Width, canBeColored ? 264 : 236);
             lblColor.Visible = canBeColored;
             panelColor.Visible = canBeColored;
         }

--- a/TombEditor/Gizmo.cs
+++ b/TombEditor/Gizmo.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using System.Windows.Forms;
 using TombLib.Graphics;
 using TombLib.LevelData;
+using TombLib.Wad.Catalog;
 
 namespace TombEditor
 {
@@ -54,6 +55,22 @@ namespace TombEditor
                 return 0.0f;
         }
 
+        private bool DisableCustomRotation()
+        {
+            if (_editor.SelectedObject is MoveableInstance)
+            {
+                var obj = _editor.SelectedObject as MoveableInstance;
+                return !TrCatalog.IsFreelyRotateable(_editor.Level.Settings.GameVersion, obj.WadObjectId.TypeId);
+            }
+            else
+                return false;
+        }
+
+        private bool DisableCustomScale()
+        {
+            return (_editor.SelectedObject is StaticInstance) && !_editor.Level.IsTombEngine;
+        }
+
         protected override void GizmoRotateY(float newAngle)
         {
             bool smoothRotationPreference = !(_editor.SelectedObject is ObjectGroup || 
@@ -66,12 +83,19 @@ namespace TombEditor
 
         protected override void GizmoRotateX(float newAngle)
         {
-            bool smoothRotationPreference = !(_editor.SelectedObject is VolumeInstance);
+            bool smoothRotationPreference = !(_editor.SelectedObject is ObjectGroup ||
+                                              _editor.SelectedObject is MoveableInstance ||
+                                              _editor.SelectedObject is StaticInstance ||
+                                              _editor.SelectedObject is VolumeInstance);
             EditorActions.RotateObject(_editor.SelectedObject, RotationAxis.X, -(float)(newAngle * (180 / Math.PI)), RotationQuanization(smoothRotationPreference), false, true);
         }
 
         protected override void GizmoRotateZ(float newAngle)
         {
+            bool smoothRotationPreference = !(_editor.SelectedObject is ObjectGroup ||
+                                              _editor.SelectedObject is MoveableInstance ||
+                                              _editor.SelectedObject is StaticInstance ||
+                                              _editor.SelectedObject is VolumeInstance);
             EditorActions.RotateObject(_editor.SelectedObject, RotationAxis.Roll, (float)(newAngle * (180 / Math.PI)), RotationQuanization(), false, true);
         }
 
@@ -171,9 +195,10 @@ namespace TombEditor
         protected override bool SupportTranslateY => _editor.SelectedObject is PositionBasedObjectInstance || 
                                                     (_editor.SelectedObject is GhostBlockInstance && ((GhostBlockInstance)_editor.SelectedObject).SelectedCorner.HasValue);
 
-        protected override bool SupportScale => _editor.SelectedObject is IScaleable || _editor.SelectedObject is ISizeable;
+        protected override bool SupportScale => (_editor.SelectedObject is IScaleable || _editor.SelectedObject is ISizeable) && !DisableCustomScale();
+
         protected override bool SupportRotationY => _editor.SelectedObject is IRotateableY;
-        protected override bool SupportRotationX => _editor.SelectedObject is IRotateableYX;
-        protected override bool SupportRotationZ => _editor.SelectedObject is IRotateableYXRoll;
+        protected override bool SupportRotationX => _editor.SelectedObject is IRotateableYX && !DisableCustomRotation();
+        protected override bool SupportRotationZ => _editor.SelectedObject is IRotateableYXRoll && !DisableCustomRotation();
     }
 }

--- a/TombEditor/Gizmo.cs
+++ b/TombEditor/Gizmo.cs
@@ -66,37 +66,28 @@ namespace TombEditor
                 return false;
         }
 
-        private bool DisableCustomScale()
-        {
-            return (_editor.SelectedObject is StaticInstance) && !_editor.Level.IsTombEngine;
-        }
+        private bool DisableCustomScale => (_editor.SelectedObject is StaticInstance) && !_editor.Level.IsTombEngine;
+
+        private bool SmoothRotationPreference => !(_editor.SelectedObject is ObjectGroup || 
+                                                   _editor.SelectedObject is MoveableInstance || 
+                                                   _editor.SelectedObject is StaticInstance || 
+                                                   _editor.SelectedObject is VolumeInstance);
 
         protected override void GizmoRotateY(float newAngle)
         {
-            bool smoothRotationPreference = !(_editor.SelectedObject is ObjectGroup || 
-                                              _editor.SelectedObject is MoveableInstance || 
-                                              _editor.SelectedObject is StaticInstance || 
-                                              _editor.SelectedObject is VolumeInstance);
+            
 
-            EditorActions.RotateObject(_editor.SelectedObject, RotationAxis.Y, (float)(newAngle * (180 / Math.PI)), RotationQuanization(smoothRotationPreference), false, true);
+            EditorActions.RotateObject(_editor.SelectedObject, RotationAxis.Y, (float)(newAngle * (180 / Math.PI)), RotationQuanization(SmoothRotationPreference), false, true);
         }
 
         protected override void GizmoRotateX(float newAngle)
         {
-            bool smoothRotationPreference = !(_editor.SelectedObject is ObjectGroup ||
-                                              _editor.SelectedObject is MoveableInstance ||
-                                              _editor.SelectedObject is StaticInstance ||
-                                              _editor.SelectedObject is VolumeInstance);
-            EditorActions.RotateObject(_editor.SelectedObject, RotationAxis.X, -(float)(newAngle * (180 / Math.PI)), RotationQuanization(smoothRotationPreference), false, true);
+            EditorActions.RotateObject(_editor.SelectedObject, RotationAxis.X, -(float)(newAngle * (180 / Math.PI)), RotationQuanization(SmoothRotationPreference), false, true);
         }
 
         protected override void GizmoRotateZ(float newAngle)
         {
-            bool smoothRotationPreference = !(_editor.SelectedObject is ObjectGroup ||
-                                              _editor.SelectedObject is MoveableInstance ||
-                                              _editor.SelectedObject is StaticInstance ||
-                                              _editor.SelectedObject is VolumeInstance);
-            EditorActions.RotateObject(_editor.SelectedObject, RotationAxis.Roll, (float)(newAngle * (180 / Math.PI)), RotationQuanization(), false, true);
+            EditorActions.RotateObject(_editor.SelectedObject, RotationAxis.Roll, (float)(newAngle * (180 / Math.PI)), RotationQuanization(SmoothRotationPreference), false, true);
         }
 
         protected override void GizmoScaleX(float scale)
@@ -195,7 +186,7 @@ namespace TombEditor
         protected override bool SupportTranslateY => _editor.SelectedObject is PositionBasedObjectInstance || 
                                                     (_editor.SelectedObject is GhostBlockInstance && ((GhostBlockInstance)_editor.SelectedObject).SelectedCorner.HasValue);
 
-        protected override bool SupportScale => (_editor.SelectedObject is IScaleable || _editor.SelectedObject is ISizeable) && !DisableCustomScale();
+        protected override bool SupportScale => (_editor.SelectedObject is IScaleable || _editor.SelectedObject is ISizeable) && !DisableCustomScale;
 
         protected override bool SupportRotationY => _editor.SelectedObject is IRotateableY;
         protected override bool SupportRotationX => _editor.SelectedObject is IRotateableYX && !DisableCustomRotation();

--- a/TombLib/TombLib/Catalogs/TrCatalog.xml
+++ b/TombLib/TombLib/Catalogs/TrCatalog.xml
@@ -6019,7 +6019,7 @@
 			<moveable id="338" name="SPIKY_FLOOR" />
 			<moveable id="339" name="SPIKY_WALL" />
 			<moveable id="340" name="SPIKY_CEILING" />
-			<moveable id="341" name="TEETH_SPIKES" />
+			<moveable id="341" name="TEETH_SPIKES" freeRot="true" />
 			<moveable id="342" name="JOBY_SPIKES" />
 			<moveable id="343" name="SENTRY_GUN" />
 			<moveable id="344" name="MAPPER" />

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
@@ -390,8 +390,6 @@ namespace TombLib.LevelData.Compilers.TombEngine
                     }
 
                     Vector3 position = instance.Room.WorldPos + instance.Position;
-                    double angle = Math.Round(instance.RotationY * (65536.0 / 360.0));
-                    ushort angleInt = unchecked((ushort)Math.Max(0, Math.Min(ushort.MaxValue, angle)));
 
                     // Split AI objects and normal objects
                     if (TrCatalog.IsMoveableAI(TRVersion.Game.TombEngine, wadMoveable.Id.TypeId))
@@ -409,7 +407,9 @@ namespace TombLib.LevelData.Compilers.TombEngine
                             Z = (int)Math.Round(position.Z),
                             ObjectID = checked((ushort)instance.WadObjectId.TypeId),
                             Room = (ushort)_roomsRemappingDictionary[instance.Room],
-                            Angle = angleInt,
+                            Yaw = ToTrAngle(instance.RotationY),
+                            Pitch = ToTrAngle(instance.RotationX),
+                            Roll = ToTrAngle(-instance.Roll),
                             OCB = instance.Ocb,
                             BoxIndex = boxIndex,
                             Flags = (ushort)(instance.CodeBits << 1),
@@ -428,9 +428,11 @@ namespace TombLib.LevelData.Compilers.TombEngine
                             Z = (int)Math.Round(position.Z),
                             ObjectID = checked((ushort)instance.WadObjectId.TypeId),
                             Room = (short)_roomsRemappingDictionary[instance.Room],
-                            Angle = angleInt,
+                            Yaw = ToTrAngle(instance.RotationY),
+                            Pitch = ToTrAngle(instance.RotationX),
+                            Roll = ToTrAngle(-instance.Roll),
                             Color = new Vector4(instance.Color.X, instance.Color.Y, instance.Color.Z, 1.0f),
-                            Ocb = instance.Ocb,
+                            OCB = instance.Ocb,
                             Flags = unchecked((ushort)flags),
                             LuaName = instance.LuaName ?? ""
                         });

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
@@ -157,7 +157,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
                     Z = (int)Math.Round(position.Z),
                     SoundID = (ushort)instance.SoundId,
                     Flags = flags,
-                    LuaName = instance.LuaName ?? ""
+                    LuaName = instance.LuaName ?? string.Empty
                 });
             }
 
@@ -199,7 +199,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
                     Room = (short)_roomsRemappingDictionary[instance.Room],
                     Flags = instance.CameraMode == CameraInstanceMode.Locked ? 1 : 0,
                     Speed = instance.MoveTimer,
-                    LuaName = instance.LuaName ?? ""
+                    LuaName = instance.LuaName ?? string.Empty
                 });
             }
 
@@ -221,7 +221,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
                     Z = (int)Math.Round(position.Z),
                     Strength = instance.Strength,
                     BoxIndex = boxIndex,
-                    LuaName = instance.LuaName ?? ""
+                    LuaName = instance.LuaName ?? string.Empty
                 });
             }
 
@@ -413,7 +413,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
                             OCB = instance.Ocb,
                             BoxIndex = boxIndex,
                             Flags = (ushort)(instance.CodeBits << 1),
-                            LuaName = instance.LuaName ?? ""
+                            LuaName = instance.LuaName ?? string.Empty
                         });
                         _aiObjectsTable.Add(instance, _aiObjectsTable.Count);
                     }
@@ -434,7 +434,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
                             Color = new Vector4(instance.Color.X, instance.Color.Y, instance.Color.Z, 1.0f),
                             OCB = instance.Ocb,
                             Flags = unchecked((ushort)flags),
-                            LuaName = instance.LuaName ?? ""
+                            LuaName = instance.LuaName ?? string.Empty
                         });
                         _moveablesTable.Add(instance, _moveablesTable.Count);
                     }

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/Rooms.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/Rooms.cs
@@ -863,8 +863,8 @@ namespace TombLib.LevelData.Compilers.TombEngine
                     X = (int)Math.Round(newRoom.Info.X + instance.Position.X),
                     Y = (int)-Math.Round(room.WorldPos.Y + instance.Position.Y),
                     Z = (int)Math.Round(newRoom.Info.Z + instance.Position.Z),
-                    Rotation = (ushort)Math.Max(0, Math.Min(ushort.MaxValue,
-                        Math.Round(instance.RotationY * (65536.0 / 360.0)))),
+                    Yaw = ToTrAngle(instance.RotationY),
+                    Scale = instance.Scale,
                     ObjectID = checked((ushort)instance.WadObjectId.TypeId),
                     Flags = (ushort)(0x0003), // FIXME: later let user choose if solid (0x0003) or soft (0x0001)!
                     Color = new Vector4(instance.Color.X, instance.Color.Y, instance.Color.Z, 1.0f),

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/Structs.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/Structs.cs
@@ -100,7 +100,10 @@ namespace TombLib.LevelData.Compilers.TombEngine
         public int X;
         public int Y;
         public int Z;
-        public ushort Rotation;
+        public short Yaw;
+        public short Pitch;
+        public short Roll;
+        public float Scale;
         public ushort Flags;
         public Vector4 Color;
         public ushort ObjectID;
@@ -257,7 +260,6 @@ namespace TombLib.LevelData.Compilers.TombEngine
     public class TombEngineRoom
     {
         public tr_room_info Info;
-        public int NumDataWords;
         public List<TombEngineVertex> Vertices = new List<TombEngineVertex>();
         public Dictionary<TombEngineMaterial, TombEngineBucket> Buckets;
         public List<TombEnginePortal> Portals;
@@ -286,6 +288,10 @@ namespace TombLib.LevelData.Compilers.TombEngine
 
         public void Write(BinaryWriterEx writer)
         {
+            writer.Write(OriginalRoom.Name);
+            writer.Write(OriginalRoom.Properties.Tags.Count);
+            OriginalRoom.Properties.Tags.ForEach(s => writer.Write(s));
+
             writer.WriteBlock(Info);
 
             writer.Write(Vertices.Count);
@@ -406,7 +412,10 @@ namespace TombLib.LevelData.Compilers.TombEngine
                 writer.Write(sm.X);
                 writer.Write(sm.Y);
                 writer.Write(sm.Z);
-                writer.Write(sm.Rotation);
+                writer.Write(sm.Yaw);
+                writer.Write(sm.Pitch);
+                writer.Write(sm.Roll);
+                writer.Write(sm.Scale);
                 writer.Write(sm.Flags);
                 writer.Write(sm.Color);
                 writer.Write(sm.ObjectID);
@@ -633,9 +642,11 @@ namespace TombLib.LevelData.Compilers.TombEngine
         public int X;
         public int Y;
         public int Z;
+        public short Yaw;
+        public short Pitch;
+        public short Roll;
         public short OCB;
         public ushort Flags;
-        public ushort Angle;
         public int BoxIndex;
         public string LuaName;
     }
@@ -648,9 +659,11 @@ namespace TombLib.LevelData.Compilers.TombEngine
         public int X;
         public int Y;
         public int Z;
-        public ushort Angle;
+        public short Yaw;
+        public short Pitch;
+        public short Roll;
         public Vector4 Color;
-        public short Ocb;
+        public short OCB;
         public ushort Flags;
         public string LuaName;
     }

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngine.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngine.cs
@@ -209,9 +209,11 @@ namespace TombLib.LevelData.Compilers.TombEngine
                     writer.Write(item.X);
                     writer.Write(item.Y);
                     writer.Write(item.Z);
-                    writer.Write(item.Angle);
+                    writer.Write(item.Yaw);
+                    writer.Write(item.Pitch);
+                    writer.Write(item.Roll);
                     writer.Write(item.Color);
-                    writer.Write(item.Ocb);
+                    writer.Write(item.OCB);
                     writer.Write(item.Flags);
                     writer.Write(item.LuaName);
                 }
@@ -224,9 +226,11 @@ namespace TombLib.LevelData.Compilers.TombEngine
                     writer.Write(item.X);
                     writer.Write(item.Y);
                     writer.Write(item.Z);
+                    writer.Write(item.Yaw);
+                    writer.Write(item.Pitch);
+                    writer.Write(item.Roll);
                     writer.Write(item.OCB);
                     writer.Write(item.Flags);
-                    writer.Write(item.Angle);
                     writer.Write(item.BoxIndex);
                     writer.Write(item.LuaName);
                 }

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/Wad.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/Wad.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
-using System.Threading.Tasks;
 using TombLib.IO;
 using TombLib.Utils;
 using TombLib.Wad;
@@ -612,6 +611,12 @@ namespace TombLib.LevelData.Compilers.TombEngine
                         n++;
                     }
                 }
+        }
+
+        public static short ToTrAngle(float angle)
+        {
+            double result = Math.Round(angle * (65536.0f / 360.0f));
+            return unchecked((short)result);
         }
 
         private void BuildMeshTree(WadBone bone, List<tr_meshtree> meshTrees, List<WadMesh> usedMeshes)

--- a/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
@@ -138,11 +138,13 @@ namespace TombLib.LevelData.IO
         /**********/public static readonly ChunkId ObjectMovable3 = ChunkId.FromString("TeMov3");
         /**********/public static readonly ChunkId ObjectMovable4 = ChunkId.FromString("TeMov4");
         /**********/public static readonly ChunkId ObjectMovableTombEngine = ChunkId.FromString("TeMovTen");
+        /**********/public static readonly ChunkId ObjectMovableTombEngine2 = ChunkId.FromString("TeMovTen2");
         /**********/public static readonly ChunkId ObjectItemLuaId = ChunkId.FromString("TeItLuaId"); // DEPRECATED
         /**********/public static readonly ChunkId ObjectStatic = ChunkId.FromString("TeSta");
         /**********/public static readonly ChunkId ObjectStatic2 = ChunkId.FromString("TeSta2");
         /**********/public static readonly ChunkId ObjectStatic3 = ChunkId.FromString("TeSta3");
         /**********/public static readonly ChunkId ObjectStaticTombEngine = ChunkId.FromString("TeStaTen");
+        /**********/public static readonly ChunkId ObjectStaticTombEngine2 = ChunkId.FromString("TeStaTen2");
         /**********/public static readonly ChunkId ObjectCamera = ChunkId.FromString("TeCam");
         /**********/public static readonly ChunkId ObjectCamera2 = ChunkId.FromString("TeCam2");
         /**********/public static readonly ChunkId ObjectCamera3 = ChunkId.FromString("TeCam3");

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -1039,6 +1039,24 @@ namespace TombLib.LevelData.IO
                     addObject(instance);
                     newObjects.TryAdd(objectID, instance);
                 }
+                else if (id3 == Prj2Chunks.ObjectMovableTombEngine2)
+                {
+                    var instance = new MoveableInstance();
+                    instance.Position = chunkIO.Raw.ReadVector3();
+                    instance.RotationY = chunkIO.Raw.ReadSingle();
+                    instance.RotationX = chunkIO.Raw.ReadSingle();
+                    instance.Roll = chunkIO.Raw.ReadSingle();
+                    ReadOptionalLEB128Int(chunkIO.Raw);
+                    instance.WadObjectId = new WadMoveableId(chunkIO.Raw.ReadUInt32());
+                    instance.Ocb = chunkIO.Raw.ReadInt16();
+                    instance.Invisible = chunkIO.Raw.ReadBoolean();
+                    instance.ClearBody = chunkIO.Raw.ReadBoolean();
+                    instance.CodeBits = chunkIO.Raw.ReadByte();
+                    instance.Color = chunkIO.Raw.ReadVector3();
+                    instance.LuaName = chunkIO.Raw.ReadStringUTF8();
+                    addObject(instance);
+                    newObjects.TryAdd(objectID, instance);
+                }
                 else if (id3 == Prj2Chunks.ObjectStatic ||
                          id3 == Prj2Chunks.ObjectStatic2)
                 {
@@ -1071,6 +1089,22 @@ namespace TombLib.LevelData.IO
                     newObjects.TryAdd(objectID, instance);
                     instance.Position = chunkIO.Raw.ReadVector3();
                     instance.RotationY = chunkIO.Raw.ReadSingle();
+                    ReadOptionalLEB128Int(chunkIO.Raw);
+                    instance.WadObjectId = new WadStaticId(chunkIO.Raw.ReadUInt32());
+                    instance.Color = chunkIO.Raw.ReadVector3();
+                    instance.Ocb = chunkIO.Raw.ReadInt16();
+                    instance.LuaName = chunkIO.Raw.ReadStringUTF8();
+                    addObject(instance);
+                }
+                else if (id3 == Prj2Chunks.ObjectStaticTombEngine2)
+                {
+                    var instance = new StaticInstance();
+                    newObjects.TryAdd(objectID, instance);
+                    instance.Position = chunkIO.Raw.ReadVector3();
+                    instance.RotationY = chunkIO.Raw.ReadSingle();
+                    chunkIO.Raw.ReadSingle(); // Reserved: instance.RotationX
+                    chunkIO.Raw.ReadSingle(); // Reserved: instance.Roll
+                    instance.Scale = chunkIO.Raw.ReadSingle();
                     ReadOptionalLEB128Int(chunkIO.Raw);
                     instance.WadObjectId = new WadStaticId(chunkIO.Raw.ReadUInt32());
                     instance.Color = chunkIO.Raw.ReadVector3();
@@ -1133,7 +1167,7 @@ namespace TombLib.LevelData.IO
                     var instance = new SpriteInstance();
                     instance.Position = chunkIO.Raw.ReadVector3();
                     instance.Sequence = chunkIO.Raw.ReadInt32();
-                    instance.Frame    = chunkIO.Raw.ReadInt32();
+                    instance.Frame = chunkIO.Raw.ReadInt32();
                     addObject(instance);
                     newObjects.TryAdd(objectID, instance);
                 }
@@ -1254,7 +1288,7 @@ namespace TombLib.LevelData.IO
                     }
                     else if (id3 == Prj2Chunks.ObjectSoundSource4)
                     {
-                        instance.SoundId = chunkIO.Raw.ReadInt32();  
+                        instance.SoundId = chunkIO.Raw.ReadInt32();
                         chunkIO.Raw.ReadInt16(); // Unused
                         chunkIO.Raw.ReadByte(); // Unused
                     }
@@ -1273,7 +1307,7 @@ namespace TombLib.LevelData.IO
                 {
                     var instance = new SoundSourceInstance();
                     instance.Position = chunkIO.Raw.ReadVector3();
-                    instance.SoundId  = chunkIO.Raw.ReadInt32();
+                    instance.SoundId = chunkIO.Raw.ReadInt32();
                     instance.PlayMode = (SoundSourcePlayMode)chunkIO.Raw.ReadInt32();
                     addObject(instance);
                     newObjects.TryAdd(objectID, instance);
@@ -1412,10 +1446,10 @@ namespace TombLib.LevelData.IO
                     var instance = new GhostBlockInstance();
                     instance.SectorPosition = new VectorInt2(x, y);
 
-                    instance.Floor.XnZn   = LEB128.ReadShort(chunkIO.Raw);
-                    instance.Floor.XnZp   = LEB128.ReadShort(chunkIO.Raw);
-                    instance.Floor.XpZn   = LEB128.ReadShort(chunkIO.Raw);
-                    instance.Floor.XpZp   = LEB128.ReadShort(chunkIO.Raw);
+                    instance.Floor.XnZn = LEB128.ReadShort(chunkIO.Raw);
+                    instance.Floor.XnZp = LEB128.ReadShort(chunkIO.Raw);
+                    instance.Floor.XpZn = LEB128.ReadShort(chunkIO.Raw);
+                    instance.Floor.XpZp = LEB128.ReadShort(chunkIO.Raw);
                     instance.Ceiling.XnZn = LEB128.ReadShort(chunkIO.Raw);
                     instance.Ceiling.XnZp = LEB128.ReadShort(chunkIO.Raw);
                     instance.Ceiling.XpZn = LEB128.ReadShort(chunkIO.Raw);
@@ -1434,7 +1468,7 @@ namespace TombLib.LevelData.IO
                     long targetObjectId = LEB128.ReadLong(chunkIO.Raw);
 
                     ushort realTimer = unchecked((ushort)LEB128.ReadShort(chunkIO.Raw));
-                   
+
                     instance.CodeBits = (byte)(LEB128.ReadLong(chunkIO.Raw) & 0x1f);
                     instance.OneShot = chunkIO.Raw.ReadBoolean();
 
@@ -1507,7 +1541,7 @@ namespace TombLib.LevelData.IO
                     addObject(instance);
                     newObjects.TryAdd(objectID, instance);
                 }
-                else if (id3 == Prj2Chunks.ObjectImportedGeometry || 
+                else if (id3 == Prj2Chunks.ObjectImportedGeometry ||
                          id3 == Prj2Chunks.ObjectImportedGeometry2)
                 {
                     var instance = new ImportedGeometryInstance();
@@ -1559,14 +1593,14 @@ namespace TombLib.LevelData.IO
                     });
 
                     addObject(instance);
-                    newObjects.TryAdd(objectID, instance);                    
+                    newObjects.TryAdd(objectID, instance);
                 }
                 else if (id3 == Prj2Chunks.ObjectTriggerVolumeTest ||
                          id3 == Prj2Chunks.ObjectTriggerVolume1 ||
                          id3 == Prj2Chunks.ObjectTriggerVolume2)
                 {
                     var instanceType = (VolumeShape)chunkIO.Raw.ReadByte();
-                    
+
                     VolumeInstance instance;
 
                     switch (instanceType)

--- a/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
@@ -502,20 +502,19 @@ namespace TombLib.LevelData.IO
                                     var SPxzoffs = new List<short> { 0, 0, 512, 0, 0, 0, -512, 0 };
                                     var SPDETyoffs = new List<short> { 1024, 512, 512, 512, 0, 512, 512, 512 };
                                     var rotations = new List<float> { 180.0f, 225.0f, 270.0f, 315.0f, 0.0f, 45.0f, 90.0f, 135.0f };
-                                    
+
                                     int angle = mov.Ocb & 7;
+                                    (mov as IRotateableYXRoll).RotationY = 0.0f;
 
                                     if ((mov.Ocb & 8) != 0)
                                     {
                                         (mov as IRotateableYXRoll).RotationX = rotations[angle];
-                                        (mov as IRotateableYXRoll).RotationY = 90.0f;
-                                        mov.Position -= new Vector3(SPxzoffs[angle], 0.0f, 0.0f);
+                                        mov.Position -= new Vector3(0.0f, 0.0f, SPxzoffs[angle]);
                                     }
                                     else
                                     {
-                                        (mov as IRotateableYXRoll).Roll = rotations[angle];
-                                        (mov as IRotateableYXRoll).RotationY = -90.0f;
-                                        mov.Position -= new Vector3(0.0f, 0.0f, SPxzoffs[angle]);
+                                        (mov as IRotateableYXRoll).Roll = -rotations[angle];
+                                        mov.Position += new Vector3(SPxzoffs[angle], 0.0f, 0.0f);
                                     }
 
                                     mov.Position -= new Vector3(0.0f, SPyoffs[angle], 0.0f);

--- a/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
@@ -526,7 +526,6 @@ namespace TombLib.LevelData.IO
                                         mov.Ocb = 2;
                                     else
                                         mov.Ocb = 0;
-
                                 }
                             }
 

--- a/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
@@ -509,13 +509,13 @@ namespace TombLib.LevelData.IO
                                     {
                                         (mov as IRotateableYXRoll).RotationX = rotations[angle];
                                         (mov as IRotateableYXRoll).RotationY = 90.0f;
-                                        mov.Position -= new Vector3(0.0f, 0.0f, SPxzoffs[angle]);
+                                        mov.Position -= new Vector3(SPxzoffs[angle], 0.0f, 0.0f);
                                     }
                                     else
                                     {
                                         (mov as IRotateableYXRoll).Roll = rotations[angle];
                                         (mov as IRotateableYXRoll).RotationY = -90.0f;
-                                        mov.Position += new Vector3(SPxzoffs[angle], 0.0f, 0.0f);
+                                        mov.Position -= new Vector3(0.0f, 0.0f, SPxzoffs[angle]);
                                     }
 
                                     mov.Position -= new Vector3(0.0f, SPyoffs[angle], 0.0f);

--- a/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
@@ -514,12 +514,14 @@ namespace TombLib.LevelData.IO
                     {
                         if (isTEN)
                         {
-                            using (var chunk = chunkIO.WriteChunk(Prj2Chunks.ObjectMovableTombEngine, LEB128.MaximumSize2Byte))
+                            using (var chunk = chunkIO.WriteChunk(Prj2Chunks.ObjectMovableTombEngine2, LEB128.MaximumSize2Byte))
                             {
                                 var instance = (MoveableInstance)o;
                                 LEB128.Write(chunkIO.Raw, objectInstanceLookup.TryGetOrDefault(instance, -1));
                                 chunkIO.Raw.Write(instance.Position);
                                 chunkIO.Raw.Write(instance.RotationY);
+                                chunkIO.Raw.Write(instance.RotationX);
+                                chunkIO.Raw.Write(instance.Roll);
                                 LEB128.Write(chunkIO.Raw, (long)-1);
                                 chunkIO.Raw.Write(instance.WadObjectId.TypeId);
                                 chunkIO.Raw.Write(instance.Ocb);
@@ -552,12 +554,15 @@ namespace TombLib.LevelData.IO
                     {
                         if (isTEN)
                         {
-                            using (var chunk = chunkIO.WriteChunk(Prj2Chunks.ObjectStaticTombEngine, LEB128.MaximumSize2Byte))
+                            using (var chunk = chunkIO.WriteChunk(Prj2Chunks.ObjectStaticTombEngine2, LEB128.MaximumSize2Byte))
                             {
                                 var instance = (StaticInstance)o;
                                 LEB128.Write(chunkIO.Raw, objectInstanceLookup.TryGetOrDefault(instance, -1));
                                 chunkIO.Raw.Write(instance.Position);
                                 chunkIO.Raw.Write(instance.RotationY);
+                                chunkIO.Raw.Write(0.0f); // Reserved: instance.RotationX
+                                chunkIO.Raw.Write(0.0f); // Reserved: instance.Roll
+                                chunkIO.Raw.Write(instance.Scale);
                                 LEB128.Write(chunkIO.Raw, (long)-1);
                                 chunkIO.Raw.Write(instance.WadObjectId.TypeId);
                                 chunkIO.Raw.Write(instance.Color);

--- a/TombLib/TombLib/LevelData/Instances/MoveableInstance.cs
+++ b/TombLib/TombLib/LevelData/Instances/MoveableInstance.cs
@@ -3,7 +3,7 @@ using TombLib.Wad;
 
 namespace TombLib.LevelData
 {
-    public class MoveableInstance : ItemInstance, IColorable
+    public class MoveableInstance : ItemInstance, IColorable, IRotateableYXRoll
     {
         // Don't use a reference here because the loaded Wad might not
         // contain each required object. Additionally the loaded Wads
@@ -16,5 +16,19 @@ namespace TombLib.LevelData
         public Vector3 Color { get; set; } = new Vector3(1.0f);
         public override bool CopyToAlternateRooms => false;
         public override ItemType ItemType => new ItemType(WadObjectId, Room?.Level?.Settings);
+
+        public float RotationX
+        {
+            get { return (Room?.Level?.IsTombEngine ?? false) ? _rotationX : 0.0f; }
+            set { _rotationX = value; }
+        }
+        private float _rotationX = 0.0f;
+
+        public float Roll
+        {
+            get { return (Room?.Level?.IsTombEngine ?? false) ? _roll : 0.0f; }
+            set { _roll = value; }
+        }
+        private float _roll = 1.0f;
     }
 }

--- a/TombLib/TombLib/LevelData/Instances/MoveableInstance.cs
+++ b/TombLib/TombLib/LevelData/Instances/MoveableInstance.cs
@@ -29,6 +29,6 @@ namespace TombLib.LevelData
             get { return (Room?.Level?.IsTombEngine ?? false) ? _roll : 0.0f; }
             set { _roll = value; }
         }
-        private float _roll = 1.0f;
+        private float _roll = 0.0f;
     }
 }

--- a/TombLib/TombLib/LevelData/Instances/StaticInstance.cs
+++ b/TombLib/TombLib/LevelData/Instances/StaticInstance.cs
@@ -21,7 +21,7 @@ namespace TombLib.LevelData
         All = 16380
     }
 
-    public class StaticInstance : ItemInstance, IColorable
+    public class StaticInstance : ItemInstance, IColorable, IScaleable
     {
         // Don't use a reference here because the loaded Wad might not
         // contain each required object. Additionally the loaded Wads
@@ -31,5 +31,27 @@ namespace TombLib.LevelData
         public Vector3 Color { get; set; } = new Vector3(1.0f); // Normalized float. (1.0 meaning normal brightness, 2.0 is the maximal brightness supported by tomb4.exe)
 
         public override ItemType ItemType => new ItemType(WadObjectId, Room?.Level?.Settings);
+
+        public float DefaultScale => 1.0f;
+
+        public float Scale
+        {
+            get 
+            { 
+                if (Room?.Level?.IsTombEngine ?? false)
+                    return _scale; 
+                else if (Room?.Level?.IsNG ?? false)
+                {
+                    if ((Ocb & (ushort)StaticMeshFlags.Scalable) != 0)
+                        return (Ocb & 0x0FFF) / 4.0f / 100.0f;
+                    else
+                        return 1.0f;
+                }
+                else
+                    return 1.0f;
+            }
+            set { _scale = value; }
+        }
+        private float _scale = 1.0f;
     }
 }


### PR DESCRIPTION
* Allows scaling statics for TEN with gizmo and shows scaling properly in 3D view.
* Properly shows scaling for TRNG statics as well.
* Allows free rotation of objects with `freeRot="true"` specified in trcatalog.xml (for now, only TEN teeth spikes).
* Also writes room names and tags into TEN file format.

Must be used in conjunction with branch of the same name in TEN repo.