### PR TITLE
TEN Sound sample size increase

### DIFF
--- a/TombLib/TombLib/Catalogs/TrCatalog.xml
+++ b/TombLib/TombLib/Catalogs/TrCatalog.xml
@@ -5909,8 +5909,8 @@
 			<limit name="TexPages" value="32768" />
 			<limit name="TexPageSize" value="4096" />
 			<limit name="TexInfos" value="2147483647" />
-			<limit name="SoundBitsPerSample" value="16" />
-			<limit name="SoundSampleRate" value="22050" />
+			<limit name="SoundBitsPerSample" value="32" />
+			<limit name="SoundSampleRate" value="44100" />
 			<limit name="SoundSampleSize" value="32768" />
 			<limit name="SoundSampleCount" value="32768" />
 			<limit name="SoundMapSize" value="4096" />


### PR DESCRIPTION
Updated limit for TEN to use higher quality and bigger file sized samples.

Users must specify in their level settings > misc > Set custom sample rate to 22050 if using TRLE samples. 

The updated dlls are found below. 

[bass updated dll.zip](https://github.com/MontyTRC89/Tomb-Editor/files/10834148/bass.updated.dll.zip)

