### PR TITLE
Added System.Threading.CancellationToken

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -2,6 +2,7 @@ Version 1.6.9
 =============
 
 Tomb Editor:
+ * Allow to immediately cancel level building and project opening.
  * Add a node to call events from other event sets.
 
 Version 1.6.8

--- a/SoundTool/Forms/FormMain.cs
+++ b/SoundTool/Forms/FormMain.cs
@@ -10,6 +10,7 @@ using System.IO;
 using TombLib.LevelData.IO;
 using System.Collections.Generic;
 using TombLib.IO;
+using System.Threading;
 
 namespace SoundTool
 {
@@ -299,7 +300,7 @@ namespace SoundTool
             if (string.IsNullOrEmpty(fileName) || !File.Exists(fileName))
                 return;
 
-            ReferenceLevel = Prj2Loader.LoadFromPrj2(fileName, null, new Prj2Loader.Settings { IgnoreTextures = true, IgnoreWads = true });
+            ReferenceLevel = Prj2Loader.LoadFromPrj2(fileName, null, CancellationToken.None, new Prj2Loader.Settings { IgnoreTextures = true, IgnoreWads = true });
             _configuration.SoundTool_ReferenceProject = fileName;
             UpdateUI();
         }

--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -3985,7 +3985,7 @@ namespace TombEditor
                 _editor.SendMessage(whatLoaded, PopupType.Info);
 
             using (var form = new FormOperationDialog("Build level", autoCloseWhenDone, false,
-                progressReporter =>
+                (progressReporter,cancelToken) =>
                 {
                     using (var compiler = level.Settings.GameVersion <= TRVersion.Game.TRNG ?
                             (LevelCompiler)(new LevelCompilerClassicTR(level, fileName, progressReporter)) :
@@ -3993,7 +3993,7 @@ namespace TombEditor
                     {
                         var watch = new Stopwatch();
                         watch.Start();
-                        var statistics = compiler.CompileLevel();
+                        var statistics = compiler.CompileLevel(cancelToken);
                         watch.Stop();
                         progressReporter.ReportProgress(100, "\nElapsed time: " + watch.Elapsed.TotalMilliseconds + "ms");
 
@@ -5000,8 +5000,8 @@ namespace TombEditor
 
             var newLevel = string.Empty;
 
-            using (var form = new FormOperationDialog("TombEngine level converter", false, true, progressReporter =>
-                newLevel = TombEngineConverter.Start(fileName, owner, progressReporter)))
+            using (var form = new FormOperationDialog("TombEngine level converter", false, true, (progressReporter,cancelToken) =>
+                newLevel = TombEngineConverter.Start(fileName, owner, progressReporter,cancelToken)))
             {
                 if (form.ShowDialog(owner) != DialogResult.OK || string.IsNullOrEmpty(newLevel))
                     return false;
@@ -5026,8 +5026,8 @@ namespace TombEditor
             Level newLevel = null;
             try
             {
-                using (var form = new FormOperationDialog("Open level", true, true, progressReporter =>
-                    newLevel = Prj2Loader.LoadFromPrj2(fileName, progressReporter)))
+                using (var form = new FormOperationDialog("Open level", true, true, (progressReporter,cancelToken) =>
+                    newLevel = Prj2Loader.LoadFromPrj2(fileName, progressReporter,cancelToken, new Prj2Loader.Settings())))
                 {
                     // Make sure form displays correctly if we're running in silent mode without parent window
                     if (owner == null)
@@ -5123,11 +5123,11 @@ namespace TombEditor
                     return;
 
                 Level newLevel = null;
-                using (var form = new FormOperationDialog("Import PRJ", false, false, progressReporter =>
+                using (var form = new FormOperationDialog("Import PRJ", false, false, (progressReporter,cancelToken) =>
                     newLevel = PrjLoader.LoadFromPrj(formImport.PrjPath, formImport.SoundsPath,
                     formImport.RespectMousepatchOnFlybyHandling,
                     formImport.UseHalfPixelCorrection,
-                    progressReporter)))
+                    progressReporter,cancelToken)))
                 {
                     if (form.ShowDialog(owner) != DialogResult.OK || newLevel == null)
                         return;

--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -3985,7 +3985,7 @@ namespace TombEditor
                 _editor.SendMessage(whatLoaded, PopupType.Info);
 
             using (var form = new FormOperationDialog("Build level", autoCloseWhenDone, false,
-                (progressReporter,cancelToken) =>
+                (progressReporter, cancelToken) =>
                 {
                     using (var compiler = level.Settings.GameVersion <= TRVersion.Game.TRNG ?
                             (LevelCompiler)(new LevelCompilerClassicTR(level, fileName, progressReporter)) :
@@ -5000,8 +5000,8 @@ namespace TombEditor
 
             var newLevel = string.Empty;
 
-            using (var form = new FormOperationDialog("TombEngine level converter", false, true, (progressReporter,cancelToken) =>
-                newLevel = TombEngineConverter.Start(fileName, owner, progressReporter,cancelToken)))
+            using (var form = new FormOperationDialog("TombEngine level converter", false, true, (progressReporter, cancelToken) =>
+                newLevel = TombEngineConverter.Start(fileName, owner, progressReporter, cancelToken)))
             {
                 if (form.ShowDialog(owner) != DialogResult.OK || string.IsNullOrEmpty(newLevel))
                     return false;
@@ -5026,8 +5026,8 @@ namespace TombEditor
             Level newLevel = null;
             try
             {
-                using (var form = new FormOperationDialog("Open level", true, true, (progressReporter,cancelToken) =>
-                    newLevel = Prj2Loader.LoadFromPrj2(fileName, progressReporter,cancelToken, new Prj2Loader.Settings())))
+                using (var form = new FormOperationDialog("Open level", true, true, (progressReporter, cancelToken) =>
+                    newLevel = Prj2Loader.LoadFromPrj2(fileName, progressReporter, cancelToken, new Prj2Loader.Settings())))
                 {
                     // Make sure form displays correctly if we're running in silent mode without parent window
                     if (owner == null)
@@ -5123,11 +5123,11 @@ namespace TombEditor
                     return;
 
                 Level newLevel = null;
-                using (var form = new FormOperationDialog("Import PRJ", false, false, (progressReporter,cancelToken) =>
+                using (var form = new FormOperationDialog("Import PRJ", false, false, (progressReporter, cancelToken) =>
                     newLevel = PrjLoader.LoadFromPrj(formImport.PrjPath, formImport.SoundsPath,
                     formImport.RespectMousepatchOnFlybyHandling,
                     formImport.UseHalfPixelCorrection,
-                    progressReporter,cancelToken)))
+                    progressReporter, cancelToken)))
                 {
                     if (form.ShowDialog(owner) != DialogResult.OK || newLevel == null)
                         return;
@@ -5631,7 +5631,7 @@ namespace TombEditor
                         }
         }
 
-		public static void GetObjectStatistics(Editor editor,IDictionary<WadMoveableId,uint> resultMoveables,IDictionary<WadStaticId, uint> resultStatics, out int totalMoveables, out int totalStatics)
+		public static void GetObjectStatistics(Editor editor, IDictionary<WadMoveableId,uint> resultMoveables, IDictionary<WadStaticId, uint> resultStatics, out int totalMoveables, out int totalStatics)
         {
 			totalMoveables = 0;
 			totalStatics = 0;

--- a/TombEditor/Forms/FormOperationDialog.cs
+++ b/TombEditor/Forms/FormOperationDialog.cs
@@ -48,9 +48,13 @@ namespace TombEditor.Forms
 			Run();
 		}
 
-		private void OnOperationFailure()
+		private void OnOperationFailure(Exception ex)
 		{
-			TaskbarProgress.SetState(Application.OpenForms[0].Handle, TaskbarProgress.TaskbarStates.Error);
+			if( ex is not OperationCanceledException)
+				TaskbarProgress.SetState(Application.OpenForms[0].Handle, TaskbarProgress.TaskbarStates.Error);
+			else
+				TaskbarProgress.SetState(Application.OpenForms[0].Handle, TaskbarProgress.TaskbarStates.NoProgress);
+
 			TaskbarProgress.FlashWindow();
 			pbStato.Value = 0;
 			butCancel.Enabled = true;
@@ -116,7 +120,7 @@ namespace TombEditor.Forms
 			}
 			catch (Exception ex)
 			{
-				OnOperationFailure();
+				OnOperationFailure(ex);
 				logger.Error(ex, "Operation failed: " + Text);
 
 				string message = "There was an error. Message: " + ex.Message;

--- a/TombEditor/Forms/FormOperationDialog.cs
+++ b/TombEditor/Forms/FormOperationDialog.cs
@@ -1,6 +1,4 @@
-﻿using DarkUI.Extensions;
-using DarkUI.Config;
-using System;
+﻿using System;
 using System.Drawing;
 using System.Threading;
 using System.Windows.Forms;
@@ -9,199 +7,191 @@ using NLog;
 using TombLib.Forms;
 using TombLib.Utils;
 using TombLib;
+using DarkUI.Extensions;
+using DarkUI.Config;
+using System.Threading.Tasks;
+using System.Windows.Threading;
 
 namespace TombEditor.Forms
 {
-    public partial class FormOperationDialog : DarkForm, IProgressReporter
-    {
-        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
-        
-        private readonly Action<IProgressReporter> _operation;
-        private Thread _thread;
-        private volatile bool _threadShouldAbort;
-        private readonly bool _autoCloseWhenDone;
+	public partial class FormOperationDialog : DarkForm, IProgressReporter
+	{
+		private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
-        public FormOperationDialog(string operationName, bool autoCloseWhenDone, bool noProgressBar, Action<IProgressReporter> operation)
-        {
-            _autoCloseWhenDone = autoCloseWhenDone;
-            _operation = operation;
-            InitializeComponent();
+		private readonly Action<IProgressReporter, CancellationToken> _operation;
+		private readonly bool _autoCloseWhenDone;
+		private readonly CancellationTokenSource _cancellationTokenSource;
+		private Task _task;
+		public FormOperationDialog(string operationName, bool autoCloseWhenDone, bool noProgressBar, Action<IProgressReporter, CancellationToken> operation)
+		{
+			_autoCloseWhenDone = autoCloseWhenDone;
+			_operation = operation;
+			InitializeComponent();
 
-            Text = operationName;
-            lstLog.SelectionHangingIndent = 50;
+			Text = operationName;
+			lstLog.SelectionHangingIndent = 50;
 
-            this.SetActualSize();
+			this.SetActualSize();
 
-            panelProgressBar.Visible = !noProgressBar;
-            if (!noProgressBar && Application.OpenForms.Count > 0)
-                TaskbarProgress.SetState(Application.OpenForms[0].Handle, TaskbarProgress.TaskbarStates.Normal);
+			panelProgressBar.Visible = !noProgressBar;
+			if (!noProgressBar && Application.OpenForms.Count > 0)
+				TaskbarProgress.SetState(Application.OpenForms[0].Handle, TaskbarProgress.TaskbarStates.Normal);
 
-            lstLog.BackColor = lstLog.BackColor.Multiply(Colors.Brightness);
-        }
+			lstLog.BackColor = lstLog.BackColor.Multiply(Colors.Brightness);
+			_cancellationTokenSource = new CancellationTokenSource();
 
-        private void FormOperationDialog_Shown(object sender, EventArgs e)
-        {
-            _thread = new Thread((ThreadStart)new SynchronizationCallback(Run));
-            _thread.IsBackground = true;
-            _thread.Start();
-        }
+		}
 
-        private void FormOperationDialog_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            if(_thread.IsAlive)
-            {
-                e.Cancel = true;
-                if (e.CloseReason == CloseReason.UserClosing && !_threadShouldAbort)
-                {
-                    butCancel.Enabled = false;
-                    EndThread();
-                }
-            }
-        }
+		private void FormOperationDialog_Shown(object sender, EventArgs e)
+		{
+			Run();
+		}
 
-        private void Run()
-        {
+		private void FormOperationDialog_FormClosing(object sender, FormClosingEventArgs e)
+		{
+			if (_task != null)
+			{
+				e.Cancel = true;
+				if (e.CloseReason == CloseReason.UserClosing && !_cancellationTokenSource.IsCancellationRequested)
+				{
+					butCancel.Enabled = false;
+					EndThread();
+				}
+			}
+		}
+
+		private void Run()
+		{
 #if !DEBUG
-            try
-            {
+			try
+			{
 #endif
-            _operation(this);
+				var task = Task.Run(() =>
+				{
+					_operation(this, _cancellationTokenSource.Token);
+				});
+				// Done
 
-            // Done
-            BeginInvoke((Action)delegate
-                    {
-                        TaskbarProgress.SetState(Application.OpenForms[0].Handle, TaskbarProgress.TaskbarStates.NoProgress);
-                        TaskbarProgress.FlashWindow();
-                        
-                        pbStato.Value = 100;
-						
-                        butOk.Enabled = true;
-                        butCancel.Enabled = false;
-                        butOk.Focus();
+				task.ContinueWith((t) =>
+				{
+					BeginInvoke(() =>
+					{
+						TaskbarProgress.SetState(Application.OpenForms[0].Handle, TaskbarProgress.TaskbarStates.NoProgress);
+						TaskbarProgress.FlashWindow();
 
-                        if (_autoCloseWhenDone)
-                        {
-                            DialogResult = DialogResult.OK;
-                            Close();
-                        }
-                        lstLog.BackColor = Color.LightGreen.Multiply(Colors.Brightness);
-                    });
+						pbStato.Value = 100;
+
+						butOk.Enabled = true;
+						butCancel.Enabled = false;
+						butOk.Focus();
+
+						if (_autoCloseWhenDone)
+						{
+							DialogResult = DialogResult.OK;
+							Close();
+						}
+						lstLog.BackColor = Color.LightGreen.Multiply(Colors.Brightness);
+					});
+				});
+
+				
 #if !DEBUG
-            }
-            catch (Exception ex)
-            {
-                while (ex is AggregateException) // Improve error messages from exceptions of Task.* threads
-                    ex = ex.InnerException;
+			}
+			catch (Exception ex)
+			{
+				while (ex is AggregateException) // Improve error messages from exceptions of Task.* threads
+					ex = ex.InnerException;
 
-                logger.Error(ex, "Operation failed: " + Text);
+				logger.Error(ex, "Operation failed: " + Text);
 
-                string message = "There was an error. Message: " + ex.Message;
-                Invoke((Action)delegate
-                    {
-                        pbStato.Value = 0;
-                        TaskbarProgress.SetState(Application.OpenForms[0].Handle, TaskbarProgress.TaskbarStates.NoProgress);
+				string message = "There was an error. Message: " + ex.Message;
+				Invoke(() =>
+					{
+						pbStato.Value = 0;
+						TaskbarProgress.SetState(Application.OpenForms[0].Handle, TaskbarProgress.TaskbarStates.NoProgress);
 
-                        if (!string.IsNullOrEmpty(message))
-                        {
-                            lstLog.SelectionBackColor = Color.Tomato;
-                            lstLog.AppendText(message + "\n");
-                            lstLog.ScrollToCaret();
-                        }
+						if (!string.IsNullOrEmpty(message))
+						{
+							lstLog.SelectionBackColor = Color.Tomato;
+							lstLog.AppendText(message + "\n");
+							lstLog.ScrollToCaret();
+						}
 
-                        lstLog.BackColor = Color.LightPink;
-                        butCancel.Enabled = true;
-                        butOk.Enabled = false;
-                        butCancel.Focus();
-                    });
-            }
+						lstLog.BackColor = Color.LightPink;
+						butCancel.Enabled = true;
+						butOk.Enabled = false;
+						butCancel.Focus();
+					});
+			}
 #endif
-        }
+		}
 
-        void AddMessage(float? progress, string message, bool isWarning)
-        {
-            if (!(bool)Invoke((Func<bool>)delegate
-            {
-                if (progress.HasValue)
-                {
-                    pbStato.Value = (int)Math.Round(MathC.Clamp(progress.Value, 0, 100), 0);
-                    TaskbarProgress.SetValue(Application.OpenForms[0].Handle, progress.Value, 100);
-                }
+		void AddMessage(float? progress, string message, bool isWarning)
+		{
+			BeginInvoke(() =>
+			{
+				if (progress.HasValue)
+				{
+					pbStato.Value = (int)Math.Round(MathC.Clamp(progress.Value, 0, 100), 0);
+					TaskbarProgress.SetValue(Application.OpenForms[0].Handle, progress.Value, 100);
+				}
 
-                if (!string.IsNullOrEmpty(message))
-                {
-                    lstLog.SelectionBackColor = isWarning ? Color.Yellow.Multiply(Colors.Brightness) : Color.Empty;
-                    lstLog.AppendText(message + "\n");
-                    lstLog.ScrollToCaret();
-                }
+				if (!string.IsNullOrEmpty(message))
+				{
+					lstLog.SelectionBackColor = isWarning ? Color.Yellow.Multiply(Colors.Brightness) : Color.Empty;
+					lstLog.AppendText(message + "\n");
+					lstLog.ScrollToCaret();
+				}
+			});
+		}
 
-                return !_threadShouldAbort;
-            }))
-                throw new OperationCanceledException();
-        }
+		void IProgressReporter.ReportWarn(string message)
+		{
+			logger.Warn(message);
+			AddMessage(null, message, true);
 
-        void IProgressReporter.ReportWarn(string message)
-        {
-            logger.Warn(message);
-            AddMessage(null, message, true);
+		}
 
-        }
+		void IProgressReporter.ReportInfo(string message)
+		{
+			logger.Info(message);
+			AddMessage(null, message, false);
+		}
 
-        void IProgressReporter.ReportInfo(string message)
-        {
-            logger.Info(message);
-            AddMessage(null, message, false);
-        }
+		void IProgressReporter.ReportProgress(float progress, string message)
+		{
+			logger.Info(progress + " - " + message);
+			AddMessage(progress, message, false);
+		}
 
-        void IProgressReporter.ReportProgress(float progress, string message)
-        {
-            logger.Info(progress + " - " + message);
-            AddMessage(progress, message, false);
-        }
+		void IDialogHandler.RaiseDialog(IDialogDescription description)
+		{
+			GraphicalDialogHandler.HandleDialog(description, this);
+		}
 
-        void IDialogHandler.RaiseDialog(IDialogDescription description)
-        {
-            GraphicalDialogHandler.HandleDialog(description, this);
-        }
+		private void butCancel_Click(object sender, EventArgs e)
+		{
+			Close();
+		}
 
-        private void butCancel_Click(object sender, EventArgs e)
-        {
-            Close();
-        }
+		private void butOk_Click(object sender, EventArgs e)
+		{
+			DialogResult = DialogResult.OK;
+			Close();
+		}
 
-        private void butOk_Click(object sender, EventArgs e)
-        {
-            if (_thread.IsAlive)
-                return;
-            DialogResult = DialogResult.OK;
-            Close();
-        }
+		private void EndThread()
+		{
+			Invoke(() =>
+			{
+				DialogResult = DialogResult.Cancel;
+				_cancellationTokenSource.Cancel();
+				// Try shutting down the thread softly
+				lstLog.SelectionBackColor = Color.Tomato;
+				lstLog.AppendText("Stopping the process...\n");
+				lstLog.ScrollToCaret();
+			});
 
-        private void EndThread()
-        {
-            DialogResult = DialogResult.Cancel;
-            _threadShouldAbort = true;
-
-            if (!_thread.IsAlive)
-                return;
-
-            // Try shutting down the thread softly
-            lstLog.SelectionBackColor = Color.Tomato;
-            lstLog.AppendText("Trying to stop the process...\n");
-            lstLog.ScrollToCaret();
-            for (int i = 0; i < 23; ++i)
-            {
-                if (_thread.Join(40))
-                    return;
-                Application.DoEvents();
-            }
-
-            // Shut the thread down forcefully
-            lstLog.SelectionBackColor = Color.Tomato;
-            lstLog.AppendText("Forcefully stopping process.\n");
-            lstLog.ScrollToCaret();
-            _thread.Interrupt();
-            while ((_thread.ThreadState & (ThreadState.Stopped | ThreadState.Aborted)) != 0)
-                Thread.Sleep(5);
-        }
-    }
+		}
+	}
 }

--- a/TombEditor/RoomClipboardData.cs
+++ b/TombEditor/RoomClipboardData.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Threading;
 using TombLib;
 using TombLib.IO;
 using TombLib.LevelData;
@@ -91,7 +92,7 @@ namespace TombEditor
         {
             using (var stream = new MemoryStream(_data, false))
             {
-                Level level = Prj2Loader.LoadFromPrj2(_levelPath, stream, new ProgressReporterSimple(),
+                Level level = Prj2Loader.LoadFromPrj2(_levelPath, stream, new ProgressReporterSimple(),new CancellationToken(false),
                     new Prj2Loader.Settings { IgnoreWads = true });
                 return level;
             }

--- a/TombIDE/TombIDE.Shared/SharedClasses/LevelHandling.cs
+++ b/TombIDE/TombIDE.Shared/SharedClasses/LevelHandling.cs
@@ -11,7 +11,7 @@ namespace TombIDE.Shared.SharedClasses
 	{
 		public static void UpdatePrj2GameSettings(string prj2FilePath, IGameProject destProject, string dataFileName = null)
 		{
-			Level level = Prj2Loader.LoadFromPrj2(prj2FilePath, null);
+			Level level = Prj2Loader.LoadFromPrj2(prj2FilePath, null, System.Threading.CancellationToken.None, new Prj2Loader.Settings());
 
 			string exeFilePath = destProject.GetEngineExecutableFilePath();
 			string engineDirectory = destProject.GetEngineRootDirectoryPath();

--- a/TombLib/TombLib/LevelData/Compilers/LevelCompiler.cs
+++ b/TombLib/TombLib/LevelData/Compilers/LevelCompiler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using TombLib.Utils;
 
 namespace TombLib.LevelData.Compilers
@@ -63,6 +64,6 @@ namespace TombLib.LevelData.Compilers
             _progressReporter.ReportProgress(percentage, message);
         }
 
-        public abstract CompilerStatistics CompileLevel();
+        public abstract CompilerStatistics CompileLevel(CancellationToken cancelToken);
     }
 }

--- a/TombLib/TombLib/LevelData/Compilers/LevelCompilerClassicTR.cs
+++ b/TombLib/TombLib/LevelData/Compilers/LevelCompilerClassicTR.cs
@@ -74,17 +74,17 @@ namespace TombLib.LevelData.Compilers
                 throw new NotSupportedException("A wad must be loaded to compile the final level.");
 
             _textureInfoManager = new Util.TexInfoManager(_level, _progressReporter, _limits[Limit.TexPageSize]);
-			cancelToken.ThrowIfCancellationRequested();
+            cancelToken.ThrowIfCancellationRequested();
             // Try to shuffle rooms to accomodate for more vertically connected ones
             _sortedRooms = _level.GetRearrangedRooms(_progressReporter);
 
             // Prepare level data
             ConvertWad2DataToTrData(_level);
             BuildRooms();
-			cancelToken.ThrowIfCancellationRequested();
+            cancelToken.ThrowIfCancellationRequested();
 
-			// Compile textures
-			ReportProgress(30, "Packing textures");
+            // Compile textures
+            ReportProgress(30, "Packing textures");
             _textureInfoManager.LayOutAllData(_level.Settings.GameVersion);
 
             ReportProgress(35, "   Number of TexInfos: " + _textureInfoManager.TexInfoCount);
@@ -93,18 +93,18 @@ namespace TombLib.LevelData.Compilers
             int texInfoLimit = _limits[Limit.TexInfos];
             if (_textureInfoManager.TexInfoCount > texInfoLimit)
                 _progressReporter.ReportWarn("TexInfo number overflow, maximum is " + texInfoLimit + ". Please reduce level complexity.");
-			cancelToken.ThrowIfCancellationRequested();
+            cancelToken.ThrowIfCancellationRequested();
 
-			GetAllReachableRooms();
+            GetAllReachableRooms();
             BuildPathFindingData();
             PrepareSoundSources();
             PrepareItems();
             BuildCamerasAndSinks();
             BuildFloorData();
-			cancelToken.ThrowIfCancellationRequested();
+            cancelToken.ThrowIfCancellationRequested();
 
-			// Combine the texture data collected
-			var pageCount = PrepareTextures();
+            // Combine the texture data collected
+            var pageCount = PrepareTextures();
 
             int texPageLimit = _limits[Limit.TexPages];
             if (pageCount > texPageLimit)

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
@@ -74,6 +74,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
 
             DetectTombEngineVersion(false);
             DetectTombEngineVersion(true);
+
             _textureInfoManager = new TombEngineTexInfoManager(_level, _progressReporter, _limits[Limit.TexPageSize]);
 
             // Prepare level data in parallel to the sounds

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
@@ -79,28 +79,47 @@ namespace TombLib.LevelData.Compilers.TombEngine
 
             // Prepare level data in parallel to the sounds
             ConvertWad2DataToTombEngine();
+
+			cancelToken.ThrowIfCancellationRequested();
+
             BuildRooms();
 
-            // Compile textures
-            ReportProgress(30, "Packing textures");
+			cancelToken.ThrowIfCancellationRequested();
+
+			// Compile textures
+			ReportProgress(30, "Packing textures");
             _textureInfoManager.LayOutAllData();
 
             ReportProgress(35, "   Number of TexInfos: " + _textureInfoManager.TexInfoCount);
             ReportProgress(35, "   Number of anim texture sequences: " + _textureInfoManager.AnimatedTextures.Count);
             GetAllReachableRooms();
-            BuildPathFindingData();
-            PrepareSoundSources();
+
+			cancelToken.ThrowIfCancellationRequested();
+
+			BuildPathFindingData();
+
+			cancelToken.ThrowIfCancellationRequested();
+
+			PrepareSoundSources();
             PrepareItems();
             BuildCamerasAndSinks();
-            BuildFloorData();
+
+			cancelToken.ThrowIfCancellationRequested();
+
+			BuildFloorData();
             BuildSprites();
             PrepareRoomsBuckets();
             PrepareMeshBuckets();
 
-            _progressReporter.ReportInfo("\nWriting level file...\n");
+			cancelToken.ThrowIfCancellationRequested();
+
+			_progressReporter.ReportInfo("\nWriting level file...\n");
 
             WriteLevelTombEngine();
-            CopyNodeScripts();
+
+			cancelToken.ThrowIfCancellationRequested();
+
+			CopyNodeScripts();
             
             // Needed to make decision about backup (delete or restore)
             _compiledSuccessfully = !cancelToken.IsCancellationRequested;

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
@@ -82,7 +82,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
 
 			cancelToken.ThrowIfCancellationRequested();
 
-            BuildRooms();
+            BuildRooms(cancelToken);
 
 			cancelToken.ThrowIfCancellationRequested();
 

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Reflection;
+using System.Threading;
 using TombLib.Utils;
 using TombLib.Wad;
 using TombLib.Wad.Catalog;
@@ -64,7 +65,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
                 _limits.Add(limit, TrCatalog.GetLimit(level.Settings.GameVersion, limit));
         }
 
-        public override CompilerStatistics CompileLevel()
+        public override CompilerStatistics CompileLevel(CancellationToken cancelToken)
         {
             ReportProgress(0, "Tomb Engine Level Compiler");
 
@@ -73,7 +74,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
 
             DetectTombEngineVersion(false);
             DetectTombEngineVersion(true);
-
+			cancelToken.ThrowIfCancellationRequested();
             _textureInfoManager = new TombEngineTexInfoManager(_level, _progressReporter, _limits[Limit.TexPageSize]);
 
             // Prepare level data in parallel to the sounds
@@ -86,7 +87,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
 
             ReportProgress(35, "   Number of TexInfos: " + _textureInfoManager.TexInfoCount);
             ReportProgress(35, "   Number of anim texture sequences: " + _textureInfoManager.AnimatedTextures.Count);
-            
+			cancelToken.ThrowIfCancellationRequested();
             GetAllReachableRooms();
             BuildPathFindingData();
             PrepareSoundSources();
@@ -94,7 +95,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
             BuildCamerasAndSinks();
             BuildFloorData();
             BuildSprites();
-
+			cancelToken.ThrowIfCancellationRequested();
             PrepareRoomsBuckets();
             PrepareMeshBuckets();
 
@@ -104,7 +105,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
             CopyNodeScripts();
             
             // Needed to make decision about backup (delete or restore)
-            _compiledSuccessfully = true;
+            _compiledSuccessfully = !cancelToken.IsCancellationRequested;
 
             _progressReporter.ReportInfo("\nOutput file: " + _finalDest);
 

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
@@ -80,46 +80,46 @@ namespace TombLib.LevelData.Compilers.TombEngine
             // Prepare level data in parallel to the sounds
             ConvertWad2DataToTombEngine();
 
-			cancelToken.ThrowIfCancellationRequested();
+            cancelToken.ThrowIfCancellationRequested();
 
             BuildRooms(cancelToken);
 
-			cancelToken.ThrowIfCancellationRequested();
+            cancelToken.ThrowIfCancellationRequested();
 
-			// Compile textures
-			ReportProgress(30, "Packing textures");
+            // Compile textures
+            ReportProgress(30, "Packing textures");
             _textureInfoManager.LayOutAllData();
 
             ReportProgress(35, "   Number of TexInfos: " + _textureInfoManager.TexInfoCount);
             ReportProgress(35, "   Number of anim texture sequences: " + _textureInfoManager.AnimatedTextures.Count);
             GetAllReachableRooms();
 
-			cancelToken.ThrowIfCancellationRequested();
+            cancelToken.ThrowIfCancellationRequested();
 
-			BuildPathFindingData();
+            BuildPathFindingData();
 
-			cancelToken.ThrowIfCancellationRequested();
+            cancelToken.ThrowIfCancellationRequested();
 
-			PrepareSoundSources();
+            PrepareSoundSources();
             PrepareItems();
             BuildCamerasAndSinks();
 
-			cancelToken.ThrowIfCancellationRequested();
+            cancelToken.ThrowIfCancellationRequested();
 
-			BuildFloorData();
+            BuildFloorData();
             BuildSprites();
             PrepareRoomsBuckets();
             PrepareMeshBuckets();
 
-			cancelToken.ThrowIfCancellationRequested();
+            cancelToken.ThrowIfCancellationRequested();
 
-			_progressReporter.ReportInfo("\nWriting level file...\n");
+            _progressReporter.ReportInfo("\nWriting level file...\n");
 
             WriteLevelTombEngine();
 
-			cancelToken.ThrowIfCancellationRequested();
+            cancelToken.ThrowIfCancellationRequested();
 
-			CopyNodeScripts();
+            CopyNodeScripts();
             
             // Needed to make decision about backup (delete or restore)
             _compiledSuccessfully = !cancelToken.IsCancellationRequested;
@@ -488,9 +488,9 @@ namespace TombLib.LevelData.Compilers.TombEngine
             }
 
             if (!Directory.Exists(scriptDirectory))
-			{
-				Directory.CreateDirectory(scriptDirectory);
-			}
+            {
+                Directory.CreateDirectory(scriptDirectory);
+            }
             else
             {
                 foreach (var file in Directory.GetFiles(scriptDirectory))

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
@@ -74,7 +74,6 @@ namespace TombLib.LevelData.Compilers.TombEngine
 
             DetectTombEngineVersion(false);
             DetectTombEngineVersion(true);
-			cancelToken.ThrowIfCancellationRequested();
             _textureInfoManager = new TombEngineTexInfoManager(_level, _progressReporter, _limits[Limit.TexPageSize]);
 
             // Prepare level data in parallel to the sounds
@@ -87,7 +86,6 @@ namespace TombLib.LevelData.Compilers.TombEngine
 
             ReportProgress(35, "   Number of TexInfos: " + _textureInfoManager.TexInfoCount);
             ReportProgress(35, "   Number of anim texture sequences: " + _textureInfoManager.AnimatedTextures.Count);
-			cancelToken.ThrowIfCancellationRequested();
             GetAllReachableRooms();
             BuildPathFindingData();
             PrepareSoundSources();
@@ -95,7 +93,6 @@ namespace TombLib.LevelData.Compilers.TombEngine
             BuildCamerasAndSinks();
             BuildFloorData();
             BuildSprites();
-			cancelToken.ThrowIfCancellationRequested();
             PrepareRoomsBuckets();
             PrepareMeshBuckets();
 

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -9,6 +9,7 @@ using TombLib.IO;
 using TombLib.Utils;
 using TombLib.Wad;
 using TombLib.LevelData.VisualScripting;
+using System.Threading;
 
 namespace TombLib.LevelData.IO
 {
@@ -23,14 +24,12 @@ namespace TombLib.LevelData.IO
             public bool IgnoreSoundsCatalogs = false;
         }
 
-        public static Level LoadFromPrj2(string filename, IProgressReporter progressReporter) => LoadFromPrj2(filename, progressReporter, new Settings());
-        public static Level LoadFromPrj2(string filename, IProgressReporter progressReporter, Settings loadSettings)
+        public static Level LoadFromPrj2(string filename, IProgressReporter progressReporter,CancellationToken cancelToken, Settings loadSettings)
         {
             using (var fileStream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read))
-                return LoadFromPrj2(filename, fileStream, progressReporter, loadSettings);
+                return LoadFromPrj2(filename, fileStream, progressReporter,cancelToken, loadSettings);
         }
-        public static Level LoadFromPrj2(string filename, Stream stream, IProgressReporter progressReporter) => LoadFromPrj2(filename, stream, progressReporter, new Settings());
-        public static Level LoadFromPrj2(string filename, Stream stream, IProgressReporter progressReporter, Settings loadSettings)
+        public static Level LoadFromPrj2(string filename, Stream stream, IProgressReporter progressReporter,CancellationToken cancelToken, Settings loadSettings)
         {
             using (var chunkIO = new ChunkReader(Prj2Chunks.MagicNumber, stream, Prj2Chunks.ChunkList))
             {

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -29,7 +29,7 @@ namespace TombLib.LevelData.IO
             using (var fileStream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read))
                 return LoadFromPrj2(filename, fileStream, progressReporter,cancelToken, loadSettings);
         }
-        public static Level LoadFromPrj2(string filename, Stream stream, IProgressReporter progressReporter,CancellationToken cancelToken, Settings loadSettings)
+        public static Level LoadFromPrj2(string filename, Stream stream, IProgressReporter progressReporter, CancellationToken cancelToken, Settings loadSettings)
         {
             using (var chunkIO = new ChunkReader(Prj2Chunks.MagicNumber, stream, Prj2Chunks.ChunkList))
             {
@@ -40,10 +40,12 @@ namespace TombLib.LevelData.IO
                     LevelSettings settings = null;
                     if (LoadLevelSettings(chunkIO, id, filename, ref levelSettingsIds, ref settings, loadSettings, progressReporter))
                     {
+                        cancelToken.ThrowIfCancellationRequested();
+
                         level.ApplyNewLevelSettings(settings);
                         return true;
                     }
-                    else if (LoadRooms(chunkIO, id, level, levelSettingsIds, progressReporter))
+                    else if (LoadRooms(chunkIO, id, level, levelSettingsIds, progressReporter, cancelToken))
                         return true;
                     return false;
                 });
@@ -690,7 +692,7 @@ namespace TombLib.LevelData.IO
             return true;
         }
 
-        private static bool LoadRooms(ChunkReader chunkIO, ChunkId idOuter, Level level, LevelSettingsIds levelSettingsIds, IProgressReporter progressReporter = null)
+        private static bool LoadRooms(ChunkReader chunkIO, ChunkId idOuter, Level level, LevelSettingsIds levelSettingsIds, IProgressReporter progressReporter, CancellationToken cancelToken)
         {
             if (idOuter != Prj2Chunks.Rooms)
                 return false;
@@ -713,6 +715,7 @@ namespace TombLib.LevelData.IO
                 long roomIndex = long.MinValue;
                 chunkIO.ReadChunks((id2, chunkSize2) =>
                 {
+                    cancelToken.ThrowIfCancellationRequested();
                     // Read basic room properties
                     if (id2 == Prj2Chunks.RoomIndex)
                         roomIndex = chunkIO.ReadChunkLong(chunkSize2);
@@ -734,7 +737,9 @@ namespace TombLib.LevelData.IO
                     else if (id2 == Prj2Chunks.RoomSectors)
                         chunkIO.ReadChunks((id3, chunkSize3) =>
                         {
-                            if (id3 != Prj2Chunks.Sector)
+							cancelToken.ThrowIfCancellationRequested();
+
+							if (id3 != Prj2Chunks.Sector)
                                 return false;
 
                             int ReadPos = chunkIO.Raw.ReadInt32();
@@ -744,7 +749,8 @@ namespace TombLib.LevelData.IO
 
                             chunkIO.ReadChunks((id4, chunkSize4) =>
                                 {
-                                    if (id4 == Prj2Chunks.SectorProperties)
+									cancelToken.ThrowIfCancellationRequested();
+									if (id4 == Prj2Chunks.SectorProperties)
                                     {
                                         long flag = chunkIO.ReadChunkLong(chunkSize4);
                                         if ((flag & 1) != 0 && block.Type != BlockType.BorderWall)
@@ -920,7 +926,9 @@ namespace TombLib.LevelData.IO
                         long alternateRoomIndex = -1;
                         chunkIO.ReadChunks((id3, chunkSize3) =>
                         {
-                            if (id3 == Prj2Chunks.AlternateGroup)
+							cancelToken.ThrowIfCancellationRequested();
+
+							if (id3 == Prj2Chunks.AlternateGroup)
                                 alternateGroup = chunkIO.ReadChunkShort(chunkSize3);
                             else if (id3 == Prj2Chunks.AlternateRoom)
                                 alternateRoomIndex = chunkIO.ReadChunkLong(chunkSize3);
@@ -967,29 +975,43 @@ namespace TombLib.LevelData.IO
 
             // Link rooms
             foreach (var roomLinkAction in roomLinkActions)
-                try
-                {
-                    roomLinkAction.Value(newRooms.TryGetOrDefault(roomLinkAction.Key));
-                }
-                catch (Exception exc)
-                {
-                    logger.Error(exc, "An exception was raised while trying to perform room link action.");
-                }
+            {
+				cancelToken.ThrowIfCancellationRequested();
+
+				try
+				{
+					roomLinkAction.Value(newRooms.TryGetOrDefault(roomLinkAction.Key));
+				}
+				catch (Exception exc)
+				{
+					logger.Error(exc, "An exception was raised while trying to perform room link action.");
+				}
+			}
+                
 
             // Link objects
             foreach (var objectLinkAction in objectLinkActions)
-                try
-                {
-                    objectLinkAction.Value(newObjects.TryGetOrDefault(objectLinkAction.Key));
-                }
-                catch (Exception exc)
-                {
-                    logger.Error(exc, "An exception was raised while trying to perform room link objects.");
-                }
+            {
+				cancelToken.ThrowIfCancellationRequested();
+
+				try
+				{
+					objectLinkAction.Value(newObjects.TryGetOrDefault(objectLinkAction.Key));
+				}
+				catch (Exception exc)
+				{
+					logger.Error(exc, "An exception was raised while trying to perform room link objects.");
+				}
+			}
+
 
             // Now build the real geometry and update geometry buffers
+            ParallelOptions parallelOptions = new ParallelOptions()
+            {
+                CancellationToken = cancelToken,
+            };
             progressReporter?.ReportInfo("Building world geometry");
-            Parallel.ForEach(level.ExistingRooms, room => room.BuildGeometry());
+            Parallel.ForEach(level.ExistingRooms, parallelOptions, room => room.BuildGeometry());
             return true;
         }
 

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -294,9 +294,9 @@ namespace TombLib.LevelData.IO
                 else if (id == Prj2Chunks.TextureCompression)
                     settings.CompressTextures = chunkIO.ReadChunkBool(chunkSize);
                 else if (id == Prj2Chunks.RearrangeRooms)
-					settings.RearrangeVerticalRooms = chunkIO.ReadChunkBool(chunkSize);
-				else if (id == Prj2Chunks.RemoveUnusedObjects)
-					settings.RemoveUnusedObjects = chunkIO.ReadChunkBool(chunkSize);
+                    settings.RearrangeVerticalRooms = chunkIO.ReadChunkBool(chunkSize);
+                else if (id == Prj2Chunks.RemoveUnusedObjects)
+                    settings.RemoveUnusedObjects = chunkIO.ReadChunkBool(chunkSize);
                 else if (id == Prj2Chunks.EnableCustomSampleRate)
                     settings.EnableCustomSampleRate = chunkIO.ReadChunkBool(chunkSize);
                 else if (id == Prj2Chunks.CustomSampleRate)
@@ -737,9 +737,9 @@ namespace TombLib.LevelData.IO
                     else if (id2 == Prj2Chunks.RoomSectors)
                         chunkIO.ReadChunks((id3, chunkSize3) =>
                         {
-							cancelToken.ThrowIfCancellationRequested();
+                            cancelToken.ThrowIfCancellationRequested();
 
-							if (id3 != Prj2Chunks.Sector)
+                            if (id3 != Prj2Chunks.Sector)
                                 return false;
 
                             int ReadPos = chunkIO.Raw.ReadInt32();
@@ -749,8 +749,8 @@ namespace TombLib.LevelData.IO
 
                             chunkIO.ReadChunks((id4, chunkSize4) =>
                                 {
-									cancelToken.ThrowIfCancellationRequested();
-									if (id4 == Prj2Chunks.SectorProperties)
+                                    cancelToken.ThrowIfCancellationRequested();
+                                    if (id4 == Prj2Chunks.SectorProperties)
                                     {
                                         long flag = chunkIO.ReadChunkLong(chunkSize4);
                                         if ((flag & 1) != 0 && block.Type != BlockType.BorderWall)
@@ -926,9 +926,9 @@ namespace TombLib.LevelData.IO
                         long alternateRoomIndex = -1;
                         chunkIO.ReadChunks((id3, chunkSize3) =>
                         {
-							cancelToken.ThrowIfCancellationRequested();
+                            cancelToken.ThrowIfCancellationRequested();
 
-							if (id3 == Prj2Chunks.AlternateGroup)
+                            if (id3 == Prj2Chunks.AlternateGroup)
                                 alternateGroup = chunkIO.ReadChunkShort(chunkSize3);
                             else if (id3 == Prj2Chunks.AlternateRoom)
                                 alternateRoomIndex = chunkIO.ReadChunkLong(chunkSize3);
@@ -976,33 +976,33 @@ namespace TombLib.LevelData.IO
             // Link rooms
             foreach (var roomLinkAction in roomLinkActions)
             {
-				cancelToken.ThrowIfCancellationRequested();
+                cancelToken.ThrowIfCancellationRequested();
 
-				try
-				{
-					roomLinkAction.Value(newRooms.TryGetOrDefault(roomLinkAction.Key));
-				}
-				catch (Exception exc)
-				{
-					logger.Error(exc, "An exception was raised while trying to perform room link action.");
-				}
-			}
+                try
+                {
+                    roomLinkAction.Value(newRooms.TryGetOrDefault(roomLinkAction.Key));
+                }
+                catch (Exception exc)
+                {
+                    logger.Error(exc, "An exception was raised while trying to perform room link action.");
+                }
+            }
                 
 
             // Link objects
             foreach (var objectLinkAction in objectLinkActions)
             {
-				cancelToken.ThrowIfCancellationRequested();
+                cancelToken.ThrowIfCancellationRequested();
 
-				try
-				{
-					objectLinkAction.Value(newObjects.TryGetOrDefault(objectLinkAction.Key));
-				}
-				catch (Exception exc)
-				{
-					logger.Error(exc, "An exception was raised while trying to perform room link objects.");
-				}
-			}
+                try
+                {
+                    objectLinkAction.Value(newObjects.TryGetOrDefault(objectLinkAction.Key));
+                }
+                catch (Exception exc)
+                {
+                    logger.Error(exc, "An exception was raised while trying to perform room link objects.");
+                }
+            }
 
 
             // Now build the real geometry and update geometry buffers

--- a/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
@@ -12,7 +12,7 @@ using TombLib.Wad.Catalog;
 namespace TombLib.LevelData.IO
 {
     public static class TombEngineConverter
-	{
+    {
         public static readonly string ReferenceWadPath = Path.Combine(DefaultPaths.ProgramDirectory, "Assets", "Wads", "TombEngine.wad2");
 
         public static string Start(string fileName, IWin32Window owner, IProgressReporter progressReporter, CancellationToken cancelToken)
@@ -326,7 +326,7 @@ namespace TombLib.LevelData.IO
 
                 foreach (ReferencedWad wadRef in level.Settings.Wads)
                 {
-					cancelToken.ThrowIfCancellationRequested();
+                    cancelToken.ThrowIfCancellationRequested();
                     Wad2 wad = wadRef.Wad;
                     Wad2 newWad = new Wad2 { GameVersion = TRVersion.Game.TombEngine };
 
@@ -430,7 +430,7 @@ namespace TombLib.LevelData.IO
                     // Copy all sprite sequences
                     foreach (KeyValuePair<WadSpriteSequenceId, WadSpriteSequence> sequence in wad.SpriteSequences)
                     {
-						cancelToken.ThrowIfCancellationRequested();
+                        cancelToken.ThrowIfCancellationRequested();
                         uint newSlot;
                         string oldId = TrCatalog.GetMoveableName(TRVersion.Game.TR4, sequence.Key.TypeId);
                         string newId = TrCatalog.GetMoveableTombEngineSlot(TRVersion.Game.TR4, sequence.Key.TypeId);
@@ -504,7 +504,7 @@ namespace TombLib.LevelData.IO
 
                 foreach (Room room in level.Rooms)
                 {
-					cancelToken.ThrowIfCancellationRequested();
+                    cancelToken.ThrowIfCancellationRequested();
                     if (room != null)
                     {
                         foreach (var instance in room.Objects)

--- a/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Threading;
 using System.Windows.Forms;
 using TombLib.Utils;
 using TombLib.Wad;
@@ -14,7 +15,7 @@ namespace TombLib.LevelData.IO
 	{
         public static readonly string ReferenceWadPath = Path.Combine(DefaultPaths.ProgramDirectory, "Assets", "Wads", "TombEngine.wad2");
 
-        public static string Start(string fileName, IWin32Window owner, IProgressReporter progressReporter)
+        public static string Start(string fileName, IWin32Window owner, IProgressReporter progressReporter,CancellationToken cancelToken)
         {
             if (!File.Exists(fileName))
             {
@@ -25,7 +26,7 @@ namespace TombLib.LevelData.IO
             progressReporter.ReportInfo("TombEngine Project Converter");
             progressReporter.ReportInfo(" ");
 
-            string newProject = ConvertProject(fileName, progressReporter);
+            string newProject = ConvertProject(fileName, progressReporter,cancelToken);
 
             if (string.IsNullOrEmpty(newProject))
             {
@@ -287,7 +288,7 @@ namespace TombLib.LevelData.IO
             return moveable;
         }
 
-        private static string ConvertProject(string source, IProgressReporter progressReporter)
+        private static string ConvertProject(string source, IProgressReporter progressReporter, CancellationToken cancelToken)
         {
             try
             {
@@ -296,7 +297,7 @@ namespace TombLib.LevelData.IO
 
                 // Load level and all related resources
                 Level level = Path.GetExtension(source).ToLower() == ".prj" ?
-                    PrjLoader.LoadFromPrj(source, string.Empty, true, false, null) : Prj2Loader.LoadFromPrj2(source, null);
+                    PrjLoader.LoadFromPrj(source, string.Empty, true, false, null,cancelToken) : Prj2Loader.LoadFromPrj2(source, null,cancelToken,new Prj2Loader.Settings());
 
                 if (level == null)
                 {

--- a/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
@@ -15,7 +15,7 @@ namespace TombLib.LevelData.IO
 	{
         public static readonly string ReferenceWadPath = Path.Combine(DefaultPaths.ProgramDirectory, "Assets", "Wads", "TombEngine.wad2");
 
-        public static string Start(string fileName, IWin32Window owner, IProgressReporter progressReporter,CancellationToken cancelToken)
+        public static string Start(string fileName, IWin32Window owner, IProgressReporter progressReporter, CancellationToken cancelToken)
         {
             if (!File.Exists(fileName))
             {

--- a/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
@@ -326,6 +326,7 @@ namespace TombLib.LevelData.IO
 
                 foreach (ReferencedWad wadRef in level.Settings.Wads)
                 {
+					cancelToken.ThrowIfCancellationRequested();
                     Wad2 wad = wadRef.Wad;
                     Wad2 newWad = new Wad2 { GameVersion = TRVersion.Game.TombEngine };
 
@@ -429,6 +430,7 @@ namespace TombLib.LevelData.IO
                     // Copy all sprite sequences
                     foreach (KeyValuePair<WadSpriteSequenceId, WadSpriteSequence> sequence in wad.SpriteSequences)
                     {
+						cancelToken.ThrowIfCancellationRequested();
                         uint newSlot;
                         string oldId = TrCatalog.GetMoveableName(TRVersion.Game.TR4, sequence.Key.TypeId);
                         string newId = TrCatalog.GetMoveableTombEngineSlot(TRVersion.Game.TR4, sequence.Key.TypeId);
@@ -502,6 +504,7 @@ namespace TombLib.LevelData.IO
 
                 foreach (Room room in level.Rooms)
                 {
+					cancelToken.ThrowIfCancellationRequested();
                     if (room != null)
                     {
                         foreach (var instance in room.Objects)

--- a/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2TombEngineConverter.cs
@@ -26,7 +26,7 @@ namespace TombLib.LevelData.IO
             progressReporter.ReportInfo("TombEngine Project Converter");
             progressReporter.ReportInfo(" ");
 
-            string newProject = ConvertProject(fileName, progressReporter,cancelToken);
+            string newProject = ConvertProject(fileName, progressReporter, cancelToken);
 
             if (string.IsNullOrEmpty(newProject))
             {
@@ -297,7 +297,7 @@ namespace TombLib.LevelData.IO
 
                 // Load level and all related resources
                 Level level = Path.GetExtension(source).ToLower() == ".prj" ?
-                    PrjLoader.LoadFromPrj(source, string.Empty, true, false, null,cancelToken) : Prj2Loader.LoadFromPrj2(source, null,cancelToken,new Prj2Loader.Settings());
+                    PrjLoader.LoadFromPrj(source, string.Empty, true, false, null, cancelToken) : Prj2Loader.LoadFromPrj2(source, null, cancelToken, new Prj2Loader.Settings());
 
                 if (level == null)
                 {

--- a/TombLib/TombLib/LevelData/IO/PrjLoader.cs
+++ b/TombLib/TombLib/LevelData/IO/PrjLoader.cs
@@ -154,8 +154,8 @@ namespace TombLib.LevelData.IO
                 {
                     cancelToken.ThrowIfCancellationRequested();
 
-					// Room is defined?
-					short defined = reader.ReadInt16();
+                    // Room is defined?
+                    short defined = reader.ReadInt16();
                     if (defined == 0x01)
                         continue;
 
@@ -203,9 +203,9 @@ namespace TombLib.LevelData.IO
                     }
                     for (int j = 0; j < numPortals; j++)
                     {
-						cancelToken.ThrowIfCancellationRequested();
+                        cancelToken.ThrowIfCancellationRequested();
 
-						ushort direction = reader.ReadUInt16();
+                        ushort direction = reader.ReadUInt16();
                         short portalZ = reader.ReadInt16();
                         short portalX = reader.ReadInt16();
                         short portalZBlocks = reader.ReadInt16();
@@ -278,7 +278,7 @@ namespace TombLib.LevelData.IO
                     {
                         cancelToken.ThrowIfCancellationRequested();
 
-						short objectType = reader.ReadInt16();
+                        short objectType = reader.ReadInt16();
                         short objPosZ = reader.ReadInt16();
                         short objPosX = reader.ReadInt16();
                         short objSizeZ = reader.ReadInt16();
@@ -494,16 +494,16 @@ namespace TombLib.LevelData.IO
 
                     for (int j = 0; j < numObjects2; j++)
                     {
-						cancelToken.ThrowIfCancellationRequested();
+                        cancelToken.ThrowIfCancellationRequested();
 
-						objectsThings2[j] = reader.ReadInt16();
+                        objectsThings2[j] = reader.ReadInt16();
                     }
 
                     for (int j = 0; j < numObjects2; j++)
                     {
-						cancelToken.ThrowIfCancellationRequested();
+                        cancelToken.ThrowIfCancellationRequested();
 
-						short objectType = reader.ReadInt16();
+                        short objectType = reader.ReadInt16();
                         short objPosZ = reader.ReadInt16();
                         short objPosX = reader.ReadInt16();
                         short objSizeZ = reader.ReadInt16();
@@ -705,9 +705,9 @@ namespace TombLib.LevelData.IO
                     for (int x = 0; x < room.NumXSectors; x++)
                         for (int z = 0; z < room.NumZSectors; z++)
                         {
-							cancelToken.ThrowIfCancellationRequested();
+                            cancelToken.ThrowIfCancellationRequested();
 
-							short blockType = reader.ReadInt16();
+                            short blockType = reader.ReadInt16();
                             short blockFlags1 = reader.ReadInt16();
                             short blockYfloor = reader.ReadInt16();
                             short blockYceiling = reader.ReadInt16();
@@ -1087,9 +1087,9 @@ namespace TombLib.LevelData.IO
                     progressReporter?.ReportProgress(32, "Setup portals");
                     foreach (var tempRoom in tempRooms)
                     {
-						cancelToken.ThrowIfCancellationRequested();
+                        cancelToken.ThrowIfCancellationRequested();
 
-						Room room = level.Rooms[tempRoom.Key];
+                        Room room = level.Rooms[tempRoom.Key];
                         foreach (PortalInstance portal in room.Portals)
                         {
                             // Figure out opacity of the portal
@@ -1177,9 +1177,9 @@ namespace TombLib.LevelData.IO
                     // Promote NoCollision
                     foreach (var tempRoom in tempRooms)
                     {
-						cancelToken.ThrowIfCancellationRequested();
+                        cancelToken.ThrowIfCancellationRequested();
 
-						Room room = level.Rooms[tempRoom.Key];
+                        Room room = level.Rooms[tempRoom.Key];
                         for (int z = 0; z < room.NumZSectors; ++z)
                             for (int x = 0; x < room.NumXSectors; ++x)
                             {
@@ -1201,9 +1201,9 @@ namespace TombLib.LevelData.IO
                     // (This also improves cases from earlier with alternate rooms.)
                     foreach (var tempRoom in tempRooms)
                     {
-						cancelToken.ThrowIfCancellationRequested();
+                        cancelToken.ThrowIfCancellationRequested();
 
-						Room room = level.Rooms[tempRoom.Key];
+                        Room room = level.Rooms[tempRoom.Key];
                         foreach (PortalInstance portal in room.Portals)
                         {
                             if (portal.Direction == PortalDirection.Ceiling)
@@ -1340,9 +1340,9 @@ namespace TombLib.LevelData.IO
                         if (sfx.Sounds != null)
                             foreach (var soundInfo in sfx.Sounds.SoundInfos)
                             {
-								cancelToken.ThrowIfCancellationRequested();
+                                cancelToken.ThrowIfCancellationRequested();
 
-								if (sounds != null)
+                                if (sounds != null)
                                 {
                                     var catalogInfo = sounds.TryGetSoundInfo(soundInfo.Id);
                                     if (catalogInfo != null)
@@ -1402,9 +1402,9 @@ namespace TombLib.LevelData.IO
                 // After loading slots, I compare them to legacy names and I add moveables and statics
                 for (var i = 0; i < numRooms; i++)
                 {
-					cancelToken.ThrowIfCancellationRequested();
+                    cancelToken.ThrowIfCancellationRequested();
 
-					if (level.Rooms[i] == null)
+                    if (level.Rooms[i] == null)
                         continue;
 
                     for (var j = 0; j < tempObjects[i].Count; j++)
@@ -1470,9 +1470,9 @@ namespace TombLib.LevelData.IO
                     foreach (var room in level.ExistingRooms)
                         foreach (var instance in room.Triggers.ToList())
                         {
-							cancelToken.ThrowIfCancellationRequested();
+                            cancelToken.ThrowIfCancellationRequested();
 
-							instance.Target = NG.NgParameterInfo.FixTriggerParameter(level, instance, instance.Target,
+                            instance.Target = NG.NgParameterInfo.FixTriggerParameter(level, instance, instance.Target,
                                 NG.NgParameterInfo.GetTargetRange(level.Settings, instance.TriggerType, instance.TargetType, instance.Timer), objectLookup, progressReporter);
                             instance.Timer  = NG.NgParameterInfo.FixTriggerParameter(level, instance, instance.Timer,
                                 NG.NgParameterInfo.GetTimerRange(level.Settings, instance.TriggerType, instance.TargetType, instance.Target), objectLookup, progressReporter);
@@ -1504,9 +1504,9 @@ namespace TombLib.LevelData.IO
 
                 for (int i = 0; i < 40; i++)
                 {
-					cancelToken.ThrowIfCancellationRequested();
+                    cancelToken.ThrowIfCancellationRequested();
 
-					int defined = reader.ReadInt32();
+                    int defined = reader.ReadInt32();
                     int firstTexture = reader.ReadInt32();
                     int lastTexture = reader.ReadInt32();
 
@@ -1539,9 +1539,9 @@ namespace TombLib.LevelData.IO
                     int skippedBytes = 0;
                     for (int i = 0; i < 256;)
                     {
-						cancelToken.ThrowIfCancellationRequested();
+                        cancelToken.ThrowIfCancellationRequested();
 
-						var FootStepSound = (TextureFootStep.Type)(reader.ReadByte() & 0xf);
+                        var FootStepSound = (TextureFootStep.Type)(reader.ReadByte() & 0xf);
                         texture.SetFootStepSound(i % 4, i / 4, FootStepSound);
                         texture.SetFootStepSound((i + 1) % 4, i / 4, FootStepSound);
                         texture.SetFootStepSound(i % 4, ((i) / 4) + 1, FootStepSound);
@@ -1567,9 +1567,9 @@ namespace TombLib.LevelData.IO
                 {
                     for (int i = 0; i < 256; i++)
                     {
-						cancelToken.ThrowIfCancellationRequested();
+                        cancelToken.ThrowIfCancellationRequested();
 
-						var FootStepSound = (TextureFootStep.Type)(reader.ReadByte() & 0xf);
+                        var FootStepSound = (TextureFootStep.Type)(reader.ReadByte() & 0xf);
                         texture.SetFootStepSound(i % 4, i / 4, FootStepSound);
                     }
                 }
@@ -1603,9 +1603,9 @@ namespace TombLib.LevelData.IO
                             // Parse NG chunks
                             while (reader.BaseStream.Position < reader.BaseStream.Length)
                             {
-								cancelToken.ThrowIfCancellationRequested();
+                                cancelToken.ThrowIfCancellationRequested();
 
-								var size = reader.ReadUInt16();
+                                var size = reader.ReadUInt16();
                                 var chunkId = reader.ReadUInt16();
 
                                 if (size == 0x474E && chunkId == 0x454C)
@@ -1684,9 +1684,9 @@ namespace TombLib.LevelData.IO
                     for (int z = 0; z < room.NumZSectors; z++)
                         for (int x = 0; x < room.NumXSectors; x++)
                         {
-							cancelToken.ThrowIfCancellationRequested();
+                            cancelToken.ThrowIfCancellationRequested();
 
-							var prjBlock = tempRooms[i]._blocks[x, z];
+                            var prjBlock = tempRooms[i]._blocks[x, z];
 
                             // 0: BLOCK_TEX_FLOOR
                             LoadTextureArea(room, x, z, BlockFace.Floor, texture, tempTextures, prjBlock._faces[0], progressReporter);

--- a/TombLib/TombLib/LevelData/IO/PrjLoader.cs
+++ b/TombLib/TombLib/LevelData/IO/PrjLoader.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using TombLib.IO;
 using TombLib.Utils;
@@ -94,7 +95,7 @@ namespace TombLib.LevelData.IO
 
         public static Level LoadFromPrj(string filename, string soundsPath, 
                                         bool remapFlybyBitmask, bool adjustUV,
-                                        IProgressReporter progressReporter)
+                                        IProgressReporter progressReporter,CancellationToken cancelToken)
         {
             var level = new Level();
 

--- a/TombLib/TombLib/LevelData/IO/PrjLoader.cs
+++ b/TombLib/TombLib/LevelData/IO/PrjLoader.cs
@@ -95,7 +95,7 @@ namespace TombLib.LevelData.IO
 
         public static Level LoadFromPrj(string filename, string soundsPath, 
                                         bool remapFlybyBitmask, bool adjustUV,
-                                        IProgressReporter progressReporter,CancellationToken cancelToken)
+                                        IProgressReporter progressReporter, CancellationToken cancelToken)
         {
             var level = new Level();
 

--- a/TombLib/TombLib/LevelData/IO/PrjLoader.cs
+++ b/TombLib/TombLib/LevelData/IO/PrjLoader.cs
@@ -152,8 +152,10 @@ namespace TombLib.LevelData.IO
 
                 for (int i = 0; i < numRooms; i++)
                 {
-                    // Room is defined?
-                    short defined = reader.ReadInt16();
+                    cancelToken.ThrowIfCancellationRequested();
+
+					// Room is defined?
+					short defined = reader.ReadInt16();
                     if (defined == 0x01)
                         continue;
 
@@ -201,7 +203,9 @@ namespace TombLib.LevelData.IO
                     }
                     for (int j = 0; j < numPortals; j++)
                     {
-                        ushort direction = reader.ReadUInt16();
+						cancelToken.ThrowIfCancellationRequested();
+
+						ushort direction = reader.ReadUInt16();
                         short portalZ = reader.ReadInt16();
                         short portalX = reader.ReadInt16();
                         short portalZBlocks = reader.ReadInt16();
@@ -272,7 +276,9 @@ namespace TombLib.LevelData.IO
 
                     for (int j = 0; j < numObjects; j++)
                     {
-                        short objectType = reader.ReadInt16();
+                        cancelToken.ThrowIfCancellationRequested();
+
+						short objectType = reader.ReadInt16();
                         short objPosZ = reader.ReadInt16();
                         short objPosX = reader.ReadInt16();
                         short objSizeZ = reader.ReadInt16();
@@ -488,12 +494,16 @@ namespace TombLib.LevelData.IO
 
                     for (int j = 0; j < numObjects2; j++)
                     {
-                        objectsThings2[j] = reader.ReadInt16();
+						cancelToken.ThrowIfCancellationRequested();
+
+						objectsThings2[j] = reader.ReadInt16();
                     }
 
                     for (int j = 0; j < numObjects2; j++)
                     {
-                        short objectType = reader.ReadInt16();
+						cancelToken.ThrowIfCancellationRequested();
+
+						short objectType = reader.ReadInt16();
                         short objPosZ = reader.ReadInt16();
                         short objPosX = reader.ReadInt16();
                         short objSizeZ = reader.ReadInt16();
@@ -695,7 +705,9 @@ namespace TombLib.LevelData.IO
                     for (int x = 0; x < room.NumXSectors; x++)
                         for (int z = 0; z < room.NumZSectors; z++)
                         {
-                            short blockType = reader.ReadInt16();
+							cancelToken.ThrowIfCancellationRequested();
+
+							short blockType = reader.ReadInt16();
                             short blockFlags1 = reader.ReadInt16();
                             short blockYfloor = reader.ReadInt16();
                             short blockYceiling = reader.ReadInt16();
@@ -1075,7 +1087,9 @@ namespace TombLib.LevelData.IO
                     progressReporter?.ReportProgress(32, "Setup portals");
                     foreach (var tempRoom in tempRooms)
                     {
-                        Room room = level.Rooms[tempRoom.Key];
+						cancelToken.ThrowIfCancellationRequested();
+
+						Room room = level.Rooms[tempRoom.Key];
                         foreach (PortalInstance portal in room.Portals)
                         {
                             // Figure out opacity of the portal
@@ -1163,7 +1177,9 @@ namespace TombLib.LevelData.IO
                     // Promote NoCollision
                     foreach (var tempRoom in tempRooms)
                     {
-                        Room room = level.Rooms[tempRoom.Key];
+						cancelToken.ThrowIfCancellationRequested();
+
+						Room room = level.Rooms[tempRoom.Key];
                         for (int z = 0; z < room.NumZSectors; ++z)
                             for (int x = 0; x < room.NumXSectors; ++x)
                             {
@@ -1185,7 +1201,9 @@ namespace TombLib.LevelData.IO
                     // (This also improves cases from earlier with alternate rooms.)
                     foreach (var tempRoom in tempRooms)
                     {
-                        Room room = level.Rooms[tempRoom.Key];
+						cancelToken.ThrowIfCancellationRequested();
+
+						Room room = level.Rooms[tempRoom.Key];
                         foreach (PortalInstance portal in room.Portals)
                         {
                             if (portal.Direction == PortalDirection.Ceiling)
@@ -1322,7 +1340,9 @@ namespace TombLib.LevelData.IO
                         if (sfx.Sounds != null)
                             foreach (var soundInfo in sfx.Sounds.SoundInfos)
                             {
-                                if (sounds != null)
+								cancelToken.ThrowIfCancellationRequested();
+
+								if (sounds != null)
                                 {
                                     var catalogInfo = sounds.TryGetSoundInfo(soundInfo.Id);
                                     if (catalogInfo != null)
@@ -1382,7 +1402,9 @@ namespace TombLib.LevelData.IO
                 // After loading slots, I compare them to legacy names and I add moveables and statics
                 for (var i = 0; i < numRooms; i++)
                 {
-                    if (level.Rooms[i] == null)
+					cancelToken.ThrowIfCancellationRequested();
+
+					if (level.Rooms[i] == null)
                         continue;
 
                     for (var j = 0; j < tempObjects[i].Count; j++)
@@ -1448,7 +1470,9 @@ namespace TombLib.LevelData.IO
                     foreach (var room in level.ExistingRooms)
                         foreach (var instance in room.Triggers.ToList())
                         {
-                            instance.Target = NG.NgParameterInfo.FixTriggerParameter(level, instance, instance.Target,
+							cancelToken.ThrowIfCancellationRequested();
+
+							instance.Target = NG.NgParameterInfo.FixTriggerParameter(level, instance, instance.Target,
                                 NG.NgParameterInfo.GetTargetRange(level.Settings, instance.TriggerType, instance.TargetType, instance.Timer), objectLookup, progressReporter);
                             instance.Timer  = NG.NgParameterInfo.FixTriggerParameter(level, instance, instance.Timer,
                                 NG.NgParameterInfo.GetTimerRange(level.Settings, instance.TriggerType, instance.TargetType, instance.Target), objectLookup, progressReporter);
@@ -1480,7 +1504,9 @@ namespace TombLib.LevelData.IO
 
                 for (int i = 0; i < 40; i++)
                 {
-                    int defined = reader.ReadInt32();
+					cancelToken.ThrowIfCancellationRequested();
+
+					int defined = reader.ReadInt32();
                     int firstTexture = reader.ReadInt32();
                     int lastTexture = reader.ReadInt32();
 
@@ -1513,7 +1539,9 @@ namespace TombLib.LevelData.IO
                     int skippedBytes = 0;
                     for (int i = 0; i < 256;)
                     {
-                        var FootStepSound = (TextureFootStep.Type)(reader.ReadByte() & 0xf);
+						cancelToken.ThrowIfCancellationRequested();
+
+						var FootStepSound = (TextureFootStep.Type)(reader.ReadByte() & 0xf);
                         texture.SetFootStepSound(i % 4, i / 4, FootStepSound);
                         texture.SetFootStepSound((i + 1) % 4, i / 4, FootStepSound);
                         texture.SetFootStepSound(i % 4, ((i) / 4) + 1, FootStepSound);
@@ -1539,7 +1567,9 @@ namespace TombLib.LevelData.IO
                 {
                     for (int i = 0; i < 256; i++)
                     {
-                        var FootStepSound = (TextureFootStep.Type)(reader.ReadByte() & 0xf);
+						cancelToken.ThrowIfCancellationRequested();
+
+						var FootStepSound = (TextureFootStep.Type)(reader.ReadByte() & 0xf);
                         texture.SetFootStepSound(i % 4, i / 4, FootStepSound);
                     }
                 }
@@ -1573,7 +1603,9 @@ namespace TombLib.LevelData.IO
                             // Parse NG chunks
                             while (reader.BaseStream.Position < reader.BaseStream.Length)
                             {
-                                var size = reader.ReadUInt16();
+								cancelToken.ThrowIfCancellationRequested();
+
+								var size = reader.ReadUInt16();
                                 var chunkId = reader.ReadUInt16();
 
                                 if (size == 0x474E && chunkId == 0x454C)
@@ -1652,7 +1684,9 @@ namespace TombLib.LevelData.IO
                     for (int z = 0; z < room.NumZSectors; z++)
                         for (int x = 0; x < room.NumXSectors; x++)
                         {
-                            var prjBlock = tempRooms[i]._blocks[x, z];
+							cancelToken.ThrowIfCancellationRequested();
+
+							var prjBlock = tempRooms[i]._blocks[x, z];
 
                             // 0: BLOCK_TEX_FLOOR
                             LoadTextureArea(room, x, z, BlockFace.Floor, texture, tempTextures, prjBlock._faces[0], progressReporter);
@@ -1937,7 +1971,11 @@ namespace TombLib.LevelData.IO
 
             // Update level geometry
             progressReporter?.ReportProgress(95, "Building rooms");
-            Parallel.ForEach(level.ExistingRooms, room => room.BuildGeometry());
+            ParallelOptions options = new ParallelOptions
+            {
+                CancellationToken = cancelToken
+            };
+            Parallel.ForEach(level.ExistingRooms, options, room => room.BuildGeometry());
             progressReporter?.ReportProgress(100, "Level loaded correctly!");
 
             return level;

--- a/WadTool/WadActions.cs
+++ b/WadTool/WadActions.cs
@@ -209,7 +209,7 @@ namespace WadTool
             if (string.IsNullOrEmpty(path))
                 return false;
 
-            tool.ReferenceLevel = Prj2Loader.LoadFromPrj2(path, null, new Prj2Loader.Settings { IgnoreTextures = true, IgnoreWads = true });
+            tool.ReferenceLevel = Prj2Loader.LoadFromPrj2(path, null, CancellationToken.None, new Prj2Loader.Settings { IgnoreTextures = true, IgnoreWads = true });
 
             if (tool.ReferenceLevel != null)
             {


### PR DESCRIPTION
This allows cooperative cancellation, the tasks themselves can react to cancellation. Previously Level compilation was always completed when hitting cancel. Now the token can be checked if cancellation is requested and return/abort cooperatively via `ThrowIfCancellationRequested`. See [here](https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken?view=net-7.0)

This is extremely helpful with long running tasks such as Level compilation or PRJ conversion