### PR TITLE
Increased WadRenderer Texture Atlas Size

### DIFF
--- a/TombLib/TombLib/Graphics/WadRenderer.cs
+++ b/TombLib/TombLib/Graphics/WadRenderer.cs
@@ -44,7 +44,7 @@ namespace TombLib.Graphics
 
         // Size of the atlas
         // DX10 requires minimum 8K textures support for hardware certification so we should be safe with this
-        public const int TextureAtlasSize = 4096;
+        public const int TextureAtlasSize = 8192;
 
         public void Dispose()
         {


### PR DESCRIPTION
Temporary fix for #706

Could possibly crash on platforms that do not have enough space for uncompressed RGBA8 textures of size 8192x8192 (256 MB) 