### PR TITLE
Management "reasons" of the end of the level. Separate management of global events

### DIFF
--- a/TombEditor/Command.cs
+++ b/TombEditor/Command.cs
@@ -906,7 +906,6 @@ namespace TombEditor
 
             AddCommand("EditVolumes", "Edit volumes...", CommandType.Edit, delegate (CommandArgs args)
             {
-
                 var existingWindow = Application.OpenForms[nameof(FormVolume)];
                 if (existingWindow == null)
                 {

--- a/TombEditor/Command.cs
+++ b/TombEditor/Command.cs
@@ -892,12 +892,25 @@ namespace TombEditor
                     existingWindow.Focus();
             });
 
-            AddCommand("EditEventSets", "Edit event sets...", CommandType.Edit, delegate (CommandArgs args)
+            AddCommand("EditEventSets", "Edit global events...", CommandType.Edit, delegate (CommandArgs args)
             {
                 var existingWindow = Application.OpenForms[nameof(FormVolume)];
                 if (existingWindow == null)
                 {
                     var propForm = new FormVolume(null);
+                    propForm.Show(args.Window);
+                }
+                else
+                    existingWindow.Focus();
+            });
+
+            AddCommand("EditVolumes", "Edit volumes...", CommandType.Edit, delegate (CommandArgs args)
+            {
+
+                var existingWindow = Application.OpenForms[nameof(FormVolume)];
+                if (existingWindow == null)
+                {
+                    var propForm = new FormVolume(null, true);
                     propForm.Show(args.Window);
                 }
                 else

--- a/TombEditor/Forms/FormMain.Designer.cs
+++ b/TombEditor/Forms/FormMain.Designer.cs
@@ -17,2485 +17,2301 @@ namespace TombEditor.Forms
         /// </summary>
         private void InitializeComponent()
         {
-            this.menuStrip = new DarkUI.Controls.DarkMenuStrip();
-            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.newLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openRecentToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.importTRLEPRJToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.convertToTENToolstripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.buildLevelPlayToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.buildLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.undoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.redoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.stampToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-            this.bookmarkObjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.bookmarkRestoreObjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.editObjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.editEventSetsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.searchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.searchAndReplaceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.viewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetCameraToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.relocateCameraToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toggleFlyModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-            this.drawWhiteTextureLightingOnlyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ShowRealTintForObjectsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.roomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.newRoomToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.newRoomUpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.newRoomDownToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.newRoomLeftToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.newRoomRightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.newRoomFrontToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.newRoomBackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.duplicateRoomToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.cropRoomToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.splitRoomToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.mergeRoomsHorizontallyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-            this.moveRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.wholeRoomUpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.moveRoomUp4ClicksToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.wholeRoomDownToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.moveRoomDown4ClicksToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.moveRoomLeftToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.moveRoomRightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.moveRoomForwardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.moveRoomBackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.transformRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.rotateRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.rotateRoomsCountercockwiseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.mirrorRoomsOnXAxisToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.mirrorRoomsOnZAxisToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectWaterRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectSkyRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectOutsideRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-            this.selectConnectedRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectRoomsByTagsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-            this.exportRoomToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.importRoomsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem9 = new System.Windows.Forms.ToolStripMenuItem();
-            this.itemsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addWadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.removeWadsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.reloadWadsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.reloadSoundsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItem8 = new System.Windows.Forms.ToolStripMenuItem();
-            this.addCameraToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addFlybyCameraToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addSpriteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addSinkToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addSoundSourceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addImportedGeometryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addGhostBlockToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addMemoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addPortalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addTriggerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addBoxVolumeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.addSphereVolumeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-            this.deleteAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteAllLightsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteAllTriggersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteMissingObjectsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-            this.findObjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.moveLaraToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectItemsInSelectedAreaToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectFloorBelowObjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.splitSectorObjectOnSelectionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.setStaticMeshColorToRoomLightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem10 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
-            this.makeQuickItemGroupToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.getObjectStatisticsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.generateObjectNamesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.texturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.loadTextureToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.removeTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.unloadTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.reloadTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.importConvertTexturesToPng = new System.Windows.Forms.ToolStripMenuItem();
-            this.remapTextureToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator9 = new System.Windows.Forms.ToolStripSeparator();
-            this.textureFloorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.textureWallsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.textureCeilingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
-            this.clearAllTexturesInRoomToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.clearAllTexturesInRoomToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator10 = new System.Windows.Forms.ToolStripSeparator();
-            this.findTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.animationRangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.transformToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.smoothRandomFloorUpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.smoothRandomFloorDownToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.smoothRandomCeilingUpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.smoothRandomCeilingDownToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator11 = new System.Windows.Forms.ToolStripSeparator();
-            this.sharpRandomFloorUpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.sharpRandomFloorDownToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.sharpRandomCeilingUpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.sharpRandomCeilingDownToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator12 = new System.Windows.Forms.ToolStripSeparator();
-            this.averageFloorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.averageCeilingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.flattenFloorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.flattenCeilingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetGeometryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator13 = new System.Windows.Forms.ToolStripSeparator();
-            this.gridWallsIn3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.gridWallsIn5ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.gridWallsIn3SquaresToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.gridWallsIn5SquaresToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem5 = new System.Windows.Forms.ToolStripMenuItem();
-            this.editOptionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.keyboardLayoutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItem7 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem6 = new System.Windows.Forms.ToolStripMenuItem();
-            this.butFindMenu = new System.Windows.Forms.ToolStripMenuItem();
-            this.windowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.restoreDefaultLayoutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuSeparator14 = new System.Windows.Forms.ToolStripSeparator();
-            this.sectorOptionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.roomOptionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.itemBrowserToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.importedGeometryBrowserToolstripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.triggerListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.lightingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.paletteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.texturePanelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.objectListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.statisticsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.dockableToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.floatingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tbSearchMenu = new System.Windows.Forms.ToolStripTextBox();
-            this.debugToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.debugAction0ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.debugAction1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.debugAction2ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.debugAction3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.debugAction4ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.debugAction5ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.debugScriptToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.butRoomDown = new DarkUI.Controls.DarkButton();
-            this.butEditRoomName = new DarkUI.Controls.DarkButton();
-            this.butDeleteRoom = new DarkUI.Controls.DarkButton();
-            this.statusStrip = new DarkUI.Controls.DarkStatusStrip();
-            this.statusStripSelectedRoom = new System.Windows.Forms.ToolStripStatusLabel();
-            this.statusStripGlobalSelectionArea = new System.Windows.Forms.ToolStripStatusLabel();
-            this.statusStripLocalSelectionArea = new System.Windows.Forms.ToolStripStatusLabel();
-            this.statusAutosave = new System.Windows.Forms.ToolStripStatusLabel();
-            this.dockArea = new DarkUI.Docking.DarkDockPanel();
-            this.panelDockArea = new System.Windows.Forms.Panel();
-            this.assToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuStrip.SuspendLayout();
-            this.statusStrip.SuspendLayout();
-            this.panelDockArea.SuspendLayout();
-            this.SuspendLayout();
+            menuStrip = new DarkUI.Controls.DarkMenuStrip();
+            fileToolStripMenuItem = new ToolStripMenuItem();
+            newLevelToolStripMenuItem = new ToolStripMenuItem();
+            openLevelToolStripMenuItem = new ToolStripMenuItem();
+            openRecentToolStripMenuItem = new ToolStripMenuItem();
+            saveLevelToolStripMenuItem = new ToolStripMenuItem();
+            saveAsToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuSeparator1 = new ToolStripSeparator();
+            importTRLEPRJToolStripMenuItem = new ToolStripMenuItem();
+            convertToTENToolstripMenuItem = new ToolStripMenuItem();
+            toolStripMenuSeparator2 = new ToolStripSeparator();
+            buildLevelPlayToolStripMenuItem = new ToolStripMenuItem();
+            buildLevelToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuSeparator3 = new ToolStripSeparator();
+            exitToolStripMenuItem = new ToolStripMenuItem();
+            editToolStripMenuItem = new ToolStripMenuItem();
+            undoToolStripMenuItem = new ToolStripMenuItem();
+            redoToolStripMenuItem = new ToolStripMenuItem();
+            toolStripSeparator2 = new ToolStripSeparator();
+            cutToolStripMenuItem = new ToolStripMenuItem();
+            copyToolStripMenuItem = new ToolStripMenuItem();
+            pasteToolStripMenuItem = new ToolStripMenuItem();
+            stampToolStripMenuItem = new ToolStripMenuItem();
+            deleteToolStripMenuItem = new ToolStripMenuItem();
+            selectAllToolStripMenuItem = new ToolStripMenuItem();
+            toolStripSeparator4 = new ToolStripSeparator();
+            bookmarkObjectToolStripMenuItem = new ToolStripMenuItem();
+            bookmarkRestoreObjectToolStripMenuItem = new ToolStripMenuItem();
+            toolStripSeparator1 = new ToolStripSeparator();
+            editObjectToolStripMenuItem = new ToolStripMenuItem();
+            editEventSetsToolStripMenuItem = new ToolStripMenuItem();
+            searchToolStripMenuItem = new ToolStripMenuItem();
+            searchAndReplaceToolStripMenuItem = new ToolStripMenuItem();
+            viewToolStripMenuItem = new ToolStripMenuItem();
+            resetCameraToolStripMenuItem = new ToolStripMenuItem();
+            relocateCameraToolStripMenuItem = new ToolStripMenuItem();
+            toggleFlyModeToolStripMenuItem = new ToolStripMenuItem();
+            toolStripSeparator8 = new ToolStripSeparator();
+            drawWhiteTextureLightingOnlyToolStripMenuItem = new ToolStripMenuItem();
+            ShowRealTintForObjectsToolStripMenuItem = new ToolStripMenuItem();
+            roomsToolStripMenuItem = new ToolStripMenuItem();
+            newRoomToolStripMenuItem = new ToolStripMenuItem();
+            newRoomUpToolStripMenuItem = new ToolStripMenuItem();
+            newRoomDownToolStripMenuItem = new ToolStripMenuItem();
+            newRoomLeftToolStripMenuItem = new ToolStripMenuItem();
+            newRoomRightToolStripMenuItem = new ToolStripMenuItem();
+            newRoomFrontToolStripMenuItem = new ToolStripMenuItem();
+            newRoomBackToolStripMenuItem = new ToolStripMenuItem();
+            duplicateRoomToolStripMenuItem = new ToolStripMenuItem();
+            cropRoomToolStripMenuItem = new ToolStripMenuItem();
+            splitRoomToolStripMenuItem = new ToolStripMenuItem();
+            mergeRoomsHorizontallyToolStripMenuItem = new ToolStripMenuItem();
+            deleteRoomsToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuSeparator5 = new ToolStripSeparator();
+            moveRoomsToolStripMenuItem = new ToolStripMenuItem();
+            wholeRoomUpToolStripMenuItem = new ToolStripMenuItem();
+            moveRoomUp4ClicksToolStripMenuItem = new ToolStripMenuItem();
+            wholeRoomDownToolStripMenuItem = new ToolStripMenuItem();
+            moveRoomDown4ClicksToolStripMenuItem = new ToolStripMenuItem();
+            moveRoomLeftToolStripMenuItem = new ToolStripMenuItem();
+            moveRoomRightToolStripMenuItem = new ToolStripMenuItem();
+            moveRoomForwardToolStripMenuItem = new ToolStripMenuItem();
+            moveRoomBackToolStripMenuItem = new ToolStripMenuItem();
+            transformRoomsToolStripMenuItem = new ToolStripMenuItem();
+            rotateRoomsToolStripMenuItem = new ToolStripMenuItem();
+            rotateRoomsCountercockwiseToolStripMenuItem = new ToolStripMenuItem();
+            mirrorRoomsOnXAxisToolStripMenuItem = new ToolStripMenuItem();
+            mirrorRoomsOnZAxisToolStripMenuItem = new ToolStripMenuItem();
+            selectRoomsToolStripMenuItem = new ToolStripMenuItem();
+            selectWaterRoomsToolStripMenuItem = new ToolStripMenuItem();
+            selectSkyRoomsToolStripMenuItem = new ToolStripMenuItem();
+            selectOutsideRoomsToolStripMenuItem = new ToolStripMenuItem();
+            selectToolStripMenuItem = new ToolStripMenuItem();
+            toolStripSeparator6 = new ToolStripSeparator();
+            selectConnectedRoomsToolStripMenuItem = new ToolStripMenuItem();
+            selectRoomsByTagsToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuItem1 = new ToolStripSeparator();
+            exportRoomToolStripMenuItem = new ToolStripMenuItem();
+            importRoomsToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuItem9 = new ToolStripMenuItem();
+            itemsToolStripMenuItem = new ToolStripMenuItem();
+            addWadToolStripMenuItem = new ToolStripMenuItem();
+            removeWadsToolStripMenuItem = new ToolStripMenuItem();
+            reloadWadsToolStripMenuItem = new ToolStripMenuItem();
+            reloadSoundsToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuSeparator6 = new ToolStripSeparator();
+            toolStripMenuItem8 = new ToolStripMenuItem();
+            addCameraToolStripMenuItem = new ToolStripMenuItem();
+            addFlybyCameraToolStripMenuItem = new ToolStripMenuItem();
+            addSpriteToolStripMenuItem = new ToolStripMenuItem();
+            addSinkToolStripMenuItem = new ToolStripMenuItem();
+            addSoundSourceToolStripMenuItem = new ToolStripMenuItem();
+            addImportedGeometryToolStripMenuItem = new ToolStripMenuItem();
+            addGhostBlockToolStripMenuItem = new ToolStripMenuItem();
+            addMemoToolStripMenuItem = new ToolStripMenuItem();
+            addPortalToolStripMenuItem = new ToolStripMenuItem();
+            addTriggerToolStripMenuItem = new ToolStripMenuItem();
+            addBoxVolumeToolStripMenuItem = new ToolStripMenuItem();
+            addSphereVolumeToolStripMenuItem = new ToolStripMenuItem();
+            toolStripSeparator7 = new ToolStripSeparator();
+            deleteAllToolStripMenuItem = new ToolStripMenuItem();
+            deleteAllLightsToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuItem2 = new ToolStripMenuItem();
+            deleteAllTriggersToolStripMenuItem = new ToolStripMenuItem();
+            deleteMissingObjectsToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuSeparator8 = new ToolStripSeparator();
+            findObjectToolStripMenuItem = new ToolStripMenuItem();
+            moveLaraToolStripMenuItem = new ToolStripMenuItem();
+            selectItemsInSelectedAreaToolStripMenuItem = new ToolStripMenuItem();
+            selectFloorBelowObjectToolStripMenuItem = new ToolStripMenuItem();
+            splitSectorObjectOnSelectionToolStripMenuItem = new ToolStripMenuItem();
+            toolStripSeparator3 = new ToolStripSeparator();
+            setStaticMeshColorToRoomLightToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuItem10 = new ToolStripMenuItem();
+            toolStripSeparator9 = new ToolStripSeparator();
+            makeQuickItemGroupToolStripMenuItem = new ToolStripMenuItem();
+            getObjectStatisticsToolStripMenuItem = new ToolStripMenuItem();
+            generateObjectNamesToolStripMenuItem = new ToolStripMenuItem();
+            texturesToolStripMenuItem = new ToolStripMenuItem();
+            loadTextureToolStripMenuItem = new ToolStripMenuItem();
+            removeTexturesToolStripMenuItem = new ToolStripMenuItem();
+            unloadTexturesToolStripMenuItem = new ToolStripMenuItem();
+            reloadTexturesToolStripMenuItem = new ToolStripMenuItem();
+            importConvertTexturesToPng = new ToolStripMenuItem();
+            remapTextureToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuSeparator9 = new ToolStripSeparator();
+            textureFloorToolStripMenuItem = new ToolStripMenuItem();
+            textureWallsToolStripMenuItem = new ToolStripMenuItem();
+            textureCeilingToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuItem3 = new ToolStripSeparator();
+            clearAllTexturesInRoomToolStripMenuItem = new ToolStripMenuItem();
+            clearAllTexturesInRoomToolStripMenuItem1 = new ToolStripMenuItem();
+            toolStripMenuSeparator10 = new ToolStripSeparator();
+            findTexturesToolStripMenuItem = new ToolStripMenuItem();
+            animationRangesToolStripMenuItem = new ToolStripMenuItem();
+            transformToolStripMenuItem = new ToolStripMenuItem();
+            smoothRandomFloorUpToolStripMenuItem = new ToolStripMenuItem();
+            smoothRandomFloorDownToolStripMenuItem = new ToolStripMenuItem();
+            smoothRandomCeilingUpToolStripMenuItem = new ToolStripMenuItem();
+            smoothRandomCeilingDownToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuSeparator11 = new ToolStripSeparator();
+            sharpRandomFloorUpToolStripMenuItem = new ToolStripMenuItem();
+            sharpRandomFloorDownToolStripMenuItem = new ToolStripMenuItem();
+            sharpRandomCeilingUpToolStripMenuItem = new ToolStripMenuItem();
+            sharpRandomCeilingDownToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuSeparator12 = new ToolStripSeparator();
+            averageFloorToolStripMenuItem = new ToolStripMenuItem();
+            averageCeilingToolStripMenuItem = new ToolStripMenuItem();
+            flattenFloorToolStripMenuItem = new ToolStripMenuItem();
+            flattenCeilingToolStripMenuItem = new ToolStripMenuItem();
+            resetGeometryToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuSeparator13 = new ToolStripSeparator();
+            gridWallsIn3ToolStripMenuItem = new ToolStripMenuItem();
+            gridWallsIn5ToolStripMenuItem = new ToolStripMenuItem();
+            gridWallsIn3SquaresToolStripMenuItem = new ToolStripMenuItem();
+            gridWallsIn5SquaresToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuItem4 = new ToolStripMenuItem();
+            toolStripMenuItem5 = new ToolStripMenuItem();
+            editOptionsToolStripMenuItem = new ToolStripMenuItem();
+            keyboardLayoutToolStripMenuItem = new ToolStripMenuItem();
+            toolStripSeparator5 = new ToolStripSeparator();
+            toolStripMenuItem7 = new ToolStripMenuItem();
+            toolStripMenuItem6 = new ToolStripMenuItem();
+            butFindMenu = new ToolStripMenuItem();
+            windowToolStripMenuItem = new ToolStripMenuItem();
+            restoreDefaultLayoutToolStripMenuItem = new ToolStripMenuItem();
+            toolStripMenuSeparator14 = new ToolStripSeparator();
+            sectorOptionsToolStripMenuItem = new ToolStripMenuItem();
+            roomOptionsToolStripMenuItem = new ToolStripMenuItem();
+            itemBrowserToolStripMenuItem = new ToolStripMenuItem();
+            importedGeometryBrowserToolstripMenuItem = new ToolStripMenuItem();
+            triggerListToolStripMenuItem = new ToolStripMenuItem();
+            lightingToolStripMenuItem = new ToolStripMenuItem();
+            paletteToolStripMenuItem = new ToolStripMenuItem();
+            texturePanelToolStripMenuItem = new ToolStripMenuItem();
+            objectListToolStripMenuItem = new ToolStripMenuItem();
+            statisticsToolStripMenuItem = new ToolStripMenuItem();
+            dockableToolStripMenuItem = new ToolStripMenuItem();
+            floatingToolStripMenuItem = new ToolStripMenuItem();
+            helpToolStripMenuItem = new ToolStripMenuItem();
+            aboutToolStripMenuItem = new ToolStripMenuItem();
+            tbSearchMenu = new ToolStripTextBox();
+            debugToolStripMenuItem = new ToolStripMenuItem();
+            debugAction0ToolStripMenuItem = new ToolStripMenuItem();
+            debugAction1ToolStripMenuItem = new ToolStripMenuItem();
+            debugAction2ToolStripMenuItem = new ToolStripMenuItem();
+            debugAction3ToolStripMenuItem = new ToolStripMenuItem();
+            debugAction4ToolStripMenuItem = new ToolStripMenuItem();
+            debugAction5ToolStripMenuItem = new ToolStripMenuItem();
+            debugScriptToolStripMenuItem = new ToolStripMenuItem();
+            butRoomDown = new DarkUI.Controls.DarkButton();
+            butEditRoomName = new DarkUI.Controls.DarkButton();
+            butDeleteRoom = new DarkUI.Controls.DarkButton();
+            statusStrip = new DarkUI.Controls.DarkStatusStrip();
+            statusStripSelectedRoom = new ToolStripStatusLabel();
+            statusStripGlobalSelectionArea = new ToolStripStatusLabel();
+            statusStripLocalSelectionArea = new ToolStripStatusLabel();
+            statusAutosave = new ToolStripStatusLabel();
+            dockArea = new DarkUI.Docking.DarkDockPanel();
+            panelDockArea = new Panel();
+            assToolStripMenuItem = new ToolStripMenuItem();
+            editVolumesToolStripMenuItem = new ToolStripMenuItem();
+            menuStrip.SuspendLayout();
+            statusStrip.SuspendLayout();
+            panelDockArea.SuspendLayout();
+            SuspendLayout();
             // 
             // menuStrip
             // 
-            this.menuStrip.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.menuStrip.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.fileToolStripMenuItem,
-            this.editToolStripMenuItem,
-            this.viewToolStripMenuItem,
-            this.roomsToolStripMenuItem,
-            this.itemsToolStripMenuItem,
-            this.texturesToolStripMenuItem,
-            this.transformToolStripMenuItem,
-            this.toolStripMenuItem4,
-            this.butFindMenu,
-            this.windowToolStripMenuItem,
-            this.helpToolStripMenuItem,
-            this.tbSearchMenu,
-            this.debugToolStripMenuItem});
-            this.menuStrip.Location = new System.Drawing.Point(0, 0);
-            this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Padding = new System.Windows.Forms.Padding(3, 2, 0, 2);
-            this.menuStrip.Size = new System.Drawing.Size(913, 29);
-            this.menuStrip.TabIndex = 0;
-            this.menuStrip.Text = "darkMenuStrip1";
+            menuStrip.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            menuStrip.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            menuStrip.Items.AddRange(new ToolStripItem[] { fileToolStripMenuItem, editToolStripMenuItem, viewToolStripMenuItem, roomsToolStripMenuItem, itemsToolStripMenuItem, texturesToolStripMenuItem, transformToolStripMenuItem, toolStripMenuItem4, butFindMenu, windowToolStripMenuItem, helpToolStripMenuItem, tbSearchMenu, debugToolStripMenuItem });
+            menuStrip.Location = new System.Drawing.Point(0, 0);
+            menuStrip.Name = "menuStrip";
+            menuStrip.Padding = new Padding(3, 2, 0, 2);
+            menuStrip.Size = new System.Drawing.Size(913, 29);
+            menuStrip.TabIndex = 0;
+            menuStrip.Text = "darkMenuStrip1";
             // 
             // fileToolStripMenuItem
             // 
-            this.fileToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.newLevelToolStripMenuItem,
-            this.openLevelToolStripMenuItem,
-            this.openRecentToolStripMenuItem,
-            this.saveLevelToolStripMenuItem,
-            this.saveAsToolStripMenuItem,
-            this.toolStripMenuSeparator1,
-            this.importTRLEPRJToolStripMenuItem,
-            this.convertToTENToolstripMenuItem,
-            this.toolStripMenuSeparator2,
-            this.buildLevelPlayToolStripMenuItem,
-            this.buildLevelToolStripMenuItem,
-            this.toolStripMenuSeparator3,
-            this.exitToolStripMenuItem});
-            this.fileToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 25);
-            this.fileToolStripMenuItem.Text = "File";
+            fileToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            fileToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { newLevelToolStripMenuItem, openLevelToolStripMenuItem, openRecentToolStripMenuItem, saveLevelToolStripMenuItem, saveAsToolStripMenuItem, toolStripMenuSeparator1, importTRLEPRJToolStripMenuItem, convertToTENToolstripMenuItem, toolStripMenuSeparator2, buildLevelPlayToolStripMenuItem, buildLevelToolStripMenuItem, toolStripMenuSeparator3, exitToolStripMenuItem });
+            fileToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            fileToolStripMenuItem.Size = new System.Drawing.Size(41, 25);
+            fileToolStripMenuItem.Text = "File";
             // 
             // newLevelToolStripMenuItem
             // 
-            this.newLevelToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.newLevelToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.newLevelToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_create_new_16;
-            this.newLevelToolStripMenuItem.Name = "newLevelToolStripMenuItem";
-            this.newLevelToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.newLevelToolStripMenuItem.Tag = "NewLevel";
-            this.newLevelToolStripMenuItem.Text = "NewLevel";
+            newLevelToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            newLevelToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            newLevelToolStripMenuItem.Image = Properties.Resources.general_create_new_16;
+            newLevelToolStripMenuItem.Name = "newLevelToolStripMenuItem";
+            newLevelToolStripMenuItem.Size = new System.Drawing.Size(247, 24);
+            newLevelToolStripMenuItem.Tag = "NewLevel";
+            newLevelToolStripMenuItem.Text = "NewLevel";
             // 
             // openLevelToolStripMenuItem
             // 
-            this.openLevelToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.openLevelToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.openLevelToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_Open_16;
-            this.openLevelToolStripMenuItem.Name = "openLevelToolStripMenuItem";
-            this.openLevelToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.openLevelToolStripMenuItem.Tag = "OpenLevel";
-            this.openLevelToolStripMenuItem.Text = "OpenLevel";
+            openLevelToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            openLevelToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            openLevelToolStripMenuItem.Image = Properties.Resources.general_Open_16;
+            openLevelToolStripMenuItem.Name = "openLevelToolStripMenuItem";
+            openLevelToolStripMenuItem.Size = new System.Drawing.Size(247, 24);
+            openLevelToolStripMenuItem.Tag = "OpenLevel";
+            openLevelToolStripMenuItem.Text = "OpenLevel";
             // 
             // openRecentToolStripMenuItem
             // 
-            this.openRecentToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.openRecentToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.openRecentToolStripMenuItem.Name = "openRecentToolStripMenuItem";
-            this.openRecentToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.openRecentToolStripMenuItem.Text = "Open recent";
+            openRecentToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            openRecentToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            openRecentToolStripMenuItem.Name = "openRecentToolStripMenuItem";
+            openRecentToolStripMenuItem.Size = new System.Drawing.Size(247, 24);
+            openRecentToolStripMenuItem.Text = "Open recent";
             // 
             // saveLevelToolStripMenuItem
             // 
-            this.saveLevelToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.saveLevelToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.saveLevelToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_Save_16;
-            this.saveLevelToolStripMenuItem.Name = "saveLevelToolStripMenuItem";
-            this.saveLevelToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.saveLevelToolStripMenuItem.Tag = "SaveLevel";
-            this.saveLevelToolStripMenuItem.Text = "SaveLevel";
+            saveLevelToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            saveLevelToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            saveLevelToolStripMenuItem.Image = Properties.Resources.general_Save_16;
+            saveLevelToolStripMenuItem.Name = "saveLevelToolStripMenuItem";
+            saveLevelToolStripMenuItem.Size = new System.Drawing.Size(247, 24);
+            saveLevelToolStripMenuItem.Tag = "SaveLevel";
+            saveLevelToolStripMenuItem.Text = "SaveLevel";
             // 
             // saveAsToolStripMenuItem
             // 
-            this.saveAsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.saveAsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.saveAsToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_Save_As_16;
-            this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.saveAsToolStripMenuItem.Tag = "SaveLevelAs";
-            this.saveAsToolStripMenuItem.Text = "SaveLevelAs";
+            saveAsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            saveAsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            saveAsToolStripMenuItem.Image = Properties.Resources.general_Save_As_16;
+            saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
+            saveAsToolStripMenuItem.Size = new System.Drawing.Size(247, 24);
+            saveAsToolStripMenuItem.Tag = "SaveLevelAs";
+            saveAsToolStripMenuItem.Text = "SaveLevelAs";
             // 
             // toolStripMenuSeparator1
             // 
-            this.toolStripMenuSeparator1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuSeparator1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator1.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator1.Name = "toolStripMenuSeparator1";
-            this.toolStripMenuSeparator1.Size = new System.Drawing.Size(218, 6);
+            toolStripMenuSeparator1.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuSeparator1.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator1.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator1.Name = "toolStripMenuSeparator1";
+            toolStripMenuSeparator1.Size = new System.Drawing.Size(244, 6);
             // 
             // importTRLEPRJToolStripMenuItem
             // 
-            this.importTRLEPRJToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.importTRLEPRJToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.importTRLEPRJToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_Import_16;
-            this.importTRLEPRJToolStripMenuItem.Name = "importTRLEPRJToolStripMenuItem";
-            this.importTRLEPRJToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.importTRLEPRJToolStripMenuItem.Tag = "ImportPrj";
-            this.importTRLEPRJToolStripMenuItem.Text = "ImportPrj";
+            importTRLEPRJToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            importTRLEPRJToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            importTRLEPRJToolStripMenuItem.Image = Properties.Resources.general_Import_16;
+            importTRLEPRJToolStripMenuItem.Name = "importTRLEPRJToolStripMenuItem";
+            importTRLEPRJToolStripMenuItem.Size = new System.Drawing.Size(247, 24);
+            importTRLEPRJToolStripMenuItem.Tag = "ImportPrj";
+            importTRLEPRJToolStripMenuItem.Text = "ImportPrj";
             // 
             // convertToTENToolstripMenuItem
             // 
-            this.convertToTENToolstripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.convertToTENToolstripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.convertToTENToolstripMenuItem.Image = global::TombEditor.Properties.Resources.actions_TEN_16;
-            this.convertToTENToolstripMenuItem.Name = "convertToTENToolstripMenuItem";
-            this.convertToTENToolstripMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.convertToTENToolstripMenuItem.Tag = "ConvertLevelToTombEngine";
-            this.convertToTENToolstripMenuItem.Text = "ConvertLevelToTombEngine";
+            convertToTENToolstripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            convertToTENToolstripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            convertToTENToolstripMenuItem.Image = Properties.Resources.actions_TEN_16;
+            convertToTENToolstripMenuItem.Name = "convertToTENToolstripMenuItem";
+            convertToTENToolstripMenuItem.Size = new System.Drawing.Size(247, 24);
+            convertToTENToolstripMenuItem.Tag = "ConvertLevelToTombEngine";
+            convertToTENToolstripMenuItem.Text = "ConvertLevelToTombEngine";
             // 
             // toolStripMenuSeparator2
             // 
-            this.toolStripMenuSeparator2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator2.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator2.Name = "toolStripMenuSeparator2";
-            this.toolStripMenuSeparator2.Size = new System.Drawing.Size(218, 6);
+            toolStripMenuSeparator2.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator2.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator2.Name = "toolStripMenuSeparator2";
+            toolStripMenuSeparator2.Size = new System.Drawing.Size(244, 6);
             // 
             // buildLevelPlayToolStripMenuItem
             // 
-            this.buildLevelPlayToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.buildLevelPlayToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.buildLevelPlayToolStripMenuItem.Image = global::TombEditor.Properties.Resources.actions_play_16;
-            this.buildLevelPlayToolStripMenuItem.Name = "buildLevelPlayToolStripMenuItem";
-            this.buildLevelPlayToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.buildLevelPlayToolStripMenuItem.Tag = "BuildAndPlay";
-            this.buildLevelPlayToolStripMenuItem.Text = "BuildAndPlay";
+            buildLevelPlayToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            buildLevelPlayToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            buildLevelPlayToolStripMenuItem.Image = Properties.Resources.actions_play_16;
+            buildLevelPlayToolStripMenuItem.Name = "buildLevelPlayToolStripMenuItem";
+            buildLevelPlayToolStripMenuItem.Size = new System.Drawing.Size(247, 24);
+            buildLevelPlayToolStripMenuItem.Tag = "BuildAndPlay";
+            buildLevelPlayToolStripMenuItem.Text = "BuildAndPlay";
             // 
             // buildLevelToolStripMenuItem
             // 
-            this.buildLevelToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.buildLevelToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.buildLevelToolStripMenuItem.Image = global::TombEditor.Properties.Resources.actions_compile_16;
-            this.buildLevelToolStripMenuItem.Name = "buildLevelToolStripMenuItem";
-            this.buildLevelToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.buildLevelToolStripMenuItem.Tag = "BuildLevel";
-            this.buildLevelToolStripMenuItem.Text = "BuildLevel";
+            buildLevelToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            buildLevelToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            buildLevelToolStripMenuItem.Image = Properties.Resources.actions_compile_16;
+            buildLevelToolStripMenuItem.Name = "buildLevelToolStripMenuItem";
+            buildLevelToolStripMenuItem.Size = new System.Drawing.Size(247, 24);
+            buildLevelToolStripMenuItem.Tag = "BuildLevel";
+            buildLevelToolStripMenuItem.Text = "BuildLevel";
             // 
             // toolStripMenuSeparator3
             // 
-            this.toolStripMenuSeparator3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator3.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator3.Name = "toolStripMenuSeparator3";
-            this.toolStripMenuSeparator3.Size = new System.Drawing.Size(218, 6);
+            toolStripMenuSeparator3.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator3.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator3.Name = "toolStripMenuSeparator3";
+            toolStripMenuSeparator3.Size = new System.Drawing.Size(244, 6);
             // 
             // exitToolStripMenuItem
             // 
-            this.exitToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.exitToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.exitToolStripMenuItem.Tag = "QuitEditor";
-            this.exitToolStripMenuItem.Text = "QuitEditor";
+            exitToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            exitToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+            exitToolStripMenuItem.Size = new System.Drawing.Size(247, 24);
+            exitToolStripMenuItem.Tag = "QuitEditor";
+            exitToolStripMenuItem.Text = "QuitEditor";
             // 
             // editToolStripMenuItem
             // 
-            this.editToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.undoToolStripMenuItem,
-            this.redoToolStripMenuItem,
-            this.toolStripSeparator2,
-            this.cutToolStripMenuItem,
-            this.copyToolStripMenuItem,
-            this.pasteToolStripMenuItem,
-            this.stampToolStripMenuItem,
-            this.deleteToolStripMenuItem,
-            this.selectAllToolStripMenuItem,
-            this.toolStripSeparator4,
-            this.bookmarkObjectToolStripMenuItem,
-            this.bookmarkRestoreObjectToolStripMenuItem,
-            this.toolStripSeparator1,
-            this.editObjectToolStripMenuItem,
-            this.editEventSetsToolStripMenuItem,
-            this.searchToolStripMenuItem,
-            this.searchAndReplaceToolStripMenuItem});
-            this.editToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 25);
-            this.editToolStripMenuItem.Text = "Edit";
+            editToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            editToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { undoToolStripMenuItem, redoToolStripMenuItem, toolStripSeparator2, cutToolStripMenuItem, copyToolStripMenuItem, pasteToolStripMenuItem, stampToolStripMenuItem, deleteToolStripMenuItem, selectAllToolStripMenuItem, toolStripSeparator4, bookmarkObjectToolStripMenuItem, bookmarkRestoreObjectToolStripMenuItem, toolStripSeparator1, editObjectToolStripMenuItem, editEventSetsToolStripMenuItem, editVolumesToolStripMenuItem, searchToolStripMenuItem, searchAndReplaceToolStripMenuItem });
+            editToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            editToolStripMenuItem.Name = "editToolStripMenuItem";
+            editToolStripMenuItem.Size = new System.Drawing.Size(44, 25);
+            editToolStripMenuItem.Text = "Edit";
             // 
             // undoToolStripMenuItem
             // 
-            this.undoToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.undoToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.undoToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_undo_16;
-            this.undoToolStripMenuItem.Name = "undoToolStripMenuItem";
-            this.undoToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.undoToolStripMenuItem.Tag = "Undo";
-            this.undoToolStripMenuItem.Text = "Undo";
+            undoToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            undoToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            undoToolStripMenuItem.Image = Properties.Resources.general_undo_16;
+            undoToolStripMenuItem.Name = "undoToolStripMenuItem";
+            undoToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            undoToolStripMenuItem.Tag = "Undo";
+            undoToolStripMenuItem.Text = "Undo";
             // 
             // redoToolStripMenuItem
             // 
-            this.redoToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.redoToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.redoToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_redo_16;
-            this.redoToolStripMenuItem.Name = "redoToolStripMenuItem";
-            this.redoToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.redoToolStripMenuItem.Tag = "Redo";
-            this.redoToolStripMenuItem.Text = "Redo";
+            redoToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            redoToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            redoToolStripMenuItem.Image = Properties.Resources.general_redo_16;
+            redoToolStripMenuItem.Name = "redoToolStripMenuItem";
+            redoToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            redoToolStripMenuItem.Tag = "Redo";
+            redoToolStripMenuItem.Text = "Redo";
             // 
             // toolStripSeparator2
             // 
-            this.toolStripSeparator2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripSeparator2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator2.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(209, 6);
+            toolStripSeparator2.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripSeparator2.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator2.Margin = new Padding(0, 0, 0, 1);
+            toolStripSeparator2.Name = "toolStripSeparator2";
+            toolStripSeparator2.Size = new System.Drawing.Size(232, 6);
             // 
             // cutToolStripMenuItem
             // 
-            this.cutToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.cutToolStripMenuItem.Enabled = false;
-            this.cutToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
-            this.cutToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.cutToolStripMenuItem.Tag = "Cut";
-            this.cutToolStripMenuItem.Text = "Cut";
+            cutToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            cutToolStripMenuItem.Enabled = false;
+            cutToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            cutToolStripMenuItem.Name = "cutToolStripMenuItem";
+            cutToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            cutToolStripMenuItem.Tag = "Cut";
+            cutToolStripMenuItem.Text = "Cut";
             // 
             // copyToolStripMenuItem
             // 
-            this.copyToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.copyToolStripMenuItem.Enabled = false;
-            this.copyToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.copyToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_copy_16;
-            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.copyToolStripMenuItem.Tag = "Copy";
-            this.copyToolStripMenuItem.Text = "Copy";
+            copyToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            copyToolStripMenuItem.Enabled = false;
+            copyToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            copyToolStripMenuItem.Image = Properties.Resources.general_copy_16;
+            copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+            copyToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            copyToolStripMenuItem.Tag = "Copy";
+            copyToolStripMenuItem.Text = "Copy";
             // 
             // pasteToolStripMenuItem
             // 
-            this.pasteToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.pasteToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.pasteToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_clipboard_16;
-            this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
-            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.pasteToolStripMenuItem.Tag = "Paste";
-            this.pasteToolStripMenuItem.Text = "Paste";
+            pasteToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            pasteToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            pasteToolStripMenuItem.Image = Properties.Resources.general_clipboard_16;
+            pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
+            pasteToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            pasteToolStripMenuItem.Tag = "Paste";
+            pasteToolStripMenuItem.Text = "Paste";
             // 
             // stampToolStripMenuItem
             // 
-            this.stampToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.stampToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.stampToolStripMenuItem.Image = global::TombEditor.Properties.Resources.actions_rubber_stamp_16;
-            this.stampToolStripMenuItem.Name = "stampToolStripMenuItem";
-            this.stampToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.stampToolStripMenuItem.Tag = "StampObject";
-            this.stampToolStripMenuItem.Text = "StampObject";
+            stampToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            stampToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            stampToolStripMenuItem.Image = Properties.Resources.actions_rubber_stamp_16;
+            stampToolStripMenuItem.Name = "stampToolStripMenuItem";
+            stampToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            stampToolStripMenuItem.Tag = "StampObject";
+            stampToolStripMenuItem.Text = "StampObject";
             // 
             // deleteToolStripMenuItem
             // 
-            this.deleteToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.deleteToolStripMenuItem.Enabled = false;
-            this.deleteToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.deleteToolStripMenuItem.Name = "deleteToolStripMenuItem";
-            this.deleteToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.deleteToolStripMenuItem.Tag = "Delete";
-            this.deleteToolStripMenuItem.Text = "Delete";
+            deleteToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            deleteToolStripMenuItem.Enabled = false;
+            deleteToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            deleteToolStripMenuItem.Name = "deleteToolStripMenuItem";
+            deleteToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            deleteToolStripMenuItem.Tag = "Delete";
+            deleteToolStripMenuItem.Text = "Delete";
             // 
             // selectAllToolStripMenuItem
             // 
-            this.selectAllToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.selectAllToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
-            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.selectAllToolStripMenuItem.Tag = "SelectAll";
-            this.selectAllToolStripMenuItem.Text = "SelectAll";
+            selectAllToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            selectAllToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
+            selectAllToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            selectAllToolStripMenuItem.Tag = "SelectAll";
+            selectAllToolStripMenuItem.Text = "SelectAll";
             // 
             // toolStripSeparator4
             // 
-            this.toolStripSeparator4.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripSeparator4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator4.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(209, 6);
+            toolStripSeparator4.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripSeparator4.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator4.Margin = new Padding(0, 0, 0, 1);
+            toolStripSeparator4.Name = "toolStripSeparator4";
+            toolStripSeparator4.Size = new System.Drawing.Size(232, 6);
             // 
             // bookmarkObjectToolStripMenuItem
             // 
-            this.bookmarkObjectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.bookmarkObjectToolStripMenuItem.Enabled = false;
-            this.bookmarkObjectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.bookmarkObjectToolStripMenuItem.Name = "bookmarkObjectToolStripMenuItem";
-            this.bookmarkObjectToolStripMenuItem.ShortcutKeyDisplayString = "";
-            this.bookmarkObjectToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.bookmarkObjectToolStripMenuItem.Tag = "BookmarkObject";
-            this.bookmarkObjectToolStripMenuItem.Text = "BookmarkObject";
+            bookmarkObjectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            bookmarkObjectToolStripMenuItem.Enabled = false;
+            bookmarkObjectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            bookmarkObjectToolStripMenuItem.Name = "bookmarkObjectToolStripMenuItem";
+            bookmarkObjectToolStripMenuItem.ShortcutKeyDisplayString = "";
+            bookmarkObjectToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            bookmarkObjectToolStripMenuItem.Tag = "BookmarkObject";
+            bookmarkObjectToolStripMenuItem.Text = "BookmarkObject";
             // 
             // bookmarkRestoreObjectToolStripMenuItem
             // 
-            this.bookmarkRestoreObjectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.bookmarkRestoreObjectToolStripMenuItem.Enabled = false;
-            this.bookmarkRestoreObjectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.bookmarkRestoreObjectToolStripMenuItem.Name = "bookmarkRestoreObjectToolStripMenuItem";
-            this.bookmarkRestoreObjectToolStripMenuItem.ShortcutKeyDisplayString = "";
-            this.bookmarkRestoreObjectToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.bookmarkRestoreObjectToolStripMenuItem.Tag = "SelectBookmarkedObject";
-            this.bookmarkRestoreObjectToolStripMenuItem.Text = "SelectBookmarkedObject";
+            bookmarkRestoreObjectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            bookmarkRestoreObjectToolStripMenuItem.Enabled = false;
+            bookmarkRestoreObjectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            bookmarkRestoreObjectToolStripMenuItem.Name = "bookmarkRestoreObjectToolStripMenuItem";
+            bookmarkRestoreObjectToolStripMenuItem.ShortcutKeyDisplayString = "";
+            bookmarkRestoreObjectToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            bookmarkRestoreObjectToolStripMenuItem.Tag = "SelectBookmarkedObject";
+            bookmarkRestoreObjectToolStripMenuItem.Text = "SelectBookmarkedObject";
             // 
             // toolStripSeparator1
             // 
-            this.toolStripSeparator1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripSeparator1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator1.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(209, 6);
+            toolStripSeparator1.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripSeparator1.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator1.Margin = new Padding(0, 0, 0, 1);
+            toolStripSeparator1.Name = "toolStripSeparator1";
+            toolStripSeparator1.Size = new System.Drawing.Size(232, 6);
             // 
             // editObjectToolStripMenuItem
             // 
-            this.editObjectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.editObjectToolStripMenuItem.Enabled = false;
-            this.editObjectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.editObjectToolStripMenuItem.Name = "editObjectToolStripMenuItem";
-            this.editObjectToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.editObjectToolStripMenuItem.Tag = "EditObject";
-            this.editObjectToolStripMenuItem.Text = "EditObject";
+            editObjectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            editObjectToolStripMenuItem.Enabled = false;
+            editObjectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            editObjectToolStripMenuItem.Name = "editObjectToolStripMenuItem";
+            editObjectToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            editObjectToolStripMenuItem.Tag = "EditObject";
+            editObjectToolStripMenuItem.Text = "EditObject";
             // 
             // editEventSetsToolStripMenuItem
             // 
-            this.editEventSetsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.editEventSetsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.editEventSetsToolStripMenuItem.Name = "editEventSetsToolStripMenuItem";
-            this.editEventSetsToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.editEventSetsToolStripMenuItem.Tag = "EditEventSets";
-            this.editEventSetsToolStripMenuItem.Text = "EditEventSets";
+            editEventSetsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            editEventSetsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            editEventSetsToolStripMenuItem.Name = "editEventSetsToolStripMenuItem";
+            editEventSetsToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            editEventSetsToolStripMenuItem.Tag = "EditEventSets";
+            editEventSetsToolStripMenuItem.Text = "EditEventSets";
             // 
             // searchToolStripMenuItem
             // 
-            this.searchToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.searchToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.searchToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_search_16;
-            this.searchToolStripMenuItem.Name = "searchToolStripMenuItem";
-            this.searchToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.searchToolStripMenuItem.Tag = "Search";
-            this.searchToolStripMenuItem.Text = "Search";
+            searchToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            searchToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            searchToolStripMenuItem.Image = Properties.Resources.general_search_16;
+            searchToolStripMenuItem.Name = "searchToolStripMenuItem";
+            searchToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            searchToolStripMenuItem.Tag = "Search";
+            searchToolStripMenuItem.Text = "Search";
             // 
             // searchAndReplaceToolStripMenuItem
             // 
-            this.searchAndReplaceToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.searchAndReplaceToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.searchAndReplaceToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_search_and_replace_16;
-            this.searchAndReplaceToolStripMenuItem.Name = "searchAndReplaceToolStripMenuItem";
-            this.searchAndReplaceToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
-            this.searchAndReplaceToolStripMenuItem.Tag = "SearchAndReplaceObjects";
-            this.searchAndReplaceToolStripMenuItem.Text = "SearchAndReplaceObjects";
+            searchAndReplaceToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            searchAndReplaceToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            searchAndReplaceToolStripMenuItem.Image = Properties.Resources.general_search_and_replace_16;
+            searchAndReplaceToolStripMenuItem.Name = "searchAndReplaceToolStripMenuItem";
+            searchAndReplaceToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            searchAndReplaceToolStripMenuItem.Tag = "SearchAndReplaceObjects";
+            searchAndReplaceToolStripMenuItem.Text = "SearchAndReplaceObjects";
             // 
             // viewToolStripMenuItem
             // 
-            this.viewToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.viewToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.resetCameraToolStripMenuItem,
-            this.relocateCameraToolStripMenuItem,
-            this.toggleFlyModeToolStripMenuItem,
-            this.toolStripSeparator8,
-            this.drawWhiteTextureLightingOnlyToolStripMenuItem,
-            this.ShowRealTintForObjectsToolStripMenuItem});
-            this.viewToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
-            this.viewToolStripMenuItem.Size = new System.Drawing.Size(44, 25);
-            this.viewToolStripMenuItem.Text = "View";
+            viewToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            viewToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { resetCameraToolStripMenuItem, relocateCameraToolStripMenuItem, toggleFlyModeToolStripMenuItem, toolStripSeparator8, drawWhiteTextureLightingOnlyToolStripMenuItem, ShowRealTintForObjectsToolStripMenuItem });
+            viewToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            viewToolStripMenuItem.Name = "viewToolStripMenuItem";
+            viewToolStripMenuItem.Size = new System.Drawing.Size(50, 25);
+            viewToolStripMenuItem.Text = "View";
             // 
             // resetCameraToolStripMenuItem
             // 
-            this.resetCameraToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.resetCameraToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.resetCameraToolStripMenuItem.Image = global::TombEditor.Properties.Resources.actions_center_direction_16;
-            this.resetCameraToolStripMenuItem.Name = "resetCameraToolStripMenuItem";
-            this.resetCameraToolStripMenuItem.Size = new System.Drawing.Size(239, 22);
-            this.resetCameraToolStripMenuItem.Tag = "ResetCamera";
-            this.resetCameraToolStripMenuItem.Text = "ResetCamera";
+            resetCameraToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            resetCameraToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            resetCameraToolStripMenuItem.Image = Properties.Resources.actions_center_direction_16;
+            resetCameraToolStripMenuItem.Name = "resetCameraToolStripMenuItem";
+            resetCameraToolStripMenuItem.Size = new System.Drawing.Size(269, 24);
+            resetCameraToolStripMenuItem.Tag = "ResetCamera";
+            resetCameraToolStripMenuItem.Text = "ResetCamera";
             // 
             // relocateCameraToolStripMenuItem
             // 
-            this.relocateCameraToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.relocateCameraToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.relocateCameraToolStripMenuItem.Name = "relocateCameraToolStripMenuItem";
-            this.relocateCameraToolStripMenuItem.Size = new System.Drawing.Size(239, 22);
-            this.relocateCameraToolStripMenuItem.Tag = "RelocateCamera";
-            this.relocateCameraToolStripMenuItem.Text = "RelocateCamera";
+            relocateCameraToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            relocateCameraToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            relocateCameraToolStripMenuItem.Name = "relocateCameraToolStripMenuItem";
+            relocateCameraToolStripMenuItem.Size = new System.Drawing.Size(269, 24);
+            relocateCameraToolStripMenuItem.Tag = "RelocateCamera";
+            relocateCameraToolStripMenuItem.Text = "RelocateCamera";
             // 
             // toggleFlyModeToolStripMenuItem
             // 
-            this.toggleFlyModeToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toggleFlyModeToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toggleFlyModeToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_airplane_16;
-            this.toggleFlyModeToolStripMenuItem.Name = "toggleFlyModeToolStripMenuItem";
-            this.toggleFlyModeToolStripMenuItem.Size = new System.Drawing.Size(239, 22);
-            this.toggleFlyModeToolStripMenuItem.Tag = "ToggleFlyMode";
-            this.toggleFlyModeToolStripMenuItem.Text = "ToggleFlyMode";
+            toggleFlyModeToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toggleFlyModeToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toggleFlyModeToolStripMenuItem.Image = Properties.Resources.general_airplane_16;
+            toggleFlyModeToolStripMenuItem.Name = "toggleFlyModeToolStripMenuItem";
+            toggleFlyModeToolStripMenuItem.Size = new System.Drawing.Size(269, 24);
+            toggleFlyModeToolStripMenuItem.Tag = "ToggleFlyMode";
+            toggleFlyModeToolStripMenuItem.Text = "ToggleFlyMode";
             // 
             // toolStripSeparator8
             // 
-            this.toolStripSeparator8.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripSeparator8.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator8.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripSeparator8.Name = "toolStripSeparator8";
-            this.toolStripSeparator8.Size = new System.Drawing.Size(236, 6);
+            toolStripSeparator8.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripSeparator8.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator8.Margin = new Padding(0, 0, 0, 1);
+            toolStripSeparator8.Name = "toolStripSeparator8";
+            toolStripSeparator8.Size = new System.Drawing.Size(266, 6);
             // 
             // drawWhiteTextureLightingOnlyToolStripMenuItem
             // 
-            this.drawWhiteTextureLightingOnlyToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.drawWhiteTextureLightingOnlyToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.drawWhiteTextureLightingOnlyToolStripMenuItem.Image = global::TombEditor.Properties.Resources.actions_DrawUntexturedLights_16;
-            this.drawWhiteTextureLightingOnlyToolStripMenuItem.Name = "drawWhiteTextureLightingOnlyToolStripMenuItem";
-            this.drawWhiteTextureLightingOnlyToolStripMenuItem.Size = new System.Drawing.Size(239, 22);
-            this.drawWhiteTextureLightingOnlyToolStripMenuItem.Tag = "DrawWhiteTextureLightingOnly";
-            this.drawWhiteTextureLightingOnlyToolStripMenuItem.Text = "DrawWhiteTextureLightingOnly";
+            drawWhiteTextureLightingOnlyToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            drawWhiteTextureLightingOnlyToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            drawWhiteTextureLightingOnlyToolStripMenuItem.Image = Properties.Resources.actions_DrawUntexturedLights_16;
+            drawWhiteTextureLightingOnlyToolStripMenuItem.Name = "drawWhiteTextureLightingOnlyToolStripMenuItem";
+            drawWhiteTextureLightingOnlyToolStripMenuItem.Size = new System.Drawing.Size(269, 24);
+            drawWhiteTextureLightingOnlyToolStripMenuItem.Tag = "DrawWhiteTextureLightingOnly";
+            drawWhiteTextureLightingOnlyToolStripMenuItem.Text = "DrawWhiteTextureLightingOnly";
             // 
             // ShowRealTintForObjectsToolStripMenuItem
             // 
-            this.ShowRealTintForObjectsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.ShowRealTintForObjectsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.ShowRealTintForObjectsToolStripMenuItem.Image = global::TombEditor.Properties.Resources.actions_StaticTint_16;
-            this.ShowRealTintForObjectsToolStripMenuItem.Name = "ShowRealTintForObjectsToolStripMenuItem";
-            this.ShowRealTintForObjectsToolStripMenuItem.Size = new System.Drawing.Size(239, 22);
-            this.ShowRealTintForObjectsToolStripMenuItem.Tag = "ShowRealTintForObjects";
-            this.ShowRealTintForObjectsToolStripMenuItem.Text = "ShowRealTintForObjects";
+            ShowRealTintForObjectsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            ShowRealTintForObjectsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            ShowRealTintForObjectsToolStripMenuItem.Image = Properties.Resources.actions_StaticTint_16;
+            ShowRealTintForObjectsToolStripMenuItem.Name = "ShowRealTintForObjectsToolStripMenuItem";
+            ShowRealTintForObjectsToolStripMenuItem.Size = new System.Drawing.Size(269, 24);
+            ShowRealTintForObjectsToolStripMenuItem.Tag = "ShowRealTintForObjects";
+            ShowRealTintForObjectsToolStripMenuItem.Text = "ShowRealTintForObjects";
             // 
             // roomsToolStripMenuItem
             // 
-            this.roomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.roomsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.newRoomToolStripMenuItem,
-            this.duplicateRoomToolStripMenuItem,
-            this.cropRoomToolStripMenuItem,
-            this.splitRoomToolStripMenuItem,
-            this.mergeRoomsHorizontallyToolStripMenuItem,
-            this.deleteRoomsToolStripMenuItem,
-            this.toolStripMenuSeparator5,
-            this.moveRoomsToolStripMenuItem,
-            this.transformRoomsToolStripMenuItem,
-            this.selectRoomsToolStripMenuItem,
-            this.toolStripMenuItem1,
-            this.exportRoomToolStripMenuItem,
-            this.importRoomsToolStripMenuItem,
-            this.toolStripMenuItem9});
-            this.roomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.roomsToolStripMenuItem.Name = "roomsToolStripMenuItem";
-            this.roomsToolStripMenuItem.Size = new System.Drawing.Size(56, 25);
-            this.roomsToolStripMenuItem.Text = "Rooms";
+            roomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            roomsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { newRoomToolStripMenuItem, duplicateRoomToolStripMenuItem, cropRoomToolStripMenuItem, splitRoomToolStripMenuItem, mergeRoomsHorizontallyToolStripMenuItem, deleteRoomsToolStripMenuItem, toolStripMenuSeparator5, moveRoomsToolStripMenuItem, transformRoomsToolStripMenuItem, selectRoomsToolStripMenuItem, toolStripMenuItem1, exportRoomToolStripMenuItem, importRoomsToolStripMenuItem, toolStripMenuItem9 });
+            roomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            roomsToolStripMenuItem.Name = "roomsToolStripMenuItem";
+            roomsToolStripMenuItem.Size = new System.Drawing.Size(63, 25);
+            roomsToolStripMenuItem.Text = "Rooms";
             // 
             // newRoomToolStripMenuItem
             // 
-            this.newRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.newRoomToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.newRoomUpToolStripMenuItem,
-            this.newRoomDownToolStripMenuItem,
-            this.newRoomLeftToolStripMenuItem,
-            this.newRoomRightToolStripMenuItem,
-            this.newRoomFrontToolStripMenuItem,
-            this.newRoomBackToolStripMenuItem});
-            this.newRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.newRoomToolStripMenuItem.Name = "newRoomToolStripMenuItem";
-            this.newRoomToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.newRoomToolStripMenuItem.Text = "New room";
+            newRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            newRoomToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { newRoomUpToolStripMenuItem, newRoomDownToolStripMenuItem, newRoomLeftToolStripMenuItem, newRoomRightToolStripMenuItem, newRoomFrontToolStripMenuItem, newRoomBackToolStripMenuItem });
+            newRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            newRoomToolStripMenuItem.Name = "newRoomToolStripMenuItem";
+            newRoomToolStripMenuItem.Size = new System.Drawing.Size(233, 24);
+            newRoomToolStripMenuItem.Text = "New room";
             // 
             // newRoomUpToolStripMenuItem
             // 
-            this.newRoomUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.newRoomUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.newRoomUpToolStripMenuItem.Name = "newRoomUpToolStripMenuItem";
-            this.newRoomUpToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
-            this.newRoomUpToolStripMenuItem.Tag = "NewRoomUp";
-            this.newRoomUpToolStripMenuItem.Text = "NewRoomUp";
+            newRoomUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            newRoomUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            newRoomUpToolStripMenuItem.Name = "newRoomUpToolStripMenuItem";
+            newRoomUpToolStripMenuItem.Size = new System.Drawing.Size(177, 24);
+            newRoomUpToolStripMenuItem.Tag = "NewRoomUp";
+            newRoomUpToolStripMenuItem.Text = "NewRoomUp";
             // 
             // newRoomDownToolStripMenuItem
             // 
-            this.newRoomDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.newRoomDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.newRoomDownToolStripMenuItem.Name = "newRoomDownToolStripMenuItem";
-            this.newRoomDownToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
-            this.newRoomDownToolStripMenuItem.Tag = "NewRoomDown";
-            this.newRoomDownToolStripMenuItem.Text = "NewRoomDown";
+            newRoomDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            newRoomDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            newRoomDownToolStripMenuItem.Name = "newRoomDownToolStripMenuItem";
+            newRoomDownToolStripMenuItem.Size = new System.Drawing.Size(177, 24);
+            newRoomDownToolStripMenuItem.Tag = "NewRoomDown";
+            newRoomDownToolStripMenuItem.Text = "NewRoomDown";
             // 
             // newRoomLeftToolStripMenuItem
             // 
-            this.newRoomLeftToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.newRoomLeftToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.newRoomLeftToolStripMenuItem.Name = "newRoomLeftToolStripMenuItem";
-            this.newRoomLeftToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
-            this.newRoomLeftToolStripMenuItem.Tag = "NewRoomLeft";
-            this.newRoomLeftToolStripMenuItem.Text = "NewRoomLeft";
+            newRoomLeftToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            newRoomLeftToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            newRoomLeftToolStripMenuItem.Name = "newRoomLeftToolStripMenuItem";
+            newRoomLeftToolStripMenuItem.Size = new System.Drawing.Size(177, 24);
+            newRoomLeftToolStripMenuItem.Tag = "NewRoomLeft";
+            newRoomLeftToolStripMenuItem.Text = "NewRoomLeft";
             // 
             // newRoomRightToolStripMenuItem
             // 
-            this.newRoomRightToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.newRoomRightToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.newRoomRightToolStripMenuItem.Name = "newRoomRightToolStripMenuItem";
-            this.newRoomRightToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
-            this.newRoomRightToolStripMenuItem.Tag = "NewRoomRight";
-            this.newRoomRightToolStripMenuItem.Text = "NewRoomRight";
+            newRoomRightToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            newRoomRightToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            newRoomRightToolStripMenuItem.Name = "newRoomRightToolStripMenuItem";
+            newRoomRightToolStripMenuItem.Size = new System.Drawing.Size(177, 24);
+            newRoomRightToolStripMenuItem.Tag = "NewRoomRight";
+            newRoomRightToolStripMenuItem.Text = "NewRoomRight";
             // 
             // newRoomFrontToolStripMenuItem
             // 
-            this.newRoomFrontToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.newRoomFrontToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.newRoomFrontToolStripMenuItem.Name = "newRoomFrontToolStripMenuItem";
-            this.newRoomFrontToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
-            this.newRoomFrontToolStripMenuItem.Tag = "NewRoomFront";
-            this.newRoomFrontToolStripMenuItem.Text = "NewRoomFront";
+            newRoomFrontToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            newRoomFrontToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            newRoomFrontToolStripMenuItem.Name = "newRoomFrontToolStripMenuItem";
+            newRoomFrontToolStripMenuItem.Size = new System.Drawing.Size(177, 24);
+            newRoomFrontToolStripMenuItem.Tag = "NewRoomFront";
+            newRoomFrontToolStripMenuItem.Text = "NewRoomFront";
             // 
             // newRoomBackToolStripMenuItem
             // 
-            this.newRoomBackToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.newRoomBackToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.newRoomBackToolStripMenuItem.Name = "newRoomBackToolStripMenuItem";
-            this.newRoomBackToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
-            this.newRoomBackToolStripMenuItem.Tag = "NewRoomBack";
-            this.newRoomBackToolStripMenuItem.Text = "NewRoomBack";
+            newRoomBackToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            newRoomBackToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            newRoomBackToolStripMenuItem.Name = "newRoomBackToolStripMenuItem";
+            newRoomBackToolStripMenuItem.Size = new System.Drawing.Size(177, 24);
+            newRoomBackToolStripMenuItem.Tag = "NewRoomBack";
+            newRoomBackToolStripMenuItem.Text = "NewRoomBack";
             // 
             // duplicateRoomToolStripMenuItem
             // 
-            this.duplicateRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.duplicateRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.duplicateRoomToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_copy_16;
-            this.duplicateRoomToolStripMenuItem.Name = "duplicateRoomToolStripMenuItem";
-            this.duplicateRoomToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.duplicateRoomToolStripMenuItem.Tag = "DuplicateRoom";
-            this.duplicateRoomToolStripMenuItem.Text = "DuplicateRoom";
+            duplicateRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            duplicateRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            duplicateRoomToolStripMenuItem.Image = Properties.Resources.general_copy_16;
+            duplicateRoomToolStripMenuItem.Name = "duplicateRoomToolStripMenuItem";
+            duplicateRoomToolStripMenuItem.Size = new System.Drawing.Size(233, 24);
+            duplicateRoomToolStripMenuItem.Tag = "DuplicateRoom";
+            duplicateRoomToolStripMenuItem.Text = "DuplicateRoom";
             // 
             // cropRoomToolStripMenuItem
             // 
-            this.cropRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.cropRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.cropRoomToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_crop_16;
-            this.cropRoomToolStripMenuItem.Name = "cropRoomToolStripMenuItem";
-            this.cropRoomToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.cropRoomToolStripMenuItem.Tag = "CropRoom";
-            this.cropRoomToolStripMenuItem.Text = "CropRoom";
+            cropRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            cropRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            cropRoomToolStripMenuItem.Image = Properties.Resources.general_crop_16;
+            cropRoomToolStripMenuItem.Name = "cropRoomToolStripMenuItem";
+            cropRoomToolStripMenuItem.Size = new System.Drawing.Size(233, 24);
+            cropRoomToolStripMenuItem.Tag = "CropRoom";
+            cropRoomToolStripMenuItem.Text = "CropRoom";
             // 
             // splitRoomToolStripMenuItem
             // 
-            this.splitRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.splitRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.splitRoomToolStripMenuItem.Image = global::TombEditor.Properties.Resources.actions_Split_16;
-            this.splitRoomToolStripMenuItem.Name = "splitRoomToolStripMenuItem";
-            this.splitRoomToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.splitRoomToolStripMenuItem.Tag = "SplitRoom";
-            this.splitRoomToolStripMenuItem.Text = "SplitRoom";
+            splitRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            splitRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            splitRoomToolStripMenuItem.Image = Properties.Resources.actions_Split_16;
+            splitRoomToolStripMenuItem.Name = "splitRoomToolStripMenuItem";
+            splitRoomToolStripMenuItem.Size = new System.Drawing.Size(233, 24);
+            splitRoomToolStripMenuItem.Tag = "SplitRoom";
+            splitRoomToolStripMenuItem.Text = "SplitRoom";
             // 
             // mergeRoomsHorizontallyToolStripMenuItem
             // 
-            this.mergeRoomsHorizontallyToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.mergeRoomsHorizontallyToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.mergeRoomsHorizontallyToolStripMenuItem.Image = global::TombEditor.Properties.Resources.actions_Merge_16;
-            this.mergeRoomsHorizontallyToolStripMenuItem.Name = "mergeRoomsHorizontallyToolStripMenuItem";
-            this.mergeRoomsHorizontallyToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.mergeRoomsHorizontallyToolStripMenuItem.Tag = "MergeRoomsHorizontally";
-            this.mergeRoomsHorizontallyToolStripMenuItem.Text = "MergeRoomsHorizontally";
+            mergeRoomsHorizontallyToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            mergeRoomsHorizontallyToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            mergeRoomsHorizontallyToolStripMenuItem.Image = Properties.Resources.actions_Merge_16;
+            mergeRoomsHorizontallyToolStripMenuItem.Name = "mergeRoomsHorizontallyToolStripMenuItem";
+            mergeRoomsHorizontallyToolStripMenuItem.Size = new System.Drawing.Size(233, 24);
+            mergeRoomsHorizontallyToolStripMenuItem.Tag = "MergeRoomsHorizontally";
+            mergeRoomsHorizontallyToolStripMenuItem.Text = "MergeRoomsHorizontally";
             // 
             // deleteRoomsToolStripMenuItem
             // 
-            this.deleteRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.deleteRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.deleteRoomsToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_trash_16;
-            this.deleteRoomsToolStripMenuItem.Name = "deleteRoomsToolStripMenuItem";
-            this.deleteRoomsToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.deleteRoomsToolStripMenuItem.Tag = "DeleteRooms";
-            this.deleteRoomsToolStripMenuItem.Text = "DeleteRooms";
+            deleteRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            deleteRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            deleteRoomsToolStripMenuItem.Image = Properties.Resources.general_trash_16;
+            deleteRoomsToolStripMenuItem.Name = "deleteRoomsToolStripMenuItem";
+            deleteRoomsToolStripMenuItem.Size = new System.Drawing.Size(233, 24);
+            deleteRoomsToolStripMenuItem.Tag = "DeleteRooms";
+            deleteRoomsToolStripMenuItem.Text = "DeleteRooms";
             // 
             // toolStripMenuSeparator5
             // 
-            this.toolStripMenuSeparator5.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuSeparator5.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator5.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator5.Name = "toolStripMenuSeparator5";
-            this.toolStripMenuSeparator5.Size = new System.Drawing.Size(206, 6);
+            toolStripMenuSeparator5.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuSeparator5.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator5.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator5.Name = "toolStripMenuSeparator5";
+            toolStripMenuSeparator5.Size = new System.Drawing.Size(230, 6);
             // 
             // moveRoomsToolStripMenuItem
             // 
-            this.moveRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.moveRoomsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.wholeRoomUpToolStripMenuItem,
-            this.moveRoomUp4ClicksToolStripMenuItem,
-            this.wholeRoomDownToolStripMenuItem,
-            this.moveRoomDown4ClicksToolStripMenuItem,
-            this.moveRoomLeftToolStripMenuItem,
-            this.moveRoomRightToolStripMenuItem,
-            this.moveRoomForwardToolStripMenuItem,
-            this.moveRoomBackToolStripMenuItem});
-            this.moveRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.moveRoomsToolStripMenuItem.Name = "moveRoomsToolStripMenuItem";
-            this.moveRoomsToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.moveRoomsToolStripMenuItem.Text = "Move rooms";
+            moveRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            moveRoomsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { wholeRoomUpToolStripMenuItem, moveRoomUp4ClicksToolStripMenuItem, wholeRoomDownToolStripMenuItem, moveRoomDown4ClicksToolStripMenuItem, moveRoomLeftToolStripMenuItem, moveRoomRightToolStripMenuItem, moveRoomForwardToolStripMenuItem, moveRoomBackToolStripMenuItem });
+            moveRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            moveRoomsToolStripMenuItem.Name = "moveRoomsToolStripMenuItem";
+            moveRoomsToolStripMenuItem.Size = new System.Drawing.Size(233, 24);
+            moveRoomsToolStripMenuItem.Text = "Move rooms";
             // 
             // wholeRoomUpToolStripMenuItem
             // 
-            this.wholeRoomUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.wholeRoomUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.wholeRoomUpToolStripMenuItem.Name = "wholeRoomUpToolStripMenuItem";
-            this.wholeRoomUpToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
-            this.wholeRoomUpToolStripMenuItem.Tag = "MoveRoomUp";
-            this.wholeRoomUpToolStripMenuItem.Text = "MoveRoomUp";
+            wholeRoomUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            wholeRoomUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            wholeRoomUpToolStripMenuItem.Name = "wholeRoomUpToolStripMenuItem";
+            wholeRoomUpToolStripMenuItem.Size = new System.Drawing.Size(227, 24);
+            wholeRoomUpToolStripMenuItem.Tag = "MoveRoomUp";
+            wholeRoomUpToolStripMenuItem.Text = "MoveRoomUp";
             // 
             // moveRoomUp4ClicksToolStripMenuItem
             // 
-            this.moveRoomUp4ClicksToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.moveRoomUp4ClicksToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.moveRoomUp4ClicksToolStripMenuItem.Name = "moveRoomUp4ClicksToolStripMenuItem";
-            this.moveRoomUp4ClicksToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
-            this.moveRoomUp4ClicksToolStripMenuItem.Tag = "MoveRoomUp4Clicks";
-            this.moveRoomUp4ClicksToolStripMenuItem.Text = "MoveRoomUp4Clicks";
+            moveRoomUp4ClicksToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            moveRoomUp4ClicksToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            moveRoomUp4ClicksToolStripMenuItem.Name = "moveRoomUp4ClicksToolStripMenuItem";
+            moveRoomUp4ClicksToolStripMenuItem.Size = new System.Drawing.Size(227, 24);
+            moveRoomUp4ClicksToolStripMenuItem.Tag = "MoveRoomUp4Clicks";
+            moveRoomUp4ClicksToolStripMenuItem.Text = "MoveRoomUp4Clicks";
             // 
             // wholeRoomDownToolStripMenuItem
             // 
-            this.wholeRoomDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.wholeRoomDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.wholeRoomDownToolStripMenuItem.Name = "wholeRoomDownToolStripMenuItem";
-            this.wholeRoomDownToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
-            this.wholeRoomDownToolStripMenuItem.Tag = "MoveRoomDown";
-            this.wholeRoomDownToolStripMenuItem.Text = "MoveRoomDown";
+            wholeRoomDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            wholeRoomDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            wholeRoomDownToolStripMenuItem.Name = "wholeRoomDownToolStripMenuItem";
+            wholeRoomDownToolStripMenuItem.Size = new System.Drawing.Size(227, 24);
+            wholeRoomDownToolStripMenuItem.Tag = "MoveRoomDown";
+            wholeRoomDownToolStripMenuItem.Text = "MoveRoomDown";
             // 
             // moveRoomDown4ClicksToolStripMenuItem
             // 
-            this.moveRoomDown4ClicksToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.moveRoomDown4ClicksToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.moveRoomDown4ClicksToolStripMenuItem.Name = "moveRoomDown4ClicksToolStripMenuItem";
-            this.moveRoomDown4ClicksToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
-            this.moveRoomDown4ClicksToolStripMenuItem.Tag = "MoveRoomDown4Clicks";
-            this.moveRoomDown4ClicksToolStripMenuItem.Text = "MoveRoomDown4Clicks";
+            moveRoomDown4ClicksToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            moveRoomDown4ClicksToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            moveRoomDown4ClicksToolStripMenuItem.Name = "moveRoomDown4ClicksToolStripMenuItem";
+            moveRoomDown4ClicksToolStripMenuItem.Size = new System.Drawing.Size(227, 24);
+            moveRoomDown4ClicksToolStripMenuItem.Tag = "MoveRoomDown4Clicks";
+            moveRoomDown4ClicksToolStripMenuItem.Text = "MoveRoomDown4Clicks";
             // 
             // moveRoomLeftToolStripMenuItem
             // 
-            this.moveRoomLeftToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.moveRoomLeftToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.moveRoomLeftToolStripMenuItem.Name = "moveRoomLeftToolStripMenuItem";
-            this.moveRoomLeftToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
-            this.moveRoomLeftToolStripMenuItem.Tag = "MoveRoomLeft";
-            this.moveRoomLeftToolStripMenuItem.Text = "MoveRoomLeft";
+            moveRoomLeftToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            moveRoomLeftToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            moveRoomLeftToolStripMenuItem.Name = "moveRoomLeftToolStripMenuItem";
+            moveRoomLeftToolStripMenuItem.Size = new System.Drawing.Size(227, 24);
+            moveRoomLeftToolStripMenuItem.Tag = "MoveRoomLeft";
+            moveRoomLeftToolStripMenuItem.Text = "MoveRoomLeft";
             // 
             // moveRoomRightToolStripMenuItem
             // 
-            this.moveRoomRightToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.moveRoomRightToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.moveRoomRightToolStripMenuItem.Name = "moveRoomRightToolStripMenuItem";
-            this.moveRoomRightToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
-            this.moveRoomRightToolStripMenuItem.Tag = "MoveRoomRight";
-            this.moveRoomRightToolStripMenuItem.Text = "MoveRoomRight";
+            moveRoomRightToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            moveRoomRightToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            moveRoomRightToolStripMenuItem.Name = "moveRoomRightToolStripMenuItem";
+            moveRoomRightToolStripMenuItem.Size = new System.Drawing.Size(227, 24);
+            moveRoomRightToolStripMenuItem.Tag = "MoveRoomRight";
+            moveRoomRightToolStripMenuItem.Text = "MoveRoomRight";
             // 
             // moveRoomForwardToolStripMenuItem
             // 
-            this.moveRoomForwardToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.moveRoomForwardToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.moveRoomForwardToolStripMenuItem.Name = "moveRoomForwardToolStripMenuItem";
-            this.moveRoomForwardToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
-            this.moveRoomForwardToolStripMenuItem.Tag = "MoveRoomForward";
-            this.moveRoomForwardToolStripMenuItem.Text = "MoveRoomForward";
+            moveRoomForwardToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            moveRoomForwardToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            moveRoomForwardToolStripMenuItem.Name = "moveRoomForwardToolStripMenuItem";
+            moveRoomForwardToolStripMenuItem.Size = new System.Drawing.Size(227, 24);
+            moveRoomForwardToolStripMenuItem.Tag = "MoveRoomForward";
+            moveRoomForwardToolStripMenuItem.Text = "MoveRoomForward";
             // 
             // moveRoomBackToolStripMenuItem
             // 
-            this.moveRoomBackToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.moveRoomBackToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.moveRoomBackToolStripMenuItem.Name = "moveRoomBackToolStripMenuItem";
-            this.moveRoomBackToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
-            this.moveRoomBackToolStripMenuItem.Tag = "MoveRoomBack";
-            this.moveRoomBackToolStripMenuItem.Text = "MoveRoomBack";
+            moveRoomBackToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            moveRoomBackToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            moveRoomBackToolStripMenuItem.Name = "moveRoomBackToolStripMenuItem";
+            moveRoomBackToolStripMenuItem.Size = new System.Drawing.Size(227, 24);
+            moveRoomBackToolStripMenuItem.Tag = "MoveRoomBack";
+            moveRoomBackToolStripMenuItem.Text = "MoveRoomBack";
             // 
             // transformRoomsToolStripMenuItem
             // 
-            this.transformRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.transformRoomsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.rotateRoomsToolStripMenuItem,
-            this.rotateRoomsCountercockwiseToolStripMenuItem,
-            this.mirrorRoomsOnXAxisToolStripMenuItem,
-            this.mirrorRoomsOnZAxisToolStripMenuItem});
-            this.transformRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.transformRoomsToolStripMenuItem.Name = "transformRoomsToolStripMenuItem";
-            this.transformRoomsToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.transformRoomsToolStripMenuItem.Text = "Transform rooms";
+            transformRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            transformRoomsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { rotateRoomsToolStripMenuItem, rotateRoomsCountercockwiseToolStripMenuItem, mirrorRoomsOnXAxisToolStripMenuItem, mirrorRoomsOnZAxisToolStripMenuItem });
+            transformRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            transformRoomsToolStripMenuItem.Name = "transformRoomsToolStripMenuItem";
+            transformRoomsToolStripMenuItem.Size = new System.Drawing.Size(233, 24);
+            transformRoomsToolStripMenuItem.Text = "Transform rooms";
             // 
             // rotateRoomsToolStripMenuItem
             // 
-            this.rotateRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.rotateRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.rotateRoomsToolStripMenuItem.Name = "rotateRoomsToolStripMenuItem";
-            this.rotateRoomsToolStripMenuItem.Size = new System.Drawing.Size(241, 22);
-            this.rotateRoomsToolStripMenuItem.Tag = "RotateRoomsClockwise";
-            this.rotateRoomsToolStripMenuItem.Text = "RotateRoomsClockwise";
+            rotateRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            rotateRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            rotateRoomsToolStripMenuItem.Name = "rotateRoomsToolStripMenuItem";
+            rotateRoomsToolStripMenuItem.Size = new System.Drawing.Size(269, 24);
+            rotateRoomsToolStripMenuItem.Tag = "RotateRoomsClockwise";
+            rotateRoomsToolStripMenuItem.Text = "RotateRoomsClockwise";
             // 
             // rotateRoomsCountercockwiseToolStripMenuItem
             // 
-            this.rotateRoomsCountercockwiseToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.rotateRoomsCountercockwiseToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.rotateRoomsCountercockwiseToolStripMenuItem.Name = "rotateRoomsCountercockwiseToolStripMenuItem";
-            this.rotateRoomsCountercockwiseToolStripMenuItem.Size = new System.Drawing.Size(241, 22);
-            this.rotateRoomsCountercockwiseToolStripMenuItem.Tag = "RotateRoomsCounterClockwise";
-            this.rotateRoomsCountercockwiseToolStripMenuItem.Text = "RotateRoomsCounterClockwise";
+            rotateRoomsCountercockwiseToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            rotateRoomsCountercockwiseToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            rotateRoomsCountercockwiseToolStripMenuItem.Name = "rotateRoomsCountercockwiseToolStripMenuItem";
+            rotateRoomsCountercockwiseToolStripMenuItem.Size = new System.Drawing.Size(269, 24);
+            rotateRoomsCountercockwiseToolStripMenuItem.Tag = "RotateRoomsCounterClockwise";
+            rotateRoomsCountercockwiseToolStripMenuItem.Text = "RotateRoomsCounterClockwise";
             // 
             // mirrorRoomsOnXAxisToolStripMenuItem
             // 
-            this.mirrorRoomsOnXAxisToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.mirrorRoomsOnXAxisToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.mirrorRoomsOnXAxisToolStripMenuItem.Name = "mirrorRoomsOnXAxisToolStripMenuItem";
-            this.mirrorRoomsOnXAxisToolStripMenuItem.Size = new System.Drawing.Size(241, 22);
-            this.mirrorRoomsOnXAxisToolStripMenuItem.Tag = "MirrorRoomsX";
-            this.mirrorRoomsOnXAxisToolStripMenuItem.Text = "MirrorRoomsX";
+            mirrorRoomsOnXAxisToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            mirrorRoomsOnXAxisToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            mirrorRoomsOnXAxisToolStripMenuItem.Name = "mirrorRoomsOnXAxisToolStripMenuItem";
+            mirrorRoomsOnXAxisToolStripMenuItem.Size = new System.Drawing.Size(269, 24);
+            mirrorRoomsOnXAxisToolStripMenuItem.Tag = "MirrorRoomsX";
+            mirrorRoomsOnXAxisToolStripMenuItem.Text = "MirrorRoomsX";
             // 
             // mirrorRoomsOnZAxisToolStripMenuItem
             // 
-            this.mirrorRoomsOnZAxisToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.mirrorRoomsOnZAxisToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.mirrorRoomsOnZAxisToolStripMenuItem.Name = "mirrorRoomsOnZAxisToolStripMenuItem";
-            this.mirrorRoomsOnZAxisToolStripMenuItem.Size = new System.Drawing.Size(241, 22);
-            this.mirrorRoomsOnZAxisToolStripMenuItem.Tag = "MirrorRoomsZ";
-            this.mirrorRoomsOnZAxisToolStripMenuItem.Text = "MirrorRoomsZ";
+            mirrorRoomsOnZAxisToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            mirrorRoomsOnZAxisToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            mirrorRoomsOnZAxisToolStripMenuItem.Name = "mirrorRoomsOnZAxisToolStripMenuItem";
+            mirrorRoomsOnZAxisToolStripMenuItem.Size = new System.Drawing.Size(269, 24);
+            mirrorRoomsOnZAxisToolStripMenuItem.Tag = "MirrorRoomsZ";
+            mirrorRoomsOnZAxisToolStripMenuItem.Text = "MirrorRoomsZ";
             // 
             // selectRoomsToolStripMenuItem
             // 
-            this.selectRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.selectRoomsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.selectWaterRoomsToolStripMenuItem,
-            this.selectSkyRoomsToolStripMenuItem,
-            this.selectOutsideRoomsToolStripMenuItem,
-            this.selectToolStripMenuItem,
-            this.toolStripSeparator6,
-            this.selectConnectedRoomsToolStripMenuItem,
-            this.selectRoomsByTagsToolStripMenuItem});
-            this.selectRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.selectRoomsToolStripMenuItem.Name = "selectRoomsToolStripMenuItem";
-            this.selectRoomsToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.selectRoomsToolStripMenuItem.Text = "Select rooms";
+            selectRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            selectRoomsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { selectWaterRoomsToolStripMenuItem, selectSkyRoomsToolStripMenuItem, selectOutsideRoomsToolStripMenuItem, selectToolStripMenuItem, toolStripSeparator6, selectConnectedRoomsToolStripMenuItem, selectRoomsByTagsToolStripMenuItem });
+            selectRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            selectRoomsToolStripMenuItem.Name = "selectRoomsToolStripMenuItem";
+            selectRoomsToolStripMenuItem.Size = new System.Drawing.Size(233, 24);
+            selectRoomsToolStripMenuItem.Text = "Select rooms";
             // 
             // selectWaterRoomsToolStripMenuItem
             // 
-            this.selectWaterRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.selectWaterRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.selectWaterRoomsToolStripMenuItem.Name = "selectWaterRoomsToolStripMenuItem";
-            this.selectWaterRoomsToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.selectWaterRoomsToolStripMenuItem.Tag = "SelectWaterRooms";
-            this.selectWaterRoomsToolStripMenuItem.Text = "SelectWaterRooms";
+            selectWaterRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            selectWaterRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            selectWaterRoomsToolStripMenuItem.Name = "selectWaterRoomsToolStripMenuItem";
+            selectWaterRoomsToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            selectWaterRoomsToolStripMenuItem.Tag = "SelectWaterRooms";
+            selectWaterRoomsToolStripMenuItem.Text = "SelectWaterRooms";
             // 
             // selectSkyRoomsToolStripMenuItem
             // 
-            this.selectSkyRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.selectSkyRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.selectSkyRoomsToolStripMenuItem.Name = "selectSkyRoomsToolStripMenuItem";
-            this.selectSkyRoomsToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.selectSkyRoomsToolStripMenuItem.Tag = "SelectSkyRooms";
-            this.selectSkyRoomsToolStripMenuItem.Text = "SelectSkyRooms";
+            selectSkyRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            selectSkyRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            selectSkyRoomsToolStripMenuItem.Name = "selectSkyRoomsToolStripMenuItem";
+            selectSkyRoomsToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            selectSkyRoomsToolStripMenuItem.Tag = "SelectSkyRooms";
+            selectSkyRoomsToolStripMenuItem.Text = "SelectSkyRooms";
             // 
             // selectOutsideRoomsToolStripMenuItem
             // 
-            this.selectOutsideRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.selectOutsideRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.selectOutsideRoomsToolStripMenuItem.Name = "selectOutsideRoomsToolStripMenuItem";
-            this.selectOutsideRoomsToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.selectOutsideRoomsToolStripMenuItem.Tag = "SelectOutsideRooms";
-            this.selectOutsideRoomsToolStripMenuItem.Text = "SelectOutsideRooms";
+            selectOutsideRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            selectOutsideRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            selectOutsideRoomsToolStripMenuItem.Name = "selectOutsideRoomsToolStripMenuItem";
+            selectOutsideRoomsToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            selectOutsideRoomsToolStripMenuItem.Tag = "SelectOutsideRooms";
+            selectOutsideRoomsToolStripMenuItem.Text = "SelectOutsideRooms";
             // 
             // selectToolStripMenuItem
             // 
-            this.selectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.selectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.selectToolStripMenuItem.Name = "selectToolStripMenuItem";
-            this.selectToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.selectToolStripMenuItem.Tag = "SelectQuicksandRooms";
-            this.selectToolStripMenuItem.Text = "SelectQuicksandRooms";
+            selectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            selectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            selectToolStripMenuItem.Name = "selectToolStripMenuItem";
+            selectToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            selectToolStripMenuItem.Tag = "SelectQuicksandRooms";
+            selectToolStripMenuItem.Text = "SelectQuicksandRooms";
             // 
             // toolStripSeparator6
             // 
-            this.toolStripSeparator6.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripSeparator6.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator6.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(197, 6);
+            toolStripSeparator6.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripSeparator6.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator6.Margin = new Padding(0, 0, 0, 1);
+            toolStripSeparator6.Name = "toolStripSeparator6";
+            toolStripSeparator6.Size = new System.Drawing.Size(218, 6);
             // 
             // selectConnectedRoomsToolStripMenuItem
             // 
-            this.selectConnectedRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.selectConnectedRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.selectConnectedRoomsToolStripMenuItem.Name = "selectConnectedRoomsToolStripMenuItem";
-            this.selectConnectedRoomsToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.selectConnectedRoomsToolStripMenuItem.Tag = "SelectConnectedRooms";
-            this.selectConnectedRoomsToolStripMenuItem.Text = "SelectConnectedRooms";
+            selectConnectedRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            selectConnectedRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            selectConnectedRoomsToolStripMenuItem.Name = "selectConnectedRoomsToolStripMenuItem";
+            selectConnectedRoomsToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            selectConnectedRoomsToolStripMenuItem.Tag = "SelectConnectedRooms";
+            selectConnectedRoomsToolStripMenuItem.Text = "SelectConnectedRooms";
             // 
             // selectRoomsByTagsToolStripMenuItem
             // 
-            this.selectRoomsByTagsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.selectRoomsByTagsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.selectRoomsByTagsToolStripMenuItem.Name = "selectRoomsByTagsToolStripMenuItem";
-            this.selectRoomsByTagsToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.selectRoomsByTagsToolStripMenuItem.Tag = "SelectRoomsByTags";
-            this.selectRoomsByTagsToolStripMenuItem.Text = "SelectRoomsByTags";
+            selectRoomsByTagsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            selectRoomsByTagsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            selectRoomsByTagsToolStripMenuItem.Name = "selectRoomsByTagsToolStripMenuItem";
+            selectRoomsByTagsToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            selectRoomsByTagsToolStripMenuItem.Tag = "SelectRoomsByTags";
+            selectRoomsByTagsToolStripMenuItem.Text = "SelectRoomsByTags";
             // 
             // toolStripMenuItem1
             // 
-            this.toolStripMenuItem1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuItem1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuItem1.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(206, 6);
+            toolStripMenuItem1.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuItem1.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuItem1.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuItem1.Name = "toolStripMenuItem1";
+            toolStripMenuItem1.Size = new System.Drawing.Size(230, 6);
             // 
             // exportRoomToolStripMenuItem
             // 
-            this.exportRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.exportRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.exportRoomToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_Export_16;
-            this.exportRoomToolStripMenuItem.Name = "exportRoomToolStripMenuItem";
-            this.exportRoomToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.exportRoomToolStripMenuItem.Tag = "ExportRooms";
-            this.exportRoomToolStripMenuItem.Text = "ExportRooms";
+            exportRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            exportRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            exportRoomToolStripMenuItem.Image = Properties.Resources.general_Export_16;
+            exportRoomToolStripMenuItem.Name = "exportRoomToolStripMenuItem";
+            exportRoomToolStripMenuItem.Size = new System.Drawing.Size(233, 24);
+            exportRoomToolStripMenuItem.Tag = "ExportRooms";
+            exportRoomToolStripMenuItem.Text = "ExportRooms";
             // 
             // importRoomsToolStripMenuItem
             // 
-            this.importRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.importRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.importRoomsToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_Import_16;
-            this.importRoomsToolStripMenuItem.Name = "importRoomsToolStripMenuItem";
-            this.importRoomsToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.importRoomsToolStripMenuItem.Tag = "ImportRooms";
-            this.importRoomsToolStripMenuItem.Text = "ImportRooms";
-            this.importRoomsToolStripMenuItem.Visible = false;
+            importRoomsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            importRoomsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            importRoomsToolStripMenuItem.Image = Properties.Resources.general_Import_16;
+            importRoomsToolStripMenuItem.Name = "importRoomsToolStripMenuItem";
+            importRoomsToolStripMenuItem.Size = new System.Drawing.Size(233, 24);
+            importRoomsToolStripMenuItem.Tag = "ImportRooms";
+            importRoomsToolStripMenuItem.Text = "ImportRooms";
+            importRoomsToolStripMenuItem.Visible = false;
             // 
             // toolStripMenuItem9
             // 
-            this.toolStripMenuItem9.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuItem9.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuItem9.Name = "toolStripMenuItem9";
-            this.toolStripMenuItem9.Size = new System.Drawing.Size(209, 22);
-            this.toolStripMenuItem9.Tag = "ApplyRoomProperties";
-            this.toolStripMenuItem9.Text = "ApplyRoomProperties";
+            toolStripMenuItem9.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuItem9.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuItem9.Name = "toolStripMenuItem9";
+            toolStripMenuItem9.Size = new System.Drawing.Size(233, 24);
+            toolStripMenuItem9.Tag = "ApplyRoomProperties";
+            toolStripMenuItem9.Text = "ApplyRoomProperties";
             // 
             // itemsToolStripMenuItem
             // 
-            this.itemsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.itemsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.addWadToolStripMenuItem,
-            this.removeWadsToolStripMenuItem,
-            this.reloadWadsToolStripMenuItem,
-            this.reloadSoundsToolStripMenuItem,
-            this.toolStripMenuSeparator6,
-            this.toolStripMenuItem8,
-            this.addPortalToolStripMenuItem,
-            this.addTriggerToolStripMenuItem,
-            this.addBoxVolumeToolStripMenuItem,
-            this.addSphereVolumeToolStripMenuItem,
-            this.toolStripSeparator7,
-            this.deleteAllToolStripMenuItem,
-            this.toolStripMenuSeparator8,
-            this.findObjectToolStripMenuItem,
-            this.moveLaraToolStripMenuItem,
-            this.selectItemsInSelectedAreaToolStripMenuItem,
-            this.selectFloorBelowObjectToolStripMenuItem,
-            this.splitSectorObjectOnSelectionToolStripMenuItem,
-            this.toolStripSeparator3,
-            this.setStaticMeshColorToRoomLightToolStripMenuItem,
-            this.toolStripMenuItem10,
-            this.toolStripSeparator9,
-            this.makeQuickItemGroupToolStripMenuItem,
-            this.getObjectStatisticsToolStripMenuItem,
-            this.generateObjectNamesToolStripMenuItem});
-            this.itemsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.itemsToolStripMenuItem.Name = "itemsToolStripMenuItem";
-            this.itemsToolStripMenuItem.Size = new System.Drawing.Size(48, 25);
-            this.itemsToolStripMenuItem.Text = "Items";
+            itemsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            itemsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { addWadToolStripMenuItem, removeWadsToolStripMenuItem, reloadWadsToolStripMenuItem, reloadSoundsToolStripMenuItem, toolStripMenuSeparator6, toolStripMenuItem8, addPortalToolStripMenuItem, addTriggerToolStripMenuItem, addBoxVolumeToolStripMenuItem, addSphereVolumeToolStripMenuItem, toolStripSeparator7, deleteAllToolStripMenuItem, toolStripMenuSeparator8, findObjectToolStripMenuItem, moveLaraToolStripMenuItem, selectItemsInSelectedAreaToolStripMenuItem, selectFloorBelowObjectToolStripMenuItem, splitSectorObjectOnSelectionToolStripMenuItem, toolStripSeparator3, setStaticMeshColorToRoomLightToolStripMenuItem, toolStripMenuItem10, toolStripSeparator9, makeQuickItemGroupToolStripMenuItem, getObjectStatisticsToolStripMenuItem, generateObjectNamesToolStripMenuItem });
+            itemsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            itemsToolStripMenuItem.Name = "itemsToolStripMenuItem";
+            itemsToolStripMenuItem.Size = new System.Drawing.Size(55, 25);
+            itemsToolStripMenuItem.Text = "Items";
             // 
             // addWadToolStripMenuItem
             // 
-            this.addWadToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addWadToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addWadToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_plus_math_16;
-            this.addWadToolStripMenuItem.Name = "addWadToolStripMenuItem";
-            this.addWadToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.addWadToolStripMenuItem.Tag = "AddWad";
-            this.addWadToolStripMenuItem.Text = "AddWad";
+            addWadToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addWadToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addWadToolStripMenuItem.Image = Properties.Resources.general_plus_math_16;
+            addWadToolStripMenuItem.Name = "addWadToolStripMenuItem";
+            addWadToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            addWadToolStripMenuItem.Tag = "AddWad";
+            addWadToolStripMenuItem.Text = "AddWad";
             // 
             // removeWadsToolStripMenuItem
             // 
-            this.removeWadsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.removeWadsToolStripMenuItem.Enabled = false;
-            this.removeWadsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.removeWadsToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_trash_16;
-            this.removeWadsToolStripMenuItem.Name = "removeWadsToolStripMenuItem";
-            this.removeWadsToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.removeWadsToolStripMenuItem.Tag = "RemoveWads";
-            this.removeWadsToolStripMenuItem.Text = "RemoveWads";
+            removeWadsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            removeWadsToolStripMenuItem.Enabled = false;
+            removeWadsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            removeWadsToolStripMenuItem.Image = Properties.Resources.general_trash_16;
+            removeWadsToolStripMenuItem.Name = "removeWadsToolStripMenuItem";
+            removeWadsToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            removeWadsToolStripMenuItem.Tag = "RemoveWads";
+            removeWadsToolStripMenuItem.Text = "RemoveWads";
             // 
             // reloadWadsToolStripMenuItem
             // 
-            this.reloadWadsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.reloadWadsToolStripMenuItem.Enabled = false;
-            this.reloadWadsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.reloadWadsToolStripMenuItem.Name = "reloadWadsToolStripMenuItem";
-            this.reloadWadsToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.reloadWadsToolStripMenuItem.Tag = "ReloadWads";
-            this.reloadWadsToolStripMenuItem.Text = "ReloadWads";
+            reloadWadsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            reloadWadsToolStripMenuItem.Enabled = false;
+            reloadWadsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            reloadWadsToolStripMenuItem.Name = "reloadWadsToolStripMenuItem";
+            reloadWadsToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            reloadWadsToolStripMenuItem.Tag = "ReloadWads";
+            reloadWadsToolStripMenuItem.Text = "ReloadWads";
             // 
             // reloadSoundsToolStripMenuItem
             // 
-            this.reloadSoundsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.reloadSoundsToolStripMenuItem.Enabled = false;
-            this.reloadSoundsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.reloadSoundsToolStripMenuItem.Name = "reloadSoundsToolStripMenuItem";
-            this.reloadSoundsToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.reloadSoundsToolStripMenuItem.Tag = "ReloadSounds";
-            this.reloadSoundsToolStripMenuItem.Text = "ReloadSounds";
+            reloadSoundsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            reloadSoundsToolStripMenuItem.Enabled = false;
+            reloadSoundsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            reloadSoundsToolStripMenuItem.Name = "reloadSoundsToolStripMenuItem";
+            reloadSoundsToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            reloadSoundsToolStripMenuItem.Tag = "ReloadSounds";
+            reloadSoundsToolStripMenuItem.Text = "ReloadSounds";
             // 
             // toolStripMenuSeparator6
             // 
-            this.toolStripMenuSeparator6.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuSeparator6.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator6.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator6.Name = "toolStripMenuSeparator6";
-            this.toolStripMenuSeparator6.Size = new System.Drawing.Size(256, 6);
+            toolStripMenuSeparator6.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuSeparator6.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator6.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator6.Name = "toolStripMenuSeparator6";
+            toolStripMenuSeparator6.Size = new System.Drawing.Size(288, 6);
             // 
             // toolStripMenuItem8
             // 
-            this.toolStripMenuItem8.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuItem8.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.addCameraToolStripMenuItem,
-            this.addFlybyCameraToolStripMenuItem,
-            this.addSpriteToolStripMenuItem,
-            this.addSinkToolStripMenuItem,
-            this.addSoundSourceToolStripMenuItem,
-            this.addImportedGeometryToolStripMenuItem,
-            this.addGhostBlockToolStripMenuItem,
-            this.addMemoToolStripMenuItem});
-            this.toolStripMenuItem8.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuItem8.Name = "toolStripMenuItem8";
-            this.toolStripMenuItem8.Size = new System.Drawing.Size(259, 22);
-            this.toolStripMenuItem8.Text = "Add item";
+            toolStripMenuItem8.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuItem8.DropDownItems.AddRange(new ToolStripItem[] { addCameraToolStripMenuItem, addFlybyCameraToolStripMenuItem, addSpriteToolStripMenuItem, addSinkToolStripMenuItem, addSoundSourceToolStripMenuItem, addImportedGeometryToolStripMenuItem, addGhostBlockToolStripMenuItem, addMemoToolStripMenuItem });
+            toolStripMenuItem8.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuItem8.Name = "toolStripMenuItem8";
+            toolStripMenuItem8.Size = new System.Drawing.Size(291, 24);
+            toolStripMenuItem8.Text = "Add item";
             // 
             // addCameraToolStripMenuItem
             // 
-            this.addCameraToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addCameraToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addCameraToolStripMenuItem.Image = global::TombEditor.Properties.Resources.objects_Camera_16;
-            this.addCameraToolStripMenuItem.Name = "addCameraToolStripMenuItem";
-            this.addCameraToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
-            this.addCameraToolStripMenuItem.Tag = "AddCamera";
-            this.addCameraToolStripMenuItem.Text = "AddCamera";
+            addCameraToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addCameraToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addCameraToolStripMenuItem.Image = Properties.Resources.objects_Camera_16;
+            addCameraToolStripMenuItem.Name = "addCameraToolStripMenuItem";
+            addCameraToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            addCameraToolStripMenuItem.Tag = "AddCamera";
+            addCameraToolStripMenuItem.Text = "AddCamera";
             // 
             // addFlybyCameraToolStripMenuItem
             // 
-            this.addFlybyCameraToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addFlybyCameraToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addFlybyCameraToolStripMenuItem.Image = global::TombEditor.Properties.Resources.objects_movie_projector_16;
-            this.addFlybyCameraToolStripMenuItem.Name = "addFlybyCameraToolStripMenuItem";
-            this.addFlybyCameraToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
-            this.addFlybyCameraToolStripMenuItem.Tag = "AddFlybyCamera";
-            this.addFlybyCameraToolStripMenuItem.Text = "AddFlybyCamera";
+            addFlybyCameraToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addFlybyCameraToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addFlybyCameraToolStripMenuItem.Image = Properties.Resources.objects_movie_projector_16;
+            addFlybyCameraToolStripMenuItem.Name = "addFlybyCameraToolStripMenuItem";
+            addFlybyCameraToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            addFlybyCameraToolStripMenuItem.Tag = "AddFlybyCamera";
+            addFlybyCameraToolStripMenuItem.Text = "AddFlybyCamera";
             // 
             // addSpriteToolStripMenuItem
             // 
-            this.addSpriteToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addSpriteToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addSpriteToolStripMenuItem.Image = global::TombEditor.Properties.Resources.objects_Sprite_16;
-            this.addSpriteToolStripMenuItem.Name = "addSpriteToolStripMenuItem";
-            this.addSpriteToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
-            this.addSpriteToolStripMenuItem.Tag = "AddSprite";
-            this.addSpriteToolStripMenuItem.Text = "AddSprite";
+            addSpriteToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addSpriteToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addSpriteToolStripMenuItem.Image = Properties.Resources.objects_Sprite_16;
+            addSpriteToolStripMenuItem.Name = "addSpriteToolStripMenuItem";
+            addSpriteToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            addSpriteToolStripMenuItem.Tag = "AddSprite";
+            addSpriteToolStripMenuItem.Text = "AddSprite";
             // 
             // addSinkToolStripMenuItem
             // 
-            this.addSinkToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addSinkToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addSinkToolStripMenuItem.Image = global::TombEditor.Properties.Resources.objects_tornado_16;
-            this.addSinkToolStripMenuItem.Name = "addSinkToolStripMenuItem";
-            this.addSinkToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
-            this.addSinkToolStripMenuItem.Tag = "AddSink";
-            this.addSinkToolStripMenuItem.Text = "AddSink";
+            addSinkToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addSinkToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addSinkToolStripMenuItem.Image = Properties.Resources.objects_tornado_16;
+            addSinkToolStripMenuItem.Name = "addSinkToolStripMenuItem";
+            addSinkToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            addSinkToolStripMenuItem.Tag = "AddSink";
+            addSinkToolStripMenuItem.Text = "AddSink";
             // 
             // addSoundSourceToolStripMenuItem
             // 
-            this.addSoundSourceToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addSoundSourceToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addSoundSourceToolStripMenuItem.Image = global::TombEditor.Properties.Resources.objects_speaker_16;
-            this.addSoundSourceToolStripMenuItem.Name = "addSoundSourceToolStripMenuItem";
-            this.addSoundSourceToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
-            this.addSoundSourceToolStripMenuItem.Tag = "AddSoundSource";
-            this.addSoundSourceToolStripMenuItem.Text = "AddSoundSource";
+            addSoundSourceToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addSoundSourceToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addSoundSourceToolStripMenuItem.Image = Properties.Resources.objects_speaker_16;
+            addSoundSourceToolStripMenuItem.Name = "addSoundSourceToolStripMenuItem";
+            addSoundSourceToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            addSoundSourceToolStripMenuItem.Tag = "AddSoundSource";
+            addSoundSourceToolStripMenuItem.Text = "AddSoundSource";
             // 
             // addImportedGeometryToolStripMenuItem
             // 
-            this.addImportedGeometryToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addImportedGeometryToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addImportedGeometryToolStripMenuItem.Image = global::TombEditor.Properties.Resources.objects_custom_geometry;
-            this.addImportedGeometryToolStripMenuItem.Name = "addImportedGeometryToolStripMenuItem";
-            this.addImportedGeometryToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
-            this.addImportedGeometryToolStripMenuItem.Tag = "AddImportedGeometry";
-            this.addImportedGeometryToolStripMenuItem.Text = "AddImportedGeometry";
+            addImportedGeometryToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addImportedGeometryToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addImportedGeometryToolStripMenuItem.Image = Properties.Resources.objects_custom_geometry;
+            addImportedGeometryToolStripMenuItem.Name = "addImportedGeometryToolStripMenuItem";
+            addImportedGeometryToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            addImportedGeometryToolStripMenuItem.Tag = "AddImportedGeometry";
+            addImportedGeometryToolStripMenuItem.Text = "AddImportedGeometry";
             // 
             // addGhostBlockToolStripMenuItem
             // 
-            this.addGhostBlockToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addGhostBlockToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addGhostBlockToolStripMenuItem.Image = global::TombEditor.Properties.Resources.objects_geometry_override_16;
-            this.addGhostBlockToolStripMenuItem.Name = "addGhostBlockToolStripMenuItem";
-            this.addGhostBlockToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
-            this.addGhostBlockToolStripMenuItem.Tag = "AddGhostBlock";
-            this.addGhostBlockToolStripMenuItem.Text = "AddGhostBlock";
+            addGhostBlockToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addGhostBlockToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addGhostBlockToolStripMenuItem.Image = Properties.Resources.objects_geometry_override_16;
+            addGhostBlockToolStripMenuItem.Name = "addGhostBlockToolStripMenuItem";
+            addGhostBlockToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            addGhostBlockToolStripMenuItem.Tag = "AddGhostBlock";
+            addGhostBlockToolStripMenuItem.Text = "AddGhostBlock";
             // 
             // addMemoToolStripMenuItem
             // 
-            this.addMemoToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addMemoToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addMemoToolStripMenuItem.Image = global::TombEditor.Properties.Resources.objects_Memo_16;
-            this.addMemoToolStripMenuItem.Name = "addMemoToolStripMenuItem";
-            this.addMemoToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
-            this.addMemoToolStripMenuItem.Tag = "AddMemo";
-            this.addMemoToolStripMenuItem.Text = "AddMemo";
+            addMemoToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addMemoToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addMemoToolStripMenuItem.Image = Properties.Resources.objects_Memo_16;
+            addMemoToolStripMenuItem.Name = "addMemoToolStripMenuItem";
+            addMemoToolStripMenuItem.Size = new System.Drawing.Size(221, 24);
+            addMemoToolStripMenuItem.Tag = "AddMemo";
+            addMemoToolStripMenuItem.Text = "AddMemo";
             // 
             // addPortalToolStripMenuItem
             // 
-            this.addPortalToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addPortalToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addPortalToolStripMenuItem.Name = "addPortalToolStripMenuItem";
-            this.addPortalToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.addPortalToolStripMenuItem.Tag = "AddPortal";
-            this.addPortalToolStripMenuItem.Text = "AddPortal";
+            addPortalToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addPortalToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addPortalToolStripMenuItem.Name = "addPortalToolStripMenuItem";
+            addPortalToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            addPortalToolStripMenuItem.Tag = "AddPortal";
+            addPortalToolStripMenuItem.Text = "AddPortal";
             // 
             // addTriggerToolStripMenuItem
             // 
-            this.addTriggerToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addTriggerToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addTriggerToolStripMenuItem.Name = "addTriggerToolStripMenuItem";
-            this.addTriggerToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.addTriggerToolStripMenuItem.Tag = "AddTrigger";
-            this.addTriggerToolStripMenuItem.Text = "AddTrigger";
+            addTriggerToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addTriggerToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addTriggerToolStripMenuItem.Name = "addTriggerToolStripMenuItem";
+            addTriggerToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            addTriggerToolStripMenuItem.Tag = "AddTrigger";
+            addTriggerToolStripMenuItem.Text = "AddTrigger";
             // 
             // addBoxVolumeToolStripMenuItem
             // 
-            this.addBoxVolumeToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addBoxVolumeToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addBoxVolumeToolStripMenuItem.Image = global::TombEditor.Properties.Resources.objects_volume_box_16;
-            this.addBoxVolumeToolStripMenuItem.Name = "addBoxVolumeToolStripMenuItem";
-            this.addBoxVolumeToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.addBoxVolumeToolStripMenuItem.Tag = "AddBoxVolume";
-            this.addBoxVolumeToolStripMenuItem.Text = "AddBoxVolume";
-            this.addBoxVolumeToolStripMenuItem.Visible = false;
+            addBoxVolumeToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addBoxVolumeToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addBoxVolumeToolStripMenuItem.Image = Properties.Resources.objects_volume_box_16;
+            addBoxVolumeToolStripMenuItem.Name = "addBoxVolumeToolStripMenuItem";
+            addBoxVolumeToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            addBoxVolumeToolStripMenuItem.Tag = "AddBoxVolume";
+            addBoxVolumeToolStripMenuItem.Text = "AddBoxVolume";
+            addBoxVolumeToolStripMenuItem.Visible = false;
             // 
             // addSphereVolumeToolStripMenuItem
             // 
-            this.addSphereVolumeToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.addSphereVolumeToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.addSphereVolumeToolStripMenuItem.Image = global::TombEditor.Properties.Resources.objects_volume_sphere_16;
-            this.addSphereVolumeToolStripMenuItem.Name = "addSphereVolumeToolStripMenuItem";
-            this.addSphereVolumeToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.addSphereVolumeToolStripMenuItem.Tag = "AddSphereVolume";
-            this.addSphereVolumeToolStripMenuItem.Text = "AddSphereVolume";
-            this.addSphereVolumeToolStripMenuItem.Visible = false;
+            addSphereVolumeToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            addSphereVolumeToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            addSphereVolumeToolStripMenuItem.Image = Properties.Resources.objects_volume_sphere_16;
+            addSphereVolumeToolStripMenuItem.Name = "addSphereVolumeToolStripMenuItem";
+            addSphereVolumeToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            addSphereVolumeToolStripMenuItem.Tag = "AddSphereVolume";
+            addSphereVolumeToolStripMenuItem.Text = "AddSphereVolume";
+            addSphereVolumeToolStripMenuItem.Visible = false;
             // 
             // toolStripSeparator7
             // 
-            this.toolStripSeparator7.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripSeparator7.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator7.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(256, 6);
+            toolStripSeparator7.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripSeparator7.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator7.Margin = new Padding(0, 0, 0, 1);
+            toolStripSeparator7.Name = "toolStripSeparator7";
+            toolStripSeparator7.Size = new System.Drawing.Size(288, 6);
             // 
             // deleteAllToolStripMenuItem
             // 
-            this.deleteAllToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.deleteAllToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.deleteAllLightsToolStripMenuItem,
-            this.toolStripMenuItem2,
-            this.deleteAllTriggersToolStripMenuItem,
-            this.deleteMissingObjectsToolStripMenuItem});
-            this.deleteAllToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.deleteAllToolStripMenuItem.Name = "deleteAllToolStripMenuItem";
-            this.deleteAllToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.deleteAllToolStripMenuItem.Text = "Delete...";
+            deleteAllToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            deleteAllToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { deleteAllLightsToolStripMenuItem, toolStripMenuItem2, deleteAllTriggersToolStripMenuItem, deleteMissingObjectsToolStripMenuItem });
+            deleteAllToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            deleteAllToolStripMenuItem.Name = "deleteAllToolStripMenuItem";
+            deleteAllToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            deleteAllToolStripMenuItem.Text = "Delete...";
             // 
             // deleteAllLightsToolStripMenuItem
             // 
-            this.deleteAllLightsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.deleteAllLightsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.deleteAllLightsToolStripMenuItem.Name = "deleteAllLightsToolStripMenuItem";
-            this.deleteAllLightsToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.deleteAllLightsToolStripMenuItem.Tag = "DeleteAllLights";
-            this.deleteAllLightsToolStripMenuItem.Text = "DeleteAllLights";
+            deleteAllLightsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            deleteAllLightsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            deleteAllLightsToolStripMenuItem.Name = "deleteAllLightsToolStripMenuItem";
+            deleteAllLightsToolStripMenuItem.Size = new System.Drawing.Size(210, 24);
+            deleteAllLightsToolStripMenuItem.Tag = "DeleteAllLights";
+            deleteAllLightsToolStripMenuItem.Text = "DeleteAllLights";
             // 
             // toolStripMenuItem2
             // 
-            this.toolStripMenuItem2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuItem2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(188, 22);
-            this.toolStripMenuItem2.Tag = "DeleteAllObjects";
-            this.toolStripMenuItem2.Text = "DeleteAllObjects";
+            toolStripMenuItem2.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuItem2.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuItem2.Name = "toolStripMenuItem2";
+            toolStripMenuItem2.Size = new System.Drawing.Size(210, 24);
+            toolStripMenuItem2.Tag = "DeleteAllObjects";
+            toolStripMenuItem2.Text = "DeleteAllObjects";
             // 
             // deleteAllTriggersToolStripMenuItem
             // 
-            this.deleteAllTriggersToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.deleteAllTriggersToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.deleteAllTriggersToolStripMenuItem.Name = "deleteAllTriggersToolStripMenuItem";
-            this.deleteAllTriggersToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.deleteAllTriggersToolStripMenuItem.Tag = "DeleteAllTriggers";
-            this.deleteAllTriggersToolStripMenuItem.Text = "DeleteAllTriggers";
+            deleteAllTriggersToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            deleteAllTriggersToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            deleteAllTriggersToolStripMenuItem.Name = "deleteAllTriggersToolStripMenuItem";
+            deleteAllTriggersToolStripMenuItem.Size = new System.Drawing.Size(210, 24);
+            deleteAllTriggersToolStripMenuItem.Tag = "DeleteAllTriggers";
+            deleteAllTriggersToolStripMenuItem.Text = "DeleteAllTriggers";
             // 
             // deleteMissingObjectsToolStripMenuItem
             // 
-            this.deleteMissingObjectsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.deleteMissingObjectsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.deleteMissingObjectsToolStripMenuItem.Name = "deleteMissingObjectsToolStripMenuItem";
-            this.deleteMissingObjectsToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.deleteMissingObjectsToolStripMenuItem.Tag = "DeleteMissingObjects";
-            this.deleteMissingObjectsToolStripMenuItem.Text = "DeleteMissingObjects";
+            deleteMissingObjectsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            deleteMissingObjectsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            deleteMissingObjectsToolStripMenuItem.Name = "deleteMissingObjectsToolStripMenuItem";
+            deleteMissingObjectsToolStripMenuItem.Size = new System.Drawing.Size(210, 24);
+            deleteMissingObjectsToolStripMenuItem.Tag = "DeleteMissingObjects";
+            deleteMissingObjectsToolStripMenuItem.Text = "DeleteMissingObjects";
             // 
             // toolStripMenuSeparator8
             // 
-            this.toolStripMenuSeparator8.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuSeparator8.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator8.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator8.Name = "toolStripMenuSeparator8";
-            this.toolStripMenuSeparator8.Size = new System.Drawing.Size(256, 6);
-            this.toolStripMenuSeparator8.Visible = false;
+            toolStripMenuSeparator8.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuSeparator8.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator8.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator8.Name = "toolStripMenuSeparator8";
+            toolStripMenuSeparator8.Size = new System.Drawing.Size(288, 6);
+            toolStripMenuSeparator8.Visible = false;
             // 
             // findObjectToolStripMenuItem
             // 
-            this.findObjectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.findObjectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.findObjectToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_target_16;
-            this.findObjectToolStripMenuItem.Name = "findObjectToolStripMenuItem";
-            this.findObjectToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.findObjectToolStripMenuItem.Tag = "LocateItem";
-            this.findObjectToolStripMenuItem.Text = "LocateItem";
+            findObjectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            findObjectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            findObjectToolStripMenuItem.Image = Properties.Resources.general_target_16;
+            findObjectToolStripMenuItem.Name = "findObjectToolStripMenuItem";
+            findObjectToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            findObjectToolStripMenuItem.Tag = "LocateItem";
+            findObjectToolStripMenuItem.Text = "LocateItem";
             // 
             // moveLaraToolStripMenuItem
             // 
-            this.moveLaraToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.moveLaraToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.moveLaraToolStripMenuItem.Name = "moveLaraToolStripMenuItem";
-            this.moveLaraToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.moveLaraToolStripMenuItem.Tag = "MoveLara";
-            this.moveLaraToolStripMenuItem.Text = "MoveLara";
+            moveLaraToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            moveLaraToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            moveLaraToolStripMenuItem.Name = "moveLaraToolStripMenuItem";
+            moveLaraToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            moveLaraToolStripMenuItem.Tag = "MoveLara";
+            moveLaraToolStripMenuItem.Text = "MoveLara";
             // 
             // selectItemsInSelectedAreaToolStripMenuItem
             // 
-            this.selectItemsInSelectedAreaToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.selectItemsInSelectedAreaToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.selectItemsInSelectedAreaToolStripMenuItem.Name = "selectItemsInSelectedAreaToolStripMenuItem";
-            this.selectItemsInSelectedAreaToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.selectItemsInSelectedAreaToolStripMenuItem.Tag = "SelectAllObjectsInArea";
-            this.selectItemsInSelectedAreaToolStripMenuItem.Text = "SelectAllObjectsInArea";
+            selectItemsInSelectedAreaToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            selectItemsInSelectedAreaToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            selectItemsInSelectedAreaToolStripMenuItem.Name = "selectItemsInSelectedAreaToolStripMenuItem";
+            selectItemsInSelectedAreaToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            selectItemsInSelectedAreaToolStripMenuItem.Tag = "SelectAllObjectsInArea";
+            selectItemsInSelectedAreaToolStripMenuItem.Text = "SelectAllObjectsInArea";
             // 
             // selectFloorBelowObjectToolStripMenuItem
             // 
-            this.selectFloorBelowObjectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.selectFloorBelowObjectToolStripMenuItem.Enabled = false;
-            this.selectFloorBelowObjectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.selectFloorBelowObjectToolStripMenuItem.Name = "selectFloorBelowObjectToolStripMenuItem";
-            this.selectFloorBelowObjectToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.selectFloorBelowObjectToolStripMenuItem.Tag = "SelectFloorBelowObject";
-            this.selectFloorBelowObjectToolStripMenuItem.Text = "SelectFloorBelowObject";
+            selectFloorBelowObjectToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            selectFloorBelowObjectToolStripMenuItem.Enabled = false;
+            selectFloorBelowObjectToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            selectFloorBelowObjectToolStripMenuItem.Name = "selectFloorBelowObjectToolStripMenuItem";
+            selectFloorBelowObjectToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            selectFloorBelowObjectToolStripMenuItem.Tag = "SelectFloorBelowObject";
+            selectFloorBelowObjectToolStripMenuItem.Text = "SelectFloorBelowObject";
             // 
             // splitSectorObjectOnSelectionToolStripMenuItem
             // 
-            this.splitSectorObjectOnSelectionToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.splitSectorObjectOnSelectionToolStripMenuItem.Enabled = false;
-            this.splitSectorObjectOnSelectionToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.splitSectorObjectOnSelectionToolStripMenuItem.Name = "splitSectorObjectOnSelectionToolStripMenuItem";
-            this.splitSectorObjectOnSelectionToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.splitSectorObjectOnSelectionToolStripMenuItem.Tag = "SplitSectorObjectOnSelection";
-            this.splitSectorObjectOnSelectionToolStripMenuItem.Text = "SplitSectorObjectOnSelection";
+            splitSectorObjectOnSelectionToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            splitSectorObjectOnSelectionToolStripMenuItem.Enabled = false;
+            splitSectorObjectOnSelectionToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            splitSectorObjectOnSelectionToolStripMenuItem.Name = "splitSectorObjectOnSelectionToolStripMenuItem";
+            splitSectorObjectOnSelectionToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            splitSectorObjectOnSelectionToolStripMenuItem.Tag = "SplitSectorObjectOnSelection";
+            splitSectorObjectOnSelectionToolStripMenuItem.Text = "SplitSectorObjectOnSelection";
             // 
             // toolStripSeparator3
             // 
-            this.toolStripSeparator3.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripSeparator3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator3.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(256, 6);
+            toolStripSeparator3.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripSeparator3.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator3.Margin = new Padding(0, 0, 0, 1);
+            toolStripSeparator3.Name = "toolStripSeparator3";
+            toolStripSeparator3.Size = new System.Drawing.Size(288, 6);
             // 
             // setStaticMeshColorToRoomLightToolStripMenuItem
             // 
-            this.setStaticMeshColorToRoomLightToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.setStaticMeshColorToRoomLightToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.setStaticMeshColorToRoomLightToolStripMenuItem.Name = "setStaticMeshColorToRoomLightToolStripMenuItem";
-            this.setStaticMeshColorToRoomLightToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.setStaticMeshColorToRoomLightToolStripMenuItem.Tag = "SetStaticMeshesColorToRoomLight";
-            this.setStaticMeshColorToRoomLightToolStripMenuItem.Text = "SetStaticMeshesColorToRoomLight";
+            setStaticMeshColorToRoomLightToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            setStaticMeshColorToRoomLightToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            setStaticMeshColorToRoomLightToolStripMenuItem.Name = "setStaticMeshColorToRoomLightToolStripMenuItem";
+            setStaticMeshColorToRoomLightToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            setStaticMeshColorToRoomLightToolStripMenuItem.Tag = "SetStaticMeshesColorToRoomLight";
+            setStaticMeshColorToRoomLightToolStripMenuItem.Text = "SetStaticMeshesColorToRoomLight";
             // 
             // toolStripMenuItem10
             // 
-            this.toolStripMenuItem10.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuItem10.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuItem10.Name = "toolStripMenuItem10";
-            this.toolStripMenuItem10.Size = new System.Drawing.Size(259, 22);
-            this.toolStripMenuItem10.Tag = "SetStaticMeshesColor";
-            this.toolStripMenuItem10.Text = "SetStaticMeshesColor";
+            toolStripMenuItem10.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuItem10.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuItem10.Name = "toolStripMenuItem10";
+            toolStripMenuItem10.Size = new System.Drawing.Size(291, 24);
+            toolStripMenuItem10.Tag = "SetStaticMeshesColor";
+            toolStripMenuItem10.Text = "SetStaticMeshesColor";
             // 
             // toolStripSeparator9
             // 
-            this.toolStripSeparator9.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripSeparator9.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator9.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripSeparator9.Name = "toolStripSeparator9";
-            this.toolStripSeparator9.Size = new System.Drawing.Size(256, 6);
+            toolStripSeparator9.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripSeparator9.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator9.Margin = new Padding(0, 0, 0, 1);
+            toolStripSeparator9.Name = "toolStripSeparator9";
+            toolStripSeparator9.Size = new System.Drawing.Size(288, 6);
             // 
             // makeQuickItemGroupToolStripMenuItem
             // 
-            this.makeQuickItemGroupToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.makeQuickItemGroupToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.makeQuickItemGroupToolStripMenuItem.Name = "makeQuickItemGroupToolStripMenuItem";
-            this.makeQuickItemGroupToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.makeQuickItemGroupToolStripMenuItem.Tag = "MakeQuickItemGroup";
-            this.makeQuickItemGroupToolStripMenuItem.Text = "MakeQuickItemGroup";
+            makeQuickItemGroupToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            makeQuickItemGroupToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            makeQuickItemGroupToolStripMenuItem.Name = "makeQuickItemGroupToolStripMenuItem";
+            makeQuickItemGroupToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            makeQuickItemGroupToolStripMenuItem.Tag = "MakeQuickItemGroup";
+            makeQuickItemGroupToolStripMenuItem.Text = "MakeQuickItemGroup";
             // 
             // getObjectStatisticsToolStripMenuItem
             // 
-            this.getObjectStatisticsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.getObjectStatisticsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.getObjectStatisticsToolStripMenuItem.Name = "getObjectStatisticsToolStripMenuItem";
-            this.getObjectStatisticsToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.getObjectStatisticsToolStripMenuItem.Tag = "GetObjectStatistics";
-            this.getObjectStatisticsToolStripMenuItem.Text = "GetObjectStatistics";
+            getObjectStatisticsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            getObjectStatisticsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            getObjectStatisticsToolStripMenuItem.Name = "getObjectStatisticsToolStripMenuItem";
+            getObjectStatisticsToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            getObjectStatisticsToolStripMenuItem.Tag = "GetObjectStatistics";
+            getObjectStatisticsToolStripMenuItem.Text = "GetObjectStatistics";
             // 
             // generateObjectNamesToolStripMenuItem
             // 
-            this.generateObjectNamesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.generateObjectNamesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.generateObjectNamesToolStripMenuItem.Name = "generateObjectNamesToolStripMenuItem";
-            this.generateObjectNamesToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
-            this.generateObjectNamesToolStripMenuItem.Tag = "GenerateObjectNames";
-            this.generateObjectNamesToolStripMenuItem.Text = "GenerateObjectNames";
+            generateObjectNamesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            generateObjectNamesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            generateObjectNamesToolStripMenuItem.Name = "generateObjectNamesToolStripMenuItem";
+            generateObjectNamesToolStripMenuItem.Size = new System.Drawing.Size(291, 24);
+            generateObjectNamesToolStripMenuItem.Tag = "GenerateObjectNames";
+            generateObjectNamesToolStripMenuItem.Text = "GenerateObjectNames";
             // 
             // texturesToolStripMenuItem
             // 
-            this.texturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.texturesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.loadTextureToolStripMenuItem,
-            this.removeTexturesToolStripMenuItem,
-            this.unloadTexturesToolStripMenuItem,
-            this.reloadTexturesToolStripMenuItem,
-            this.importConvertTexturesToPng,
-            this.remapTextureToolStripMenuItem,
-            this.toolStripMenuSeparator9,
-            this.textureFloorToolStripMenuItem,
-            this.textureWallsToolStripMenuItem,
-            this.textureCeilingToolStripMenuItem,
-            this.toolStripMenuItem3,
-            this.clearAllTexturesInRoomToolStripMenuItem,
-            this.clearAllTexturesInRoomToolStripMenuItem1,
-            this.toolStripMenuSeparator10,
-            this.findTexturesToolStripMenuItem,
-            this.animationRangesToolStripMenuItem});
-            this.texturesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.texturesToolStripMenuItem.Name = "texturesToolStripMenuItem";
-            this.texturesToolStripMenuItem.Size = new System.Drawing.Size(62, 25);
-            this.texturesToolStripMenuItem.Text = "Textures";
+            texturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            texturesToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { loadTextureToolStripMenuItem, removeTexturesToolStripMenuItem, unloadTexturesToolStripMenuItem, reloadTexturesToolStripMenuItem, importConvertTexturesToPng, remapTextureToolStripMenuItem, toolStripMenuSeparator9, textureFloorToolStripMenuItem, textureWallsToolStripMenuItem, textureCeilingToolStripMenuItem, toolStripMenuItem3, clearAllTexturesInRoomToolStripMenuItem, clearAllTexturesInRoomToolStripMenuItem1, toolStripMenuSeparator10, findTexturesToolStripMenuItem, animationRangesToolStripMenuItem });
+            texturesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            texturesToolStripMenuItem.Name = "texturesToolStripMenuItem";
+            texturesToolStripMenuItem.Size = new System.Drawing.Size(71, 25);
+            texturesToolStripMenuItem.Text = "Textures";
             // 
             // loadTextureToolStripMenuItem
             // 
-            this.loadTextureToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.loadTextureToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.loadTextureToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_plus_math_16;
-            this.loadTextureToolStripMenuItem.Name = "loadTextureToolStripMenuItem";
-            this.loadTextureToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.loadTextureToolStripMenuItem.Tag = "AddTexture";
-            this.loadTextureToolStripMenuItem.Text = "AddTexture";
+            loadTextureToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            loadTextureToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            loadTextureToolStripMenuItem.Image = Properties.Resources.general_plus_math_16;
+            loadTextureToolStripMenuItem.Name = "loadTextureToolStripMenuItem";
+            loadTextureToolStripMenuItem.Size = new System.Drawing.Size(222, 24);
+            loadTextureToolStripMenuItem.Tag = "AddTexture";
+            loadTextureToolStripMenuItem.Text = "AddTexture";
             // 
             // removeTexturesToolStripMenuItem
             // 
-            this.removeTexturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.removeTexturesToolStripMenuItem.Enabled = false;
-            this.removeTexturesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.removeTexturesToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_trash_16;
-            this.removeTexturesToolStripMenuItem.Name = "removeTexturesToolStripMenuItem";
-            this.removeTexturesToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.removeTexturesToolStripMenuItem.Tag = "RemoveTextures";
-            this.removeTexturesToolStripMenuItem.Text = "RemoveTextures";
+            removeTexturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            removeTexturesToolStripMenuItem.Enabled = false;
+            removeTexturesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            removeTexturesToolStripMenuItem.Image = Properties.Resources.general_trash_16;
+            removeTexturesToolStripMenuItem.Name = "removeTexturesToolStripMenuItem";
+            removeTexturesToolStripMenuItem.Size = new System.Drawing.Size(222, 24);
+            removeTexturesToolStripMenuItem.Tag = "RemoveTextures";
+            removeTexturesToolStripMenuItem.Text = "RemoveTextures";
             // 
             // unloadTexturesToolStripMenuItem
             // 
-            this.unloadTexturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.unloadTexturesToolStripMenuItem.Enabled = false;
-            this.unloadTexturesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.unloadTexturesToolStripMenuItem.Name = "unloadTexturesToolStripMenuItem";
-            this.unloadTexturesToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.unloadTexturesToolStripMenuItem.Tag = "UnloadTextures";
-            this.unloadTexturesToolStripMenuItem.Text = "UnloadTextures";
+            unloadTexturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            unloadTexturesToolStripMenuItem.Enabled = false;
+            unloadTexturesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            unloadTexturesToolStripMenuItem.Name = "unloadTexturesToolStripMenuItem";
+            unloadTexturesToolStripMenuItem.Size = new System.Drawing.Size(222, 24);
+            unloadTexturesToolStripMenuItem.Tag = "UnloadTextures";
+            unloadTexturesToolStripMenuItem.Text = "UnloadTextures";
             // 
             // reloadTexturesToolStripMenuItem
             // 
-            this.reloadTexturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.reloadTexturesToolStripMenuItem.Enabled = false;
-            this.reloadTexturesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.reloadTexturesToolStripMenuItem.Name = "reloadTexturesToolStripMenuItem";
-            this.reloadTexturesToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.reloadTexturesToolStripMenuItem.Tag = "ReloadTextures";
-            this.reloadTexturesToolStripMenuItem.Text = "ReloadTextures";
+            reloadTexturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            reloadTexturesToolStripMenuItem.Enabled = false;
+            reloadTexturesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            reloadTexturesToolStripMenuItem.Name = "reloadTexturesToolStripMenuItem";
+            reloadTexturesToolStripMenuItem.Size = new System.Drawing.Size(222, 24);
+            reloadTexturesToolStripMenuItem.Tag = "ReloadTextures";
+            reloadTexturesToolStripMenuItem.Text = "ReloadTextures";
             // 
             // importConvertTexturesToPng
             // 
-            this.importConvertTexturesToPng.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.importConvertTexturesToPng.Enabled = false;
-            this.importConvertTexturesToPng.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.importConvertTexturesToPng.Image = global::TombEditor.Properties.Resources.general_Import_16;
-            this.importConvertTexturesToPng.Name = "importConvertTexturesToPng";
-            this.importConvertTexturesToPng.Size = new System.Drawing.Size(200, 22);
-            this.importConvertTexturesToPng.Tag = "ConvertTexturesToPNG";
-            this.importConvertTexturesToPng.Text = "ConvertTexturesToPNG";
+            importConvertTexturesToPng.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            importConvertTexturesToPng.Enabled = false;
+            importConvertTexturesToPng.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            importConvertTexturesToPng.Image = Properties.Resources.general_Import_16;
+            importConvertTexturesToPng.Name = "importConvertTexturesToPng";
+            importConvertTexturesToPng.Size = new System.Drawing.Size(222, 24);
+            importConvertTexturesToPng.Tag = "ConvertTexturesToPNG";
+            importConvertTexturesToPng.Text = "ConvertTexturesToPNG";
             // 
             // remapTextureToolStripMenuItem
             // 
-            this.remapTextureToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.remapTextureToolStripMenuItem.Enabled = false;
-            this.remapTextureToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.remapTextureToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_crop_16;
-            this.remapTextureToolStripMenuItem.Name = "remapTextureToolStripMenuItem";
-            this.remapTextureToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.remapTextureToolStripMenuItem.Tag = "RemapTexture";
-            this.remapTextureToolStripMenuItem.Text = "RemapTexture";
+            remapTextureToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            remapTextureToolStripMenuItem.Enabled = false;
+            remapTextureToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            remapTextureToolStripMenuItem.Image = Properties.Resources.general_crop_16;
+            remapTextureToolStripMenuItem.Name = "remapTextureToolStripMenuItem";
+            remapTextureToolStripMenuItem.Size = new System.Drawing.Size(222, 24);
+            remapTextureToolStripMenuItem.Tag = "RemapTexture";
+            remapTextureToolStripMenuItem.Text = "RemapTexture";
             // 
             // toolStripMenuSeparator9
             // 
-            this.toolStripMenuSeparator9.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuSeparator9.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator9.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator9.Name = "toolStripMenuSeparator9";
-            this.toolStripMenuSeparator9.Size = new System.Drawing.Size(197, 6);
+            toolStripMenuSeparator9.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuSeparator9.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator9.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator9.Name = "toolStripMenuSeparator9";
+            toolStripMenuSeparator9.Size = new System.Drawing.Size(219, 6);
             // 
             // textureFloorToolStripMenuItem
             // 
-            this.textureFloorToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.textureFloorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.textureFloorToolStripMenuItem.Image = global::TombEditor.Properties.Resources.texture_Floor2_16;
-            this.textureFloorToolStripMenuItem.Name = "textureFloorToolStripMenuItem";
-            this.textureFloorToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.textureFloorToolStripMenuItem.Tag = "TextureFloor";
-            this.textureFloorToolStripMenuItem.Text = "TextureFloor";
+            textureFloorToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            textureFloorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            textureFloorToolStripMenuItem.Image = Properties.Resources.texture_Floor2_16;
+            textureFloorToolStripMenuItem.Name = "textureFloorToolStripMenuItem";
+            textureFloorToolStripMenuItem.Size = new System.Drawing.Size(222, 24);
+            textureFloorToolStripMenuItem.Tag = "TextureFloor";
+            textureFloorToolStripMenuItem.Text = "TextureFloor";
             // 
             // textureWallsToolStripMenuItem
             // 
-            this.textureWallsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.textureWallsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.textureWallsToolStripMenuItem.Image = global::TombEditor.Properties.Resources.texture_Walls2_16;
-            this.textureWallsToolStripMenuItem.Name = "textureWallsToolStripMenuItem";
-            this.textureWallsToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.textureWallsToolStripMenuItem.Tag = "TextureWalls";
-            this.textureWallsToolStripMenuItem.Text = "TextureWalls";
+            textureWallsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            textureWallsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            textureWallsToolStripMenuItem.Image = Properties.Resources.texture_Walls2_16;
+            textureWallsToolStripMenuItem.Name = "textureWallsToolStripMenuItem";
+            textureWallsToolStripMenuItem.Size = new System.Drawing.Size(222, 24);
+            textureWallsToolStripMenuItem.Tag = "TextureWalls";
+            textureWallsToolStripMenuItem.Text = "TextureWalls";
             // 
             // textureCeilingToolStripMenuItem
             // 
-            this.textureCeilingToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.textureCeilingToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.textureCeilingToolStripMenuItem.Image = global::TombEditor.Properties.Resources.texture_Ceiling2_16;
-            this.textureCeilingToolStripMenuItem.Name = "textureCeilingToolStripMenuItem";
-            this.textureCeilingToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.textureCeilingToolStripMenuItem.Tag = "TextureCeiling";
-            this.textureCeilingToolStripMenuItem.Text = "TextureCeiling";
+            textureCeilingToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            textureCeilingToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            textureCeilingToolStripMenuItem.Image = Properties.Resources.texture_Ceiling2_16;
+            textureCeilingToolStripMenuItem.Name = "textureCeilingToolStripMenuItem";
+            textureCeilingToolStripMenuItem.Size = new System.Drawing.Size(222, 24);
+            textureCeilingToolStripMenuItem.Tag = "TextureCeiling";
+            textureCeilingToolStripMenuItem.Text = "TextureCeiling";
             // 
             // toolStripMenuItem3
             // 
-            this.toolStripMenuItem3.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuItem3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuItem3.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-            this.toolStripMenuItem3.Size = new System.Drawing.Size(197, 6);
+            toolStripMenuItem3.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuItem3.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuItem3.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuItem3.Name = "toolStripMenuItem3";
+            toolStripMenuItem3.Size = new System.Drawing.Size(219, 6);
             // 
             // clearAllTexturesInRoomToolStripMenuItem
             // 
-            this.clearAllTexturesInRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.clearAllTexturesInRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.clearAllTexturesInRoomToolStripMenuItem.Image = global::TombEditor.Properties.Resources.toolbox_Eraser_16;
-            this.clearAllTexturesInRoomToolStripMenuItem.Name = "clearAllTexturesInRoomToolStripMenuItem";
-            this.clearAllTexturesInRoomToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.clearAllTexturesInRoomToolStripMenuItem.Tag = "ClearAllTexturesInRoom";
-            this.clearAllTexturesInRoomToolStripMenuItem.Text = "ClearAllTexturesInRoom";
+            clearAllTexturesInRoomToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            clearAllTexturesInRoomToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            clearAllTexturesInRoomToolStripMenuItem.Image = Properties.Resources.toolbox_Eraser_16;
+            clearAllTexturesInRoomToolStripMenuItem.Name = "clearAllTexturesInRoomToolStripMenuItem";
+            clearAllTexturesInRoomToolStripMenuItem.Size = new System.Drawing.Size(222, 24);
+            clearAllTexturesInRoomToolStripMenuItem.Tag = "ClearAllTexturesInRoom";
+            clearAllTexturesInRoomToolStripMenuItem.Text = "ClearAllTexturesInRoom";
             // 
             // clearAllTexturesInRoomToolStripMenuItem1
             // 
-            this.clearAllTexturesInRoomToolStripMenuItem1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.clearAllTexturesInRoomToolStripMenuItem1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.clearAllTexturesInRoomToolStripMenuItem1.Name = "clearAllTexturesInRoomToolStripMenuItem1";
-            this.clearAllTexturesInRoomToolStripMenuItem1.Size = new System.Drawing.Size(200, 22);
-            this.clearAllTexturesInRoomToolStripMenuItem1.Tag = "ClearAllTexturesInLevel";
-            this.clearAllTexturesInRoomToolStripMenuItem1.Text = "ClearAllTexturesInLevel";
+            clearAllTexturesInRoomToolStripMenuItem1.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            clearAllTexturesInRoomToolStripMenuItem1.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            clearAllTexturesInRoomToolStripMenuItem1.Name = "clearAllTexturesInRoomToolStripMenuItem1";
+            clearAllTexturesInRoomToolStripMenuItem1.Size = new System.Drawing.Size(222, 24);
+            clearAllTexturesInRoomToolStripMenuItem1.Tag = "ClearAllTexturesInLevel";
+            clearAllTexturesInRoomToolStripMenuItem1.Text = "ClearAllTexturesInLevel";
             // 
             // toolStripMenuSeparator10
             // 
-            this.toolStripMenuSeparator10.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuSeparator10.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator10.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator10.Name = "toolStripMenuSeparator10";
-            this.toolStripMenuSeparator10.Size = new System.Drawing.Size(197, 6);
+            toolStripMenuSeparator10.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuSeparator10.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator10.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator10.Name = "toolStripMenuSeparator10";
+            toolStripMenuSeparator10.Size = new System.Drawing.Size(219, 6);
             // 
             // findTexturesToolStripMenuItem
             // 
-            this.findTexturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.findTexturesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.findTexturesToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_search_16;
-            this.findTexturesToolStripMenuItem.Name = "findTexturesToolStripMenuItem";
-            this.findTexturesToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.findTexturesToolStripMenuItem.Tag = "SearchTextures";
-            this.findTexturesToolStripMenuItem.Text = "SearchTextures";
+            findTexturesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            findTexturesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            findTexturesToolStripMenuItem.Image = Properties.Resources.general_search_16;
+            findTexturesToolStripMenuItem.Name = "findTexturesToolStripMenuItem";
+            findTexturesToolStripMenuItem.Size = new System.Drawing.Size(222, 24);
+            findTexturesToolStripMenuItem.Tag = "SearchTextures";
+            findTexturesToolStripMenuItem.Text = "SearchTextures";
             // 
             // animationRangesToolStripMenuItem
             // 
-            this.animationRangesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.animationRangesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.animationRangesToolStripMenuItem.Image = global::TombEditor.Properties.Resources.texture_anim_ranges;
-            this.animationRangesToolStripMenuItem.Name = "animationRangesToolStripMenuItem";
-            this.animationRangesToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.animationRangesToolStripMenuItem.Tag = "EditAnimationRanges";
-            this.animationRangesToolStripMenuItem.Text = "EditAnimationRanges";
+            animationRangesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            animationRangesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            animationRangesToolStripMenuItem.Image = Properties.Resources.texture_anim_ranges;
+            animationRangesToolStripMenuItem.Name = "animationRangesToolStripMenuItem";
+            animationRangesToolStripMenuItem.Size = new System.Drawing.Size(222, 24);
+            animationRangesToolStripMenuItem.Tag = "EditAnimationRanges";
+            animationRangesToolStripMenuItem.Text = "EditAnimationRanges";
             // 
             // transformToolStripMenuItem
             // 
-            this.transformToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.transformToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.smoothRandomFloorUpToolStripMenuItem,
-            this.smoothRandomFloorDownToolStripMenuItem,
-            this.smoothRandomCeilingUpToolStripMenuItem,
-            this.smoothRandomCeilingDownToolStripMenuItem,
-            this.toolStripMenuSeparator11,
-            this.sharpRandomFloorUpToolStripMenuItem,
-            this.sharpRandomFloorDownToolStripMenuItem,
-            this.sharpRandomCeilingUpToolStripMenuItem,
-            this.sharpRandomCeilingDownToolStripMenuItem,
-            this.toolStripMenuSeparator12,
-            this.averageFloorToolStripMenuItem,
-            this.averageCeilingToolStripMenuItem,
-            this.flattenFloorToolStripMenuItem,
-            this.flattenCeilingToolStripMenuItem,
-            this.resetGeometryToolStripMenuItem,
-            this.toolStripMenuSeparator13,
-            this.gridWallsIn3ToolStripMenuItem,
-            this.gridWallsIn5ToolStripMenuItem,
-            this.gridWallsIn3SquaresToolStripMenuItem,
-            this.gridWallsIn5SquaresToolStripMenuItem});
-            this.transformToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.transformToolStripMenuItem.Name = "transformToolStripMenuItem";
-            this.transformToolStripMenuItem.Size = new System.Drawing.Size(72, 25);
-            this.transformToolStripMenuItem.Text = "Transform";
+            transformToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            transformToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { smoothRandomFloorUpToolStripMenuItem, smoothRandomFloorDownToolStripMenuItem, smoothRandomCeilingUpToolStripMenuItem, smoothRandomCeilingDownToolStripMenuItem, toolStripMenuSeparator11, sharpRandomFloorUpToolStripMenuItem, sharpRandomFloorDownToolStripMenuItem, sharpRandomCeilingUpToolStripMenuItem, sharpRandomCeilingDownToolStripMenuItem, toolStripMenuSeparator12, averageFloorToolStripMenuItem, averageCeilingToolStripMenuItem, flattenFloorToolStripMenuItem, flattenCeilingToolStripMenuItem, resetGeometryToolStripMenuItem, toolStripMenuSeparator13, gridWallsIn3ToolStripMenuItem, gridWallsIn5ToolStripMenuItem, gridWallsIn3SquaresToolStripMenuItem, gridWallsIn5SquaresToolStripMenuItem });
+            transformToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            transformToolStripMenuItem.Name = "transformToolStripMenuItem";
+            transformToolStripMenuItem.Size = new System.Drawing.Size(82, 25);
+            transformToolStripMenuItem.Text = "Transform";
             // 
             // smoothRandomFloorUpToolStripMenuItem
             // 
-            this.smoothRandomFloorUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.smoothRandomFloorUpToolStripMenuItem.Enabled = false;
-            this.smoothRandomFloorUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.smoothRandomFloorUpToolStripMenuItem.Name = "smoothRandomFloorUpToolStripMenuItem";
-            this.smoothRandomFloorUpToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.smoothRandomFloorUpToolStripMenuItem.Tag = "SmoothRandomFloorUp";
-            this.smoothRandomFloorUpToolStripMenuItem.Text = "SmoothRandomFloorUp";
+            smoothRandomFloorUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            smoothRandomFloorUpToolStripMenuItem.Enabled = false;
+            smoothRandomFloorUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            smoothRandomFloorUpToolStripMenuItem.Name = "smoothRandomFloorUpToolStripMenuItem";
+            smoothRandomFloorUpToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            smoothRandomFloorUpToolStripMenuItem.Tag = "SmoothRandomFloorUp";
+            smoothRandomFloorUpToolStripMenuItem.Text = "SmoothRandomFloorUp";
             // 
             // smoothRandomFloorDownToolStripMenuItem
             // 
-            this.smoothRandomFloorDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.smoothRandomFloorDownToolStripMenuItem.Enabled = false;
-            this.smoothRandomFloorDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.smoothRandomFloorDownToolStripMenuItem.Name = "smoothRandomFloorDownToolStripMenuItem";
-            this.smoothRandomFloorDownToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.smoothRandomFloorDownToolStripMenuItem.Tag = "SmoothRandomFloorDown";
-            this.smoothRandomFloorDownToolStripMenuItem.Text = "SmoothRandomFloorDown";
+            smoothRandomFloorDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            smoothRandomFloorDownToolStripMenuItem.Enabled = false;
+            smoothRandomFloorDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            smoothRandomFloorDownToolStripMenuItem.Name = "smoothRandomFloorDownToolStripMenuItem";
+            smoothRandomFloorDownToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            smoothRandomFloorDownToolStripMenuItem.Tag = "SmoothRandomFloorDown";
+            smoothRandomFloorDownToolStripMenuItem.Text = "SmoothRandomFloorDown";
             // 
             // smoothRandomCeilingUpToolStripMenuItem
             // 
-            this.smoothRandomCeilingUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.smoothRandomCeilingUpToolStripMenuItem.Enabled = false;
-            this.smoothRandomCeilingUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.smoothRandomCeilingUpToolStripMenuItem.Name = "smoothRandomCeilingUpToolStripMenuItem";
-            this.smoothRandomCeilingUpToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.smoothRandomCeilingUpToolStripMenuItem.Tag = "SmoothRandomCeilingUp";
-            this.smoothRandomCeilingUpToolStripMenuItem.Text = "SmoothRandomCeilingUp";
+            smoothRandomCeilingUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            smoothRandomCeilingUpToolStripMenuItem.Enabled = false;
+            smoothRandomCeilingUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            smoothRandomCeilingUpToolStripMenuItem.Name = "smoothRandomCeilingUpToolStripMenuItem";
+            smoothRandomCeilingUpToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            smoothRandomCeilingUpToolStripMenuItem.Tag = "SmoothRandomCeilingUp";
+            smoothRandomCeilingUpToolStripMenuItem.Text = "SmoothRandomCeilingUp";
             // 
             // smoothRandomCeilingDownToolStripMenuItem
             // 
-            this.smoothRandomCeilingDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.smoothRandomCeilingDownToolStripMenuItem.Enabled = false;
-            this.smoothRandomCeilingDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.smoothRandomCeilingDownToolStripMenuItem.Name = "smoothRandomCeilingDownToolStripMenuItem";
-            this.smoothRandomCeilingDownToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.smoothRandomCeilingDownToolStripMenuItem.Tag = "SmoothRandomCeilingDown";
-            this.smoothRandomCeilingDownToolStripMenuItem.Text = "SmoothRandomCeilingDown";
+            smoothRandomCeilingDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            smoothRandomCeilingDownToolStripMenuItem.Enabled = false;
+            smoothRandomCeilingDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            smoothRandomCeilingDownToolStripMenuItem.Name = "smoothRandomCeilingDownToolStripMenuItem";
+            smoothRandomCeilingDownToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            smoothRandomCeilingDownToolStripMenuItem.Tag = "SmoothRandomCeilingDown";
+            smoothRandomCeilingDownToolStripMenuItem.Text = "SmoothRandomCeilingDown";
             // 
             // toolStripMenuSeparator11
             // 
-            this.toolStripMenuSeparator11.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuSeparator11.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator11.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator11.Name = "toolStripMenuSeparator11";
-            this.toolStripMenuSeparator11.Size = new System.Drawing.Size(226, 6);
+            toolStripMenuSeparator11.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuSeparator11.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator11.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator11.Name = "toolStripMenuSeparator11";
+            toolStripMenuSeparator11.Size = new System.Drawing.Size(251, 6);
             // 
             // sharpRandomFloorUpToolStripMenuItem
             // 
-            this.sharpRandomFloorUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.sharpRandomFloorUpToolStripMenuItem.Enabled = false;
-            this.sharpRandomFloorUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.sharpRandomFloorUpToolStripMenuItem.Name = "sharpRandomFloorUpToolStripMenuItem";
-            this.sharpRandomFloorUpToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.sharpRandomFloorUpToolStripMenuItem.Tag = "SharpRandomFloorUp";
-            this.sharpRandomFloorUpToolStripMenuItem.Text = "SharpRandomFloorUp";
+            sharpRandomFloorUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            sharpRandomFloorUpToolStripMenuItem.Enabled = false;
+            sharpRandomFloorUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            sharpRandomFloorUpToolStripMenuItem.Name = "sharpRandomFloorUpToolStripMenuItem";
+            sharpRandomFloorUpToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            sharpRandomFloorUpToolStripMenuItem.Tag = "SharpRandomFloorUp";
+            sharpRandomFloorUpToolStripMenuItem.Text = "SharpRandomFloorUp";
             // 
             // sharpRandomFloorDownToolStripMenuItem
             // 
-            this.sharpRandomFloorDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.sharpRandomFloorDownToolStripMenuItem.Enabled = false;
-            this.sharpRandomFloorDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.sharpRandomFloorDownToolStripMenuItem.Name = "sharpRandomFloorDownToolStripMenuItem";
-            this.sharpRandomFloorDownToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.sharpRandomFloorDownToolStripMenuItem.Tag = "SharpRandomFloorDown";
-            this.sharpRandomFloorDownToolStripMenuItem.Text = "SharpRandomFloorDown";
+            sharpRandomFloorDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            sharpRandomFloorDownToolStripMenuItem.Enabled = false;
+            sharpRandomFloorDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            sharpRandomFloorDownToolStripMenuItem.Name = "sharpRandomFloorDownToolStripMenuItem";
+            sharpRandomFloorDownToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            sharpRandomFloorDownToolStripMenuItem.Tag = "SharpRandomFloorDown";
+            sharpRandomFloorDownToolStripMenuItem.Text = "SharpRandomFloorDown";
             // 
             // sharpRandomCeilingUpToolStripMenuItem
             // 
-            this.sharpRandomCeilingUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.sharpRandomCeilingUpToolStripMenuItem.Enabled = false;
-            this.sharpRandomCeilingUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.sharpRandomCeilingUpToolStripMenuItem.Name = "sharpRandomCeilingUpToolStripMenuItem";
-            this.sharpRandomCeilingUpToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.sharpRandomCeilingUpToolStripMenuItem.Tag = "SharpRandomCeilingUp";
-            this.sharpRandomCeilingUpToolStripMenuItem.Text = "SharpRandomCeilingUp";
+            sharpRandomCeilingUpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            sharpRandomCeilingUpToolStripMenuItem.Enabled = false;
+            sharpRandomCeilingUpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            sharpRandomCeilingUpToolStripMenuItem.Name = "sharpRandomCeilingUpToolStripMenuItem";
+            sharpRandomCeilingUpToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            sharpRandomCeilingUpToolStripMenuItem.Tag = "SharpRandomCeilingUp";
+            sharpRandomCeilingUpToolStripMenuItem.Text = "SharpRandomCeilingUp";
             // 
             // sharpRandomCeilingDownToolStripMenuItem
             // 
-            this.sharpRandomCeilingDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.sharpRandomCeilingDownToolStripMenuItem.Enabled = false;
-            this.sharpRandomCeilingDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.sharpRandomCeilingDownToolStripMenuItem.Name = "sharpRandomCeilingDownToolStripMenuItem";
-            this.sharpRandomCeilingDownToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.sharpRandomCeilingDownToolStripMenuItem.Tag = "SharpRandomCeilingDown";
-            this.sharpRandomCeilingDownToolStripMenuItem.Text = "SharpRandomCeilingDown";
+            sharpRandomCeilingDownToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            sharpRandomCeilingDownToolStripMenuItem.Enabled = false;
+            sharpRandomCeilingDownToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            sharpRandomCeilingDownToolStripMenuItem.Name = "sharpRandomCeilingDownToolStripMenuItem";
+            sharpRandomCeilingDownToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            sharpRandomCeilingDownToolStripMenuItem.Tag = "SharpRandomCeilingDown";
+            sharpRandomCeilingDownToolStripMenuItem.Text = "SharpRandomCeilingDown";
             // 
             // toolStripMenuSeparator12
             // 
-            this.toolStripMenuSeparator12.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuSeparator12.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator12.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator12.Name = "toolStripMenuSeparator12";
-            this.toolStripMenuSeparator12.Size = new System.Drawing.Size(226, 6);
+            toolStripMenuSeparator12.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuSeparator12.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator12.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator12.Name = "toolStripMenuSeparator12";
+            toolStripMenuSeparator12.Size = new System.Drawing.Size(251, 6);
             // 
             // averageFloorToolStripMenuItem
             // 
-            this.averageFloorToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.averageFloorToolStripMenuItem.Enabled = false;
-            this.averageFloorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.averageFloorToolStripMenuItem.Name = "averageFloorToolStripMenuItem";
-            this.averageFloorToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.averageFloorToolStripMenuItem.Tag = "AverageFloor";
-            this.averageFloorToolStripMenuItem.Text = "AverageFloor";
+            averageFloorToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            averageFloorToolStripMenuItem.Enabled = false;
+            averageFloorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            averageFloorToolStripMenuItem.Name = "averageFloorToolStripMenuItem";
+            averageFloorToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            averageFloorToolStripMenuItem.Tag = "AverageFloor";
+            averageFloorToolStripMenuItem.Text = "AverageFloor";
             // 
             // averageCeilingToolStripMenuItem
             // 
-            this.averageCeilingToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.averageCeilingToolStripMenuItem.Enabled = false;
-            this.averageCeilingToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.averageCeilingToolStripMenuItem.Name = "averageCeilingToolStripMenuItem";
-            this.averageCeilingToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.averageCeilingToolStripMenuItem.Tag = "AverageCeiling";
-            this.averageCeilingToolStripMenuItem.Text = "AverageCeiling";
+            averageCeilingToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            averageCeilingToolStripMenuItem.Enabled = false;
+            averageCeilingToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            averageCeilingToolStripMenuItem.Name = "averageCeilingToolStripMenuItem";
+            averageCeilingToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            averageCeilingToolStripMenuItem.Tag = "AverageCeiling";
+            averageCeilingToolStripMenuItem.Text = "AverageCeiling";
             // 
             // flattenFloorToolStripMenuItem
             // 
-            this.flattenFloorToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.flattenFloorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.flattenFloorToolStripMenuItem.Name = "flattenFloorToolStripMenuItem";
-            this.flattenFloorToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.flattenFloorToolStripMenuItem.Tag = "FlattenFloor";
-            this.flattenFloorToolStripMenuItem.Text = "FlattenFloor";
+            flattenFloorToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            flattenFloorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            flattenFloorToolStripMenuItem.Name = "flattenFloorToolStripMenuItem";
+            flattenFloorToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            flattenFloorToolStripMenuItem.Tag = "FlattenFloor";
+            flattenFloorToolStripMenuItem.Text = "FlattenFloor";
             // 
             // flattenCeilingToolStripMenuItem
             // 
-            this.flattenCeilingToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.flattenCeilingToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.flattenCeilingToolStripMenuItem.Name = "flattenCeilingToolStripMenuItem";
-            this.flattenCeilingToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.flattenCeilingToolStripMenuItem.Tag = "FlattenCeiling";
-            this.flattenCeilingToolStripMenuItem.Text = "FlattenCeiling";
+            flattenCeilingToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            flattenCeilingToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            flattenCeilingToolStripMenuItem.Name = "flattenCeilingToolStripMenuItem";
+            flattenCeilingToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            flattenCeilingToolStripMenuItem.Tag = "FlattenCeiling";
+            flattenCeilingToolStripMenuItem.Text = "FlattenCeiling";
             // 
             // resetGeometryToolStripMenuItem
             // 
-            this.resetGeometryToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.resetGeometryToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.resetGeometryToolStripMenuItem.Name = "resetGeometryToolStripMenuItem";
-            this.resetGeometryToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.resetGeometryToolStripMenuItem.Tag = "ResetGeometry";
-            this.resetGeometryToolStripMenuItem.Text = "ResetGeometry";
+            resetGeometryToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            resetGeometryToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            resetGeometryToolStripMenuItem.Name = "resetGeometryToolStripMenuItem";
+            resetGeometryToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            resetGeometryToolStripMenuItem.Tag = "ResetGeometry";
+            resetGeometryToolStripMenuItem.Text = "ResetGeometry";
             // 
             // toolStripMenuSeparator13
             // 
-            this.toolStripMenuSeparator13.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuSeparator13.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator13.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator13.Name = "toolStripMenuSeparator13";
-            this.toolStripMenuSeparator13.Size = new System.Drawing.Size(226, 6);
+            toolStripMenuSeparator13.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuSeparator13.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator13.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator13.Name = "toolStripMenuSeparator13";
+            toolStripMenuSeparator13.Size = new System.Drawing.Size(251, 6);
             // 
             // gridWallsIn3ToolStripMenuItem
             // 
-            this.gridWallsIn3ToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.gridWallsIn3ToolStripMenuItem.Enabled = false;
-            this.gridWallsIn3ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.gridWallsIn3ToolStripMenuItem.Name = "gridWallsIn3ToolStripMenuItem";
-            this.gridWallsIn3ToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.gridWallsIn3ToolStripMenuItem.Tag = "GridWallsIn3";
-            this.gridWallsIn3ToolStripMenuItem.Text = "GridWallsIn3";
+            gridWallsIn3ToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            gridWallsIn3ToolStripMenuItem.Enabled = false;
+            gridWallsIn3ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            gridWallsIn3ToolStripMenuItem.Name = "gridWallsIn3ToolStripMenuItem";
+            gridWallsIn3ToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            gridWallsIn3ToolStripMenuItem.Tag = "GridWallsIn3";
+            gridWallsIn3ToolStripMenuItem.Text = "GridWallsIn3";
             // 
             // gridWallsIn5ToolStripMenuItem
             // 
-            this.gridWallsIn5ToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.gridWallsIn5ToolStripMenuItem.Enabled = false;
-            this.gridWallsIn5ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.gridWallsIn5ToolStripMenuItem.Name = "gridWallsIn5ToolStripMenuItem";
-            this.gridWallsIn5ToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.gridWallsIn5ToolStripMenuItem.Tag = "GridWallsIn5";
-            this.gridWallsIn5ToolStripMenuItem.Text = "GridWallsIn5";
+            gridWallsIn5ToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            gridWallsIn5ToolStripMenuItem.Enabled = false;
+            gridWallsIn5ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            gridWallsIn5ToolStripMenuItem.Name = "gridWallsIn5ToolStripMenuItem";
+            gridWallsIn5ToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            gridWallsIn5ToolStripMenuItem.Tag = "GridWallsIn5";
+            gridWallsIn5ToolStripMenuItem.Text = "GridWallsIn5";
             // 
             // gridWallsIn3SquaresToolStripMenuItem
             // 
-            this.gridWallsIn3SquaresToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.gridWallsIn3SquaresToolStripMenuItem.Enabled = false;
-            this.gridWallsIn3SquaresToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.gridWallsIn3SquaresToolStripMenuItem.Name = "gridWallsIn3SquaresToolStripMenuItem";
-            this.gridWallsIn3SquaresToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.gridWallsIn3SquaresToolStripMenuItem.Tag = "GridWallsIn3Squares";
-            this.gridWallsIn3SquaresToolStripMenuItem.Text = "GridWallsIn3Squares";
+            gridWallsIn3SquaresToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            gridWallsIn3SquaresToolStripMenuItem.Enabled = false;
+            gridWallsIn3SquaresToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            gridWallsIn3SquaresToolStripMenuItem.Name = "gridWallsIn3SquaresToolStripMenuItem";
+            gridWallsIn3SquaresToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            gridWallsIn3SquaresToolStripMenuItem.Tag = "GridWallsIn3Squares";
+            gridWallsIn3SquaresToolStripMenuItem.Text = "GridWallsIn3Squares";
             // 
             // gridWallsIn5SquaresToolStripMenuItem
             // 
-            this.gridWallsIn5SquaresToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.gridWallsIn5SquaresToolStripMenuItem.Enabled = false;
-            this.gridWallsIn5SquaresToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(153)))), ((int)(((byte)(153)))));
-            this.gridWallsIn5SquaresToolStripMenuItem.Name = "gridWallsIn5SquaresToolStripMenuItem";
-            this.gridWallsIn5SquaresToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.gridWallsIn5SquaresToolStripMenuItem.Tag = "GridWallsIn5Squares";
-            this.gridWallsIn5SquaresToolStripMenuItem.Text = "GridWallsIn5Squares";
+            gridWallsIn5SquaresToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            gridWallsIn5SquaresToolStripMenuItem.Enabled = false;
+            gridWallsIn5SquaresToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(153, 153, 153);
+            gridWallsIn5SquaresToolStripMenuItem.Name = "gridWallsIn5SquaresToolStripMenuItem";
+            gridWallsIn5SquaresToolStripMenuItem.Size = new System.Drawing.Size(254, 24);
+            gridWallsIn5SquaresToolStripMenuItem.Tag = "GridWallsIn5Squares";
+            gridWallsIn5SquaresToolStripMenuItem.Text = "GridWallsIn5Squares";
             // 
             // toolStripMenuItem4
             // 
-            this.toolStripMenuItem4.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuItem4.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItem5,
-            this.editOptionsToolStripMenuItem,
-            this.keyboardLayoutToolStripMenuItem,
-            this.toolStripSeparator5,
-            this.toolStripMenuItem7,
-            this.toolStripMenuItem6});
-            this.toolStripMenuItem4.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuItem4.Name = "toolStripMenuItem4";
-            this.toolStripMenuItem4.Size = new System.Drawing.Size(46, 25);
-            this.toolStripMenuItem4.Text = "Tools";
+            toolStripMenuItem4.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuItem4.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItem5, editOptionsToolStripMenuItem, keyboardLayoutToolStripMenuItem, toolStripSeparator5, toolStripMenuItem7, toolStripMenuItem6 });
+            toolStripMenuItem4.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuItem4.Name = "toolStripMenuItem4";
+            toolStripMenuItem4.Size = new System.Drawing.Size(52, 25);
+            toolStripMenuItem4.Text = "Tools";
             // 
             // toolStripMenuItem5
             // 
-            this.toolStripMenuItem5.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuItem5.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuItem5.Image = global::TombEditor.Properties.Resources.general_settings_16;
-            this.toolStripMenuItem5.Name = "toolStripMenuItem5";
-            this.toolStripMenuItem5.Size = new System.Drawing.Size(180, 22);
-            this.toolStripMenuItem5.Tag = "EditLevelSettings";
-            this.toolStripMenuItem5.Text = "EditLevelSettings";
+            toolStripMenuItem5.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuItem5.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuItem5.Image = Properties.Resources.general_settings_16;
+            toolStripMenuItem5.Name = "toolStripMenuItem5";
+            toolStripMenuItem5.Size = new System.Drawing.Size(201, 24);
+            toolStripMenuItem5.Tag = "EditLevelSettings";
+            toolStripMenuItem5.Text = "EditLevelSettings";
             // 
             // editOptionsToolStripMenuItem
             // 
-            this.editOptionsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.editOptionsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.editOptionsToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_options_16;
-            this.editOptionsToolStripMenuItem.Name = "editOptionsToolStripMenuItem";
-            this.editOptionsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.editOptionsToolStripMenuItem.Tag = "EditOptions";
-            this.editOptionsToolStripMenuItem.Text = "EditOptions";
+            editOptionsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            editOptionsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            editOptionsToolStripMenuItem.Image = Properties.Resources.general_options_16;
+            editOptionsToolStripMenuItem.Name = "editOptionsToolStripMenuItem";
+            editOptionsToolStripMenuItem.Size = new System.Drawing.Size(201, 24);
+            editOptionsToolStripMenuItem.Tag = "EditOptions";
+            editOptionsToolStripMenuItem.Text = "EditOptions";
             // 
             // keyboardLayoutToolStripMenuItem
             // 
-            this.keyboardLayoutToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.keyboardLayoutToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.keyboardLayoutToolStripMenuItem.Name = "keyboardLayoutToolStripMenuItem";
-            this.keyboardLayoutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.keyboardLayoutToolStripMenuItem.Tag = "EditKeyboardLayout";
-            this.keyboardLayoutToolStripMenuItem.Text = "EditKeyboardLayout";
+            keyboardLayoutToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            keyboardLayoutToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            keyboardLayoutToolStripMenuItem.Name = "keyboardLayoutToolStripMenuItem";
+            keyboardLayoutToolStripMenuItem.Size = new System.Drawing.Size(201, 24);
+            keyboardLayoutToolStripMenuItem.Tag = "EditKeyboardLayout";
+            keyboardLayoutToolStripMenuItem.Text = "EditKeyboardLayout";
             // 
             // toolStripSeparator5
             // 
-            this.toolStripSeparator5.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripSeparator5.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripSeparator5.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(177, 6);
+            toolStripSeparator5.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripSeparator5.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator5.Margin = new Padding(0, 0, 0, 1);
+            toolStripSeparator5.Name = "toolStripSeparator5";
+            toolStripSeparator5.Size = new System.Drawing.Size(198, 6);
             // 
             // toolStripMenuItem7
             // 
-            this.toolStripMenuItem7.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuItem7.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuItem7.Name = "toolStripMenuItem7";
-            this.toolStripMenuItem7.Size = new System.Drawing.Size(180, 22);
-            this.toolStripMenuItem7.Tag = "StartWadTool";
-            this.toolStripMenuItem7.Text = "StartWadTool";
+            toolStripMenuItem7.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuItem7.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuItem7.Name = "toolStripMenuItem7";
+            toolStripMenuItem7.Size = new System.Drawing.Size(201, 24);
+            toolStripMenuItem7.Tag = "StartWadTool";
+            toolStripMenuItem7.Text = "StartWadTool";
             // 
             // toolStripMenuItem6
             // 
-            this.toolStripMenuItem6.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuItem6.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuItem6.Name = "toolStripMenuItem6";
-            this.toolStripMenuItem6.Size = new System.Drawing.Size(180, 22);
-            this.toolStripMenuItem6.Tag = "StartSoundTool";
-            this.toolStripMenuItem6.Text = "StartSoundTool";
+            toolStripMenuItem6.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuItem6.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuItem6.Name = "toolStripMenuItem6";
+            toolStripMenuItem6.Size = new System.Drawing.Size(201, 24);
+            toolStripMenuItem6.Tag = "StartSoundTool";
+            toolStripMenuItem6.Text = "StartSoundTool";
             // 
             // butFindMenu
             // 
-            this.butFindMenu.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.butFindMenu.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.butFindMenu.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.butFindMenu.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.butFindMenu.Image = global::TombEditor.Properties.Resources.general_search_16;
-            this.butFindMenu.Margin = new System.Windows.Forms.Padding(1, 2, 1, 0);
-            this.butFindMenu.Name = "butFindMenu";
-            this.butFindMenu.Size = new System.Drawing.Size(28, 23);
-            this.butFindMenu.ToolTipText = "Search for menu entry";
-            this.butFindMenu.Click += new System.EventHandler(this.butFindMenu_Click);
+            butFindMenu.Alignment = ToolStripItemAlignment.Right;
+            butFindMenu.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            butFindMenu.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            butFindMenu.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            butFindMenu.Image = Properties.Resources.general_search_16;
+            butFindMenu.Margin = new Padding(1, 2, 1, 0);
+            butFindMenu.Name = "butFindMenu";
+            butFindMenu.Size = new System.Drawing.Size(28, 23);
+            butFindMenu.ToolTipText = "Search for menu entry";
+            butFindMenu.Click += butFindMenu_Click;
             // 
             // windowToolStripMenuItem
             // 
-            this.windowToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.windowToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.restoreDefaultLayoutToolStripMenuItem,
-            this.toolStripMenuSeparator14,
-            this.sectorOptionsToolStripMenuItem,
-            this.roomOptionsToolStripMenuItem,
-            this.itemBrowserToolStripMenuItem,
-            this.importedGeometryBrowserToolstripMenuItem,
-            this.triggerListToolStripMenuItem,
-            this.lightingToolStripMenuItem,
-            this.paletteToolStripMenuItem,
-            this.texturePanelToolStripMenuItem,
-            this.objectListToolStripMenuItem,
-            this.statisticsToolStripMenuItem,
-            this.dockableToolStripMenuItem,
-            this.floatingToolStripMenuItem});
-            this.windowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.windowToolStripMenuItem.Name = "windowToolStripMenuItem";
-            this.windowToolStripMenuItem.Size = new System.Drawing.Size(63, 25);
-            this.windowToolStripMenuItem.Text = "Window";
+            windowToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            windowToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { restoreDefaultLayoutToolStripMenuItem, toolStripMenuSeparator14, sectorOptionsToolStripMenuItem, roomOptionsToolStripMenuItem, itemBrowserToolStripMenuItem, importedGeometryBrowserToolstripMenuItem, triggerListToolStripMenuItem, lightingToolStripMenuItem, paletteToolStripMenuItem, texturePanelToolStripMenuItem, objectListToolStripMenuItem, statisticsToolStripMenuItem, dockableToolStripMenuItem, floatingToolStripMenuItem });
+            windowToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            windowToolStripMenuItem.Name = "windowToolStripMenuItem";
+            windowToolStripMenuItem.Size = new System.Drawing.Size(71, 25);
+            windowToolStripMenuItem.Text = "Window";
             // 
             // restoreDefaultLayoutToolStripMenuItem
             // 
-            this.restoreDefaultLayoutToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.restoreDefaultLayoutToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.restoreDefaultLayoutToolStripMenuItem.Name = "restoreDefaultLayoutToolStripMenuItem";
-            this.restoreDefaultLayoutToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.restoreDefaultLayoutToolStripMenuItem.Text = "Restore default layout";
-            this.restoreDefaultLayoutToolStripMenuItem.Click += new System.EventHandler(this.restoreDefaultLayoutToolStripMenuItem_Click);
+            restoreDefaultLayoutToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            restoreDefaultLayoutToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            restoreDefaultLayoutToolStripMenuItem.Name = "restoreDefaultLayoutToolStripMenuItem";
+            restoreDefaultLayoutToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            restoreDefaultLayoutToolStripMenuItem.Text = "Restore default layout";
+            restoreDefaultLayoutToolStripMenuItem.Click += restoreDefaultLayoutToolStripMenuItem_Click;
             // 
             // toolStripMenuSeparator14
             // 
-            this.toolStripMenuSeparator14.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.toolStripMenuSeparator14.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.toolStripMenuSeparator14.Margin = new System.Windows.Forms.Padding(0, 0, 0, 1);
-            this.toolStripMenuSeparator14.Name = "toolStripMenuSeparator14";
-            this.toolStripMenuSeparator14.Size = new System.Drawing.Size(243, 6);
+            toolStripMenuSeparator14.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            toolStripMenuSeparator14.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripMenuSeparator14.Margin = new Padding(0, 0, 0, 1);
+            toolStripMenuSeparator14.Name = "toolStripMenuSeparator14";
+            toolStripMenuSeparator14.Size = new System.Drawing.Size(275, 6);
             // 
             // sectorOptionsToolStripMenuItem
             // 
-            this.sectorOptionsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.sectorOptionsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.sectorOptionsToolStripMenuItem.Name = "sectorOptionsToolStripMenuItem";
-            this.sectorOptionsToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.sectorOptionsToolStripMenuItem.Tag = "ShowSectorOptions";
-            this.sectorOptionsToolStripMenuItem.Text = "ShowSectorOptions";
+            sectorOptionsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            sectorOptionsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            sectorOptionsToolStripMenuItem.Name = "sectorOptionsToolStripMenuItem";
+            sectorOptionsToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            sectorOptionsToolStripMenuItem.Tag = "ShowSectorOptions";
+            sectorOptionsToolStripMenuItem.Text = "ShowSectorOptions";
             // 
             // roomOptionsToolStripMenuItem
             // 
-            this.roomOptionsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.roomOptionsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.roomOptionsToolStripMenuItem.Name = "roomOptionsToolStripMenuItem";
-            this.roomOptionsToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.roomOptionsToolStripMenuItem.Tag = "ShowRoomOptions";
-            this.roomOptionsToolStripMenuItem.Text = "ShowRoomOptions";
+            roomOptionsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            roomOptionsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            roomOptionsToolStripMenuItem.Name = "roomOptionsToolStripMenuItem";
+            roomOptionsToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            roomOptionsToolStripMenuItem.Tag = "ShowRoomOptions";
+            roomOptionsToolStripMenuItem.Text = "ShowRoomOptions";
             // 
             // itemBrowserToolStripMenuItem
             // 
-            this.itemBrowserToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.itemBrowserToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.itemBrowserToolStripMenuItem.Name = "itemBrowserToolStripMenuItem";
-            this.itemBrowserToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.itemBrowserToolStripMenuItem.Tag = "ShowItemBrowser";
-            this.itemBrowserToolStripMenuItem.Text = "ShowItemBrowser";
+            itemBrowserToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            itemBrowserToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            itemBrowserToolStripMenuItem.Name = "itemBrowserToolStripMenuItem";
+            itemBrowserToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            itemBrowserToolStripMenuItem.Tag = "ShowItemBrowser";
+            itemBrowserToolStripMenuItem.Text = "ShowItemBrowser";
             // 
             // importedGeometryBrowserToolstripMenuItem
             // 
-            this.importedGeometryBrowserToolstripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.importedGeometryBrowserToolstripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.importedGeometryBrowserToolstripMenuItem.Name = "importedGeometryBrowserToolstripMenuItem";
-            this.importedGeometryBrowserToolstripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.importedGeometryBrowserToolstripMenuItem.Tag = "ShowImportedGeometryBrowser";
-            this.importedGeometryBrowserToolstripMenuItem.Text = "ShowImportedGeometryBrowser";
+            importedGeometryBrowserToolstripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            importedGeometryBrowserToolstripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            importedGeometryBrowserToolstripMenuItem.Name = "importedGeometryBrowserToolstripMenuItem";
+            importedGeometryBrowserToolstripMenuItem.Size = new System.Drawing.Size(278, 24);
+            importedGeometryBrowserToolstripMenuItem.Tag = "ShowImportedGeometryBrowser";
+            importedGeometryBrowserToolstripMenuItem.Text = "ShowImportedGeometryBrowser";
             // 
             // triggerListToolStripMenuItem
             // 
-            this.triggerListToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.triggerListToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.triggerListToolStripMenuItem.Name = "triggerListToolStripMenuItem";
-            this.triggerListToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.triggerListToolStripMenuItem.Tag = "ShowTriggerList";
-            this.triggerListToolStripMenuItem.Text = "ShowTriggerList";
+            triggerListToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            triggerListToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            triggerListToolStripMenuItem.Name = "triggerListToolStripMenuItem";
+            triggerListToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            triggerListToolStripMenuItem.Tag = "ShowTriggerList";
+            triggerListToolStripMenuItem.Text = "ShowTriggerList";
             // 
             // lightingToolStripMenuItem
             // 
-            this.lightingToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.lightingToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.lightingToolStripMenuItem.Name = "lightingToolStripMenuItem";
-            this.lightingToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.lightingToolStripMenuItem.Tag = "ShowLighting";
-            this.lightingToolStripMenuItem.Text = "ShowLighting";
+            lightingToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lightingToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            lightingToolStripMenuItem.Name = "lightingToolStripMenuItem";
+            lightingToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            lightingToolStripMenuItem.Tag = "ShowLighting";
+            lightingToolStripMenuItem.Text = "ShowLighting";
             // 
             // paletteToolStripMenuItem
             // 
-            this.paletteToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.paletteToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.paletteToolStripMenuItem.Name = "paletteToolStripMenuItem";
-            this.paletteToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.paletteToolStripMenuItem.Tag = "ShowPalette";
-            this.paletteToolStripMenuItem.Text = "ShowPalette";
+            paletteToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            paletteToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            paletteToolStripMenuItem.Name = "paletteToolStripMenuItem";
+            paletteToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            paletteToolStripMenuItem.Tag = "ShowPalette";
+            paletteToolStripMenuItem.Text = "ShowPalette";
             // 
             // texturePanelToolStripMenuItem
             // 
-            this.texturePanelToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.texturePanelToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.texturePanelToolStripMenuItem.Name = "texturePanelToolStripMenuItem";
-            this.texturePanelToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.texturePanelToolStripMenuItem.Tag = "ShowTexturePanel";
-            this.texturePanelToolStripMenuItem.Text = "ShowTexturePanel";
+            texturePanelToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            texturePanelToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            texturePanelToolStripMenuItem.Name = "texturePanelToolStripMenuItem";
+            texturePanelToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            texturePanelToolStripMenuItem.Tag = "ShowTexturePanel";
+            texturePanelToolStripMenuItem.Text = "ShowTexturePanel";
             // 
             // objectListToolStripMenuItem
             // 
-            this.objectListToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.objectListToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.objectListToolStripMenuItem.Name = "objectListToolStripMenuItem";
-            this.objectListToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.objectListToolStripMenuItem.Tag = "ShowObjectList";
-            this.objectListToolStripMenuItem.Text = "ShowObjectList";
+            objectListToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            objectListToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            objectListToolStripMenuItem.Name = "objectListToolStripMenuItem";
+            objectListToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            objectListToolStripMenuItem.Tag = "ShowObjectList";
+            objectListToolStripMenuItem.Text = "ShowObjectList";
             // 
             // statisticsToolStripMenuItem
             // 
-            this.statisticsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.statisticsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.statisticsToolStripMenuItem.Name = "statisticsToolStripMenuItem";
-            this.statisticsToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.statisticsToolStripMenuItem.Tag = "ShowStatistics";
-            this.statisticsToolStripMenuItem.Text = "ShowStatistics";
+            statisticsToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            statisticsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            statisticsToolStripMenuItem.Name = "statisticsToolStripMenuItem";
+            statisticsToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            statisticsToolStripMenuItem.Tag = "ShowStatistics";
+            statisticsToolStripMenuItem.Text = "ShowStatistics";
             // 
             // dockableToolStripMenuItem
             // 
-            this.dockableToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.dockableToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.dockableToolStripMenuItem.Name = "dockableToolStripMenuItem";
-            this.dockableToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.dockableToolStripMenuItem.Tag = "ShowToolPalette";
-            this.dockableToolStripMenuItem.Text = "ShowToolPalette";
+            dockableToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            dockableToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            dockableToolStripMenuItem.Name = "dockableToolStripMenuItem";
+            dockableToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            dockableToolStripMenuItem.Tag = "ShowToolPalette";
+            dockableToolStripMenuItem.Text = "ShowToolPalette";
             // 
             // floatingToolStripMenuItem
             // 
-            this.floatingToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.floatingToolStripMenuItem.CheckOnClick = true;
-            this.floatingToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.floatingToolStripMenuItem.Name = "floatingToolStripMenuItem";
-            this.floatingToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.floatingToolStripMenuItem.Text = "Tool Palette (floating)";
-            this.floatingToolStripMenuItem.CheckedChanged += new System.EventHandler(this.floatingToolStripMenuItem_CheckedChanged);
+            floatingToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            floatingToolStripMenuItem.CheckOnClick = true;
+            floatingToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            floatingToolStripMenuItem.Name = "floatingToolStripMenuItem";
+            floatingToolStripMenuItem.Size = new System.Drawing.Size(278, 24);
+            floatingToolStripMenuItem.Text = "Tool Palette (floating)";
+            floatingToolStripMenuItem.CheckedChanged += floatingToolStripMenuItem_CheckedChanged;
             // 
             // helpToolStripMenuItem
             // 
-            this.helpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.aboutToolStripMenuItem});
-            this.helpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 25);
-            this.helpToolStripMenuItem.Text = "Help";
+            helpToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            helpToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { aboutToolStripMenuItem });
+            helpToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+            helpToolStripMenuItem.Size = new System.Drawing.Size(49, 25);
+            helpToolStripMenuItem.Text = "Help";
             // 
             // aboutToolStripMenuItem
             // 
-            this.aboutToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.aboutToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.aboutToolStripMenuItem.Image = global::TombEditor.Properties.Resources.general_AboutIcon_16;
-            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(183, 22);
-            this.aboutToolStripMenuItem.Text = "About Tomb Editor...";
-            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
+            aboutToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            aboutToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            aboutToolStripMenuItem.Image = Properties.Resources.general_AboutIcon_16;
+            aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
+            aboutToolStripMenuItem.Size = new System.Drawing.Size(203, 24);
+            aboutToolStripMenuItem.Text = "About Tomb Editor...";
+            aboutToolStripMenuItem.Click += aboutToolStripMenuItem_Click;
             // 
             // tbSearchMenu
             // 
-            this.tbSearchMenu.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.tbSearchMenu.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.tbSearchMenu.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.tbSearchMenu.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this.tbSearchMenu.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.tbSearchMenu.Margin = new System.Windows.Forms.Padding(0, 2, 0, 0);
-            this.tbSearchMenu.Name = "tbSearchMenu";
-            this.tbSearchMenu.Size = new System.Drawing.Size(200, 23);
-            this.tbSearchMenu.ToolTipText = "Search for menu entry";
-            this.tbSearchMenu.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbSearchMenu_KeyDown);
+            tbSearchMenu.Alignment = ToolStripItemAlignment.Right;
+            tbSearchMenu.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            tbSearchMenu.BorderStyle = BorderStyle.FixedSingle;
+            tbSearchMenu.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            tbSearchMenu.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            tbSearchMenu.Margin = new Padding(0, 2, 0, 0);
+            tbSearchMenu.Name = "tbSearchMenu";
+            tbSearchMenu.Size = new System.Drawing.Size(200, 23);
+            tbSearchMenu.ToolTipText = "Search for menu entry";
+            tbSearchMenu.KeyDown += tbSearchMenu_KeyDown;
             // 
             // debugToolStripMenuItem
             // 
-            this.debugToolStripMenuItem.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.debugToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.debugToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.debugAction0ToolStripMenuItem,
-            this.debugAction1ToolStripMenuItem,
-            this.debugAction2ToolStripMenuItem,
-            this.debugAction3ToolStripMenuItem,
-            this.debugAction4ToolStripMenuItem,
-            this.debugAction5ToolStripMenuItem,
-            this.debugScriptToolStripMenuItem});
-            this.debugToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.debugToolStripMenuItem.Name = "debugToolStripMenuItem";
-            this.debugToolStripMenuItem.Size = new System.Drawing.Size(54, 25);
-            this.debugToolStripMenuItem.Text = "Debug";
-            this.debugToolStripMenuItem.Visible = false;
+            debugToolStripMenuItem.Alignment = ToolStripItemAlignment.Right;
+            debugToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            debugToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { debugAction0ToolStripMenuItem, debugAction1ToolStripMenuItem, debugAction2ToolStripMenuItem, debugAction3ToolStripMenuItem, debugAction4ToolStripMenuItem, debugAction5ToolStripMenuItem, debugScriptToolStripMenuItem });
+            debugToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            debugToolStripMenuItem.Name = "debugToolStripMenuItem";
+            debugToolStripMenuItem.Size = new System.Drawing.Size(62, 25);
+            debugToolStripMenuItem.Text = "Debug";
+            debugToolStripMenuItem.Visible = false;
             // 
             // debugAction0ToolStripMenuItem
             // 
-            this.debugAction0ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.debugAction0ToolStripMenuItem.Name = "debugAction0ToolStripMenuItem";
-            this.debugAction0ToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.debugAction0ToolStripMenuItem.Text = "Debug Action 0";
-            this.debugAction0ToolStripMenuItem.Click += new System.EventHandler(this.debugAction0ToolStripMenuItem_Click);
+            debugAction0ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            debugAction0ToolStripMenuItem.Name = "debugAction0ToolStripMenuItem";
+            debugAction0ToolStripMenuItem.Size = new System.Drawing.Size(174, 24);
+            debugAction0ToolStripMenuItem.Text = "Debug Action 0";
+            debugAction0ToolStripMenuItem.Click += debugAction0ToolStripMenuItem_Click;
             // 
             // debugAction1ToolStripMenuItem
             // 
-            this.debugAction1ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.debugAction1ToolStripMenuItem.Name = "debugAction1ToolStripMenuItem";
-            this.debugAction1ToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.debugAction1ToolStripMenuItem.Text = "Debug Action 1";
-            this.debugAction1ToolStripMenuItem.Click += new System.EventHandler(this.debugAction1ToolStripMenuItem_Click);
+            debugAction1ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            debugAction1ToolStripMenuItem.Name = "debugAction1ToolStripMenuItem";
+            debugAction1ToolStripMenuItem.Size = new System.Drawing.Size(174, 24);
+            debugAction1ToolStripMenuItem.Text = "Debug Action 1";
+            debugAction1ToolStripMenuItem.Click += debugAction1ToolStripMenuItem_Click;
             // 
             // debugAction2ToolStripMenuItem
             // 
-            this.debugAction2ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.debugAction2ToolStripMenuItem.Name = "debugAction2ToolStripMenuItem";
-            this.debugAction2ToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.debugAction2ToolStripMenuItem.Text = "Debug Action 2";
-            this.debugAction2ToolStripMenuItem.Click += new System.EventHandler(this.debugAction2ToolStripMenuItem_Click);
+            debugAction2ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            debugAction2ToolStripMenuItem.Name = "debugAction2ToolStripMenuItem";
+            debugAction2ToolStripMenuItem.Size = new System.Drawing.Size(174, 24);
+            debugAction2ToolStripMenuItem.Text = "Debug Action 2";
+            debugAction2ToolStripMenuItem.Click += debugAction2ToolStripMenuItem_Click;
             // 
             // debugAction3ToolStripMenuItem
             // 
-            this.debugAction3ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.debugAction3ToolStripMenuItem.Name = "debugAction3ToolStripMenuItem";
-            this.debugAction3ToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.debugAction3ToolStripMenuItem.Text = "Debug Action 3";
-            this.debugAction3ToolStripMenuItem.Click += new System.EventHandler(this.debugAction3ToolStripMenuItem_Click);
+            debugAction3ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            debugAction3ToolStripMenuItem.Name = "debugAction3ToolStripMenuItem";
+            debugAction3ToolStripMenuItem.Size = new System.Drawing.Size(174, 24);
+            debugAction3ToolStripMenuItem.Text = "Debug Action 3";
+            debugAction3ToolStripMenuItem.Click += debugAction3ToolStripMenuItem_Click;
             // 
             // debugAction4ToolStripMenuItem
             // 
-            this.debugAction4ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.debugAction4ToolStripMenuItem.Name = "debugAction4ToolStripMenuItem";
-            this.debugAction4ToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.debugAction4ToolStripMenuItem.Text = "Debug Action 4";
-            this.debugAction4ToolStripMenuItem.Click += new System.EventHandler(this.debugAction4ToolStripMenuItem_Click);
+            debugAction4ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            debugAction4ToolStripMenuItem.Name = "debugAction4ToolStripMenuItem";
+            debugAction4ToolStripMenuItem.Size = new System.Drawing.Size(174, 24);
+            debugAction4ToolStripMenuItem.Text = "Debug Action 4";
+            debugAction4ToolStripMenuItem.Click += debugAction4ToolStripMenuItem_Click;
             // 
             // debugAction5ToolStripMenuItem
             // 
-            this.debugAction5ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.debugAction5ToolStripMenuItem.Name = "debugAction5ToolStripMenuItem";
-            this.debugAction5ToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.debugAction5ToolStripMenuItem.Text = "Debug Action 5";
-            this.debugAction5ToolStripMenuItem.Click += new System.EventHandler(this.debugAction5ToolStripMenuItem_Click);
+            debugAction5ToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            debugAction5ToolStripMenuItem.Name = "debugAction5ToolStripMenuItem";
+            debugAction5ToolStripMenuItem.Size = new System.Drawing.Size(174, 24);
+            debugAction5ToolStripMenuItem.Text = "Debug Action 5";
+            debugAction5ToolStripMenuItem.Click += debugAction5ToolStripMenuItem_Click;
             // 
             // debugScriptToolStripMenuItem
             // 
-            this.debugScriptToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.debugScriptToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.debugScriptToolStripMenuItem.Name = "debugScriptToolStripMenuItem";
-            this.debugScriptToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.debugScriptToolStripMenuItem.Text = "Debug script";
-            this.debugScriptToolStripMenuItem.Click += new System.EventHandler(this.debugScriptToolStripMenuItem_Click);
+            debugScriptToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            debugScriptToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            debugScriptToolStripMenuItem.Name = "debugScriptToolStripMenuItem";
+            debugScriptToolStripMenuItem.Size = new System.Drawing.Size(174, 24);
+            debugScriptToolStripMenuItem.Text = "Debug script";
+            debugScriptToolStripMenuItem.Click += debugScriptToolStripMenuItem_Click;
             // 
             // butRoomDown
             // 
-            this.butRoomDown.Checked = false;
-            this.butRoomDown.Location = new System.Drawing.Point(0, 0);
-            this.butRoomDown.Name = "butRoomDown";
-            this.butRoomDown.Size = new System.Drawing.Size(75, 23);
-            this.butRoomDown.TabIndex = 0;
+            butRoomDown.Checked = false;
+            butRoomDown.Location = new System.Drawing.Point(0, 0);
+            butRoomDown.Name = "butRoomDown";
+            butRoomDown.Size = new System.Drawing.Size(75, 23);
+            butRoomDown.TabIndex = 0;
             // 
             // butEditRoomName
             // 
-            this.butEditRoomName.Checked = false;
-            this.butEditRoomName.Location = new System.Drawing.Point(0, 0);
-            this.butEditRoomName.Name = "butEditRoomName";
-            this.butEditRoomName.Size = new System.Drawing.Size(75, 23);
-            this.butEditRoomName.TabIndex = 0;
+            butEditRoomName.Checked = false;
+            butEditRoomName.Location = new System.Drawing.Point(0, 0);
+            butEditRoomName.Name = "butEditRoomName";
+            butEditRoomName.Size = new System.Drawing.Size(75, 23);
+            butEditRoomName.TabIndex = 0;
             // 
             // butDeleteRoom
             // 
-            this.butDeleteRoom.Checked = false;
-            this.butDeleteRoom.Location = new System.Drawing.Point(0, 0);
-            this.butDeleteRoom.Name = "butDeleteRoom";
-            this.butDeleteRoom.Size = new System.Drawing.Size(75, 23);
-            this.butDeleteRoom.TabIndex = 0;
+            butDeleteRoom.Checked = false;
+            butDeleteRoom.Location = new System.Drawing.Point(0, 0);
+            butDeleteRoom.Name = "butDeleteRoom";
+            butDeleteRoom.Size = new System.Drawing.Size(75, 23);
+            butDeleteRoom.TabIndex = 0;
             // 
             // statusStrip
             // 
-            this.statusStrip.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.statusStrip.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.statusStripSelectedRoom,
-            this.statusStripGlobalSelectionArea,
-            this.statusStripLocalSelectionArea,
-            this.statusAutosave});
-            this.statusStrip.Location = new System.Drawing.Point(0, 440);
-            this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Padding = new System.Windows.Forms.Padding(0, 5, 0, 3);
-            this.statusStrip.Size = new System.Drawing.Size(913, 29);
-            this.statusStrip.TabIndex = 29;
-            this.statusStrip.Text = "statusStrip";
+            statusStrip.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            statusStrip.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            statusStrip.Items.AddRange(new ToolStripItem[] { statusStripSelectedRoom, statusStripGlobalSelectionArea, statusStripLocalSelectionArea, statusAutosave });
+            statusStrip.Location = new System.Drawing.Point(0, 440);
+            statusStrip.Name = "statusStrip";
+            statusStrip.Padding = new Padding(0, 5, 0, 3);
+            statusStrip.Size = new System.Drawing.Size(913, 29);
+            statusStrip.TabIndex = 29;
+            statusStrip.Text = "statusStrip";
             // 
             // statusStripSelectedRoom
             // 
-            this.statusStripSelectedRoom.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.statusStripSelectedRoom.BorderStyle = System.Windows.Forms.Border3DStyle.RaisedOuter;
-            this.statusStripSelectedRoom.ForeColor = System.Drawing.Color.Silver;
-            this.statusStripSelectedRoom.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.statusStripSelectedRoom.Name = "statusStripSelectedRoom";
-            this.statusStripSelectedRoom.Size = new System.Drawing.Size(0, 21);
-            this.statusStripSelectedRoom.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            statusStripSelectedRoom.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            statusStripSelectedRoom.BorderStyle = Border3DStyle.RaisedOuter;
+            statusStripSelectedRoom.ForeColor = System.Drawing.Color.Silver;
+            statusStripSelectedRoom.Margin = new Padding(4, 0, 4, 0);
+            statusStripSelectedRoom.Name = "statusStripSelectedRoom";
+            statusStripSelectedRoom.Size = new System.Drawing.Size(0, 21);
+            statusStripSelectedRoom.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // statusStripGlobalSelectionArea
             // 
-            this.statusStripGlobalSelectionArea.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.statusStripGlobalSelectionArea.BorderStyle = System.Windows.Forms.Border3DStyle.RaisedOuter;
-            this.statusStripGlobalSelectionArea.ForeColor = System.Drawing.Color.Silver;
-            this.statusStripGlobalSelectionArea.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.statusStripGlobalSelectionArea.Name = "statusStripGlobalSelectionArea";
-            this.statusStripGlobalSelectionArea.Size = new System.Drawing.Size(0, 21);
-            this.statusStripGlobalSelectionArea.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            statusStripGlobalSelectionArea.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            statusStripGlobalSelectionArea.BorderStyle = Border3DStyle.RaisedOuter;
+            statusStripGlobalSelectionArea.ForeColor = System.Drawing.Color.Silver;
+            statusStripGlobalSelectionArea.Margin = new Padding(4, 0, 4, 0);
+            statusStripGlobalSelectionArea.Name = "statusStripGlobalSelectionArea";
+            statusStripGlobalSelectionArea.Size = new System.Drawing.Size(0, 21);
+            statusStripGlobalSelectionArea.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // statusStripLocalSelectionArea
             // 
-            this.statusStripLocalSelectionArea.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.statusStripLocalSelectionArea.BorderStyle = System.Windows.Forms.Border3DStyle.RaisedOuter;
-            this.statusStripLocalSelectionArea.ForeColor = System.Drawing.Color.Silver;
-            this.statusStripLocalSelectionArea.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.statusStripLocalSelectionArea.Name = "statusStripLocalSelectionArea";
-            this.statusStripLocalSelectionArea.Size = new System.Drawing.Size(0, 21);
-            this.statusStripLocalSelectionArea.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            statusStripLocalSelectionArea.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            statusStripLocalSelectionArea.BorderStyle = Border3DStyle.RaisedOuter;
+            statusStripLocalSelectionArea.ForeColor = System.Drawing.Color.Silver;
+            statusStripLocalSelectionArea.Margin = new Padding(4, 0, 4, 0);
+            statusStripLocalSelectionArea.Name = "statusStripLocalSelectionArea";
+            statusStripLocalSelectionArea.Size = new System.Drawing.Size(0, 21);
+            statusStripLocalSelectionArea.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // statusAutosave
             // 
-            this.statusAutosave.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.statusAutosave.ForeColor = System.Drawing.Color.Silver;
-            this.statusAutosave.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.statusAutosave.Name = "statusAutosave";
-            this.statusAutosave.Size = new System.Drawing.Size(0, 21);
+            statusAutosave.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            statusAutosave.ForeColor = System.Drawing.Color.Silver;
+            statusAutosave.Margin = new Padding(4, 0, 4, 0);
+            statusAutosave.Name = "statusAutosave";
+            statusAutosave.Size = new System.Drawing.Size(0, 21);
             // 
             // dockArea
             // 
-            this.dockArea.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dockArea.Location = new System.Drawing.Point(0, 0);
-            this.dockArea.MinimumSize = new System.Drawing.Size(274, 274);
-            this.dockArea.Name = "dockArea";
-            this.dockArea.Padding = new System.Windows.Forms.Padding(2);
-            this.dockArea.Size = new System.Drawing.Size(913, 411);
-            this.dockArea.TabIndex = 90;
-            this.dockArea.ContentAdded += new System.EventHandler<DarkUI.Docking.DockContentEventArgs>(this.ToolWindow_Added);
-            this.dockArea.ContentRemoved += new System.EventHandler<DarkUI.Docking.DockContentEventArgs>(this.ToolWindow_Removed);
+            dockArea.Dock = DockStyle.Fill;
+            dockArea.Location = new System.Drawing.Point(0, 0);
+            dockArea.MinimumSize = new System.Drawing.Size(274, 274);
+            dockArea.Name = "dockArea";
+            dockArea.Padding = new Padding(2);
+            dockArea.Size = new System.Drawing.Size(913, 411);
+            dockArea.TabIndex = 90;
+            dockArea.ContentAdded += ToolWindow_Added;
+            dockArea.ContentRemoved += ToolWindow_Removed;
             // 
             // panelDockArea
             // 
-            this.panelDockArea.Controls.Add(this.dockArea);
-            this.panelDockArea.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelDockArea.Location = new System.Drawing.Point(0, 29);
-            this.panelDockArea.Name = "panelDockArea";
-            this.panelDockArea.Size = new System.Drawing.Size(913, 411);
-            this.panelDockArea.TabIndex = 26;
+            panelDockArea.Controls.Add(dockArea);
+            panelDockArea.Dock = DockStyle.Fill;
+            panelDockArea.Location = new System.Drawing.Point(0, 29);
+            panelDockArea.Name = "panelDockArea";
+            panelDockArea.Size = new System.Drawing.Size(913, 411);
+            panelDockArea.TabIndex = 26;
             // 
             // assToolStripMenuItem
             // 
-            this.assToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
-            this.assToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.assToolStripMenuItem.Name = "assToolStripMenuItem";
-            this.assToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.assToolStripMenuItem.Text = "ass";
+            assToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            assToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            assToolStripMenuItem.Name = "assToolStripMenuItem";
+            assToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            assToolStripMenuItem.Text = "ass";
+            // 
+            // editVolumesToolStripMenuItem
+            // 
+            editVolumesToolStripMenuItem.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            editVolumesToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            editVolumesToolStripMenuItem.Name = "editVolumesToolStripMenuItem";
+            editVolumesToolStripMenuItem.Size = new System.Drawing.Size(235, 24);
+            editVolumesToolStripMenuItem.Tag = "EditVolumes";
+            editVolumesToolStripMenuItem.Text = "EditVolumes";
             // 
             // FormMain
             // 
-            this.AllowDrop = true;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(913, 469);
-            this.Controls.Add(this.panelDockArea);
-            this.Controls.Add(this.statusStrip);
-            this.Controls.Add(this.menuStrip);
-            this.KeyPreview = true;
-            this.MainMenuStrip = this.menuStrip;
-            this.Name = "FormMain";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
-            this.Text = "Tomb Editor";
-            this.menuStrip.ResumeLayout(false);
-            this.menuStrip.PerformLayout();
-            this.statusStrip.ResumeLayout(false);
-            this.statusStrip.PerformLayout();
-            this.panelDockArea.ResumeLayout(false);
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AllowDrop = true;
+            AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(913, 469);
+            Controls.Add(panelDockArea);
+            Controls.Add(statusStrip);
+            Controls.Add(menuStrip);
+            KeyPreview = true;
+            MainMenuStrip = menuStrip;
+            Name = "FormMain";
+            StartPosition = FormStartPosition.Manual;
+            Text = "Tomb Editor";
+            menuStrip.ResumeLayout(false);
+            menuStrip.PerformLayout();
+            statusStrip.ResumeLayout(false);
+            statusStrip.PerformLayout();
+            panelDockArea.ResumeLayout(false);
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
 
         private DarkUI.Controls.DarkMenuStrip menuStrip;
-        private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem roomsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem itemsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem texturesToolStripMenuItem;
+        private ToolStripMenuItem fileToolStripMenuItem;
+        private ToolStripMenuItem roomsToolStripMenuItem;
+        private ToolStripMenuItem itemsToolStripMenuItem;
+        private ToolStripMenuItem texturesToolStripMenuItem;
         private DarkUI.Controls.DarkButton butDeleteRoom;
         private DarkUI.Controls.DarkButton butEditRoomName;
         private DarkUI.Controls.DarkButton butRoomDown;
         private DarkUI.Controls.DarkStatusStrip statusStrip;
-        private System.Windows.Forms.ToolStripMenuItem newLevelToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem openLevelToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveLevelToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveAsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator1;
-        private System.Windows.Forms.ToolStripMenuItem importTRLEPRJToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator2;
-        private System.Windows.Forms.ToolStripMenuItem buildLevelToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem buildLevelPlayToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator3;
-        private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem smoothRandomFloorUpToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem smoothRandomFloorDownToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem averageFloorToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem averageCeilingToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem addCameraToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem addFlybyCameraToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem addSinkToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem addSoundSourceToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator8;
-        private System.Windows.Forms.ToolStripMenuItem findObjectToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem loadTextureToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator9;
-        private System.Windows.Forms.ToolStripMenuItem textureFloorToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem textureCeilingToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem textureWallsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator10;
-        private System.Windows.Forms.ToolStripMenuItem animationRangesToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem importConvertTexturesToPng;
-        private System.Windows.Forms.ToolStripMenuItem addWadToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator6;
-        private System.Windows.Forms.ToolStripStatusLabel statusStripSelectedRoom;
-        private System.Windows.Forms.ToolStripMenuItem smoothRandomCeilingUpToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem smoothRandomCeilingDownToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator12;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator5;
-        private System.Windows.Forms.ToolStripMenuItem duplicateRoomToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem splitRoomToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem cropRoomToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem debugToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem debugAction0ToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem debugAction1ToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem debugAction2ToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem debugAction3ToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem debugAction4ToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem debugAction5ToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator13;
-        private System.Windows.Forms.ToolStripMenuItem gridWallsIn3ToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem gridWallsIn5ToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator11;
-        private System.Windows.Forms.ToolStripMenuItem sharpRandomFloorUpToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem sharpRandomFloorDownToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem sharpRandomCeilingUpToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem sharpRandomCeilingDownToolStripMenuItem;
-        private System.Windows.Forms.ToolStripStatusLabel statusStripGlobalSelectionArea;
-        private System.Windows.Forms.ToolStripStatusLabel statusStripLocalSelectionArea;
-        private System.Windows.Forms.ToolStripMenuItem removeTexturesToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem removeWadsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem reloadTexturesToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem reloadWadsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem moveLaraToolStripMenuItem;
+        private ToolStripMenuItem newLevelToolStripMenuItem;
+        private ToolStripMenuItem openLevelToolStripMenuItem;
+        private ToolStripMenuItem saveLevelToolStripMenuItem;
+        private ToolStripMenuItem saveAsToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuSeparator1;
+        private ToolStripMenuItem importTRLEPRJToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuSeparator2;
+        private ToolStripMenuItem buildLevelToolStripMenuItem;
+        private ToolStripMenuItem buildLevelPlayToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuSeparator3;
+        private ToolStripMenuItem exitToolStripMenuItem;
+        private ToolStripMenuItem smoothRandomFloorUpToolStripMenuItem;
+        private ToolStripMenuItem smoothRandomFloorDownToolStripMenuItem;
+        private ToolStripMenuItem averageFloorToolStripMenuItem;
+        private ToolStripMenuItem averageCeilingToolStripMenuItem;
+        private ToolStripMenuItem addCameraToolStripMenuItem;
+        private ToolStripMenuItem addFlybyCameraToolStripMenuItem;
+        private ToolStripMenuItem addSinkToolStripMenuItem;
+        private ToolStripMenuItem addSoundSourceToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuSeparator8;
+        private ToolStripMenuItem findObjectToolStripMenuItem;
+        private ToolStripMenuItem loadTextureToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuSeparator9;
+        private ToolStripMenuItem textureFloorToolStripMenuItem;
+        private ToolStripMenuItem textureCeilingToolStripMenuItem;
+        private ToolStripMenuItem textureWallsToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuSeparator10;
+        private ToolStripMenuItem animationRangesToolStripMenuItem;
+        private ToolStripMenuItem importConvertTexturesToPng;
+        private ToolStripMenuItem addWadToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuSeparator6;
+        private ToolStripStatusLabel statusStripSelectedRoom;
+        private ToolStripMenuItem smoothRandomCeilingUpToolStripMenuItem;
+        private ToolStripMenuItem smoothRandomCeilingDownToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuSeparator12;
+        private ToolStripSeparator toolStripMenuSeparator5;
+        private ToolStripMenuItem duplicateRoomToolStripMenuItem;
+        private ToolStripMenuItem splitRoomToolStripMenuItem;
+        private ToolStripMenuItem cropRoomToolStripMenuItem;
+        private ToolStripMenuItem debugToolStripMenuItem;
+        private ToolStripMenuItem debugAction0ToolStripMenuItem;
+        private ToolStripMenuItem debugAction1ToolStripMenuItem;
+        private ToolStripMenuItem debugAction2ToolStripMenuItem;
+        private ToolStripMenuItem debugAction3ToolStripMenuItem;
+        private ToolStripMenuItem debugAction4ToolStripMenuItem;
+        private ToolStripMenuItem debugAction5ToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuSeparator13;
+        private ToolStripMenuItem gridWallsIn3ToolStripMenuItem;
+        private ToolStripMenuItem gridWallsIn5ToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuSeparator11;
+        private ToolStripMenuItem sharpRandomFloorUpToolStripMenuItem;
+        private ToolStripMenuItem sharpRandomFloorDownToolStripMenuItem;
+        private ToolStripMenuItem sharpRandomCeilingUpToolStripMenuItem;
+        private ToolStripMenuItem sharpRandomCeilingDownToolStripMenuItem;
+        private ToolStripStatusLabel statusStripGlobalSelectionArea;
+        private ToolStripStatusLabel statusStripLocalSelectionArea;
+        private ToolStripMenuItem removeTexturesToolStripMenuItem;
+        private ToolStripMenuItem removeWadsToolStripMenuItem;
+        private ToolStripMenuItem reloadTexturesToolStripMenuItem;
+        private ToolStripMenuItem reloadWadsToolStripMenuItem;
+        private ToolStripMenuItem moveLaraToolStripMenuItem;
         private DarkUI.Docking.DarkDockPanel dockArea;
-        private System.Windows.Forms.Panel panelDockArea;
-        private System.Windows.Forms.ToolStripMenuItem windowToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem restoreDefaultLayoutToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuSeparator14;
-        private System.Windows.Forms.ToolStripMenuItem sectorOptionsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem roomOptionsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem itemBrowserToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem triggerListToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem lightingToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem paletteToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem texturePanelToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem addGhostBlockToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem addPortalToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem addTriggerToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem transformToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
-        private System.Windows.Forms.ToolStripMenuItem exportRoomToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem objectListToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem deleteRoomsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem importRoomsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripStatusLabel statusAutosave;
-        private System.Windows.Forms.ToolStripMenuItem unloadTexturesToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem debugScriptToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem remapTextureToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem pasteToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem stampToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem deleteToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem selectAllToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-        private System.Windows.Forms.ToolStripMenuItem bookmarkObjectToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem bookmarkRestoreObjectToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-        private System.Windows.Forms.ToolStripMenuItem editObjectToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem searchToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem4;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem5;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem6;
-        private System.Windows.Forms.ToolStripMenuItem keyboardLayoutToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem mergeRoomsHorizontallyToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
-        private System.Windows.Forms.ToolStripMenuItem splitSectorObjectOnSelectionToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem clearAllTexturesInRoomToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem openRecentToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem flattenFloorToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem flattenCeilingToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem moveRoomsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem wholeRoomUpToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem wholeRoomDownToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem moveRoomLeftToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem moveRoomRightToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem moveRoomForwardToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem moveRoomBackToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem newRoomToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem newRoomUpToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem newRoomDownToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem newRoomLeftToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem newRoomRightToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem newRoomFrontToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem newRoomBackToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem editOptionsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem undoToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem redoToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-        private System.Windows.Forms.ToolStripMenuItem cutToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem3;
-        private System.Windows.Forms.ToolStripMenuItem clearAllTexturesInRoomToolStripMenuItem1;
-        private System.Windows.Forms.ToolStripMenuItem gridWallsIn3SquaresToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem gridWallsIn5SquaresToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem resetGeometryToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem moveRoomUp4ClicksToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem moveRoomDown4ClicksToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem viewToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem toggleFlyModeToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem resetCameraToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem relocateCameraToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem transformRoomsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem rotateRoomsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem rotateRoomsCountercockwiseToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem mirrorRoomsOnXAxisToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem mirrorRoomsOnZAxisToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem selectRoomsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem selectWaterRoomsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem selectSkyRoomsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem selectOutsideRoomsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem selectToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
-        private System.Windows.Forms.ToolStripMenuItem selectConnectedRoomsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem selectRoomsByTagsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-        private System.Windows.Forms.ToolStripMenuItem setStaticMeshColorToRoomLightToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem getObjectStatisticsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem7;
-        private System.Windows.Forms.ToolStripMenuItem reloadSoundsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem makeQuickItemGroupToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem addImportedGeometryToolStripMenuItem;
+        private Panel panelDockArea;
+        private ToolStripMenuItem windowToolStripMenuItem;
+        private ToolStripMenuItem restoreDefaultLayoutToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuSeparator14;
+        private ToolStripMenuItem sectorOptionsToolStripMenuItem;
+        private ToolStripMenuItem roomOptionsToolStripMenuItem;
+        private ToolStripMenuItem itemBrowserToolStripMenuItem;
+        private ToolStripMenuItem triggerListToolStripMenuItem;
+        private ToolStripMenuItem lightingToolStripMenuItem;
+        private ToolStripMenuItem paletteToolStripMenuItem;
+        private ToolStripMenuItem texturePanelToolStripMenuItem;
+        private ToolStripMenuItem addGhostBlockToolStripMenuItem;
+        private ToolStripMenuItem addPortalToolStripMenuItem;
+        private ToolStripMenuItem addTriggerToolStripMenuItem;
+        private ToolStripMenuItem transformToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuItem1;
+        private ToolStripMenuItem exportRoomToolStripMenuItem;
+        private ToolStripMenuItem helpToolStripMenuItem;
+        private ToolStripMenuItem aboutToolStripMenuItem;
+        private ToolStripMenuItem objectListToolStripMenuItem;
+        private ToolStripMenuItem deleteRoomsToolStripMenuItem;
+        private ToolStripMenuItem importRoomsToolStripMenuItem;
+        private ToolStripStatusLabel statusAutosave;
+        private ToolStripMenuItem unloadTexturesToolStripMenuItem;
+        private ToolStripMenuItem debugScriptToolStripMenuItem;
+        private ToolStripMenuItem remapTextureToolStripMenuItem;
+        private ToolStripMenuItem editToolStripMenuItem;
+        private ToolStripMenuItem copyToolStripMenuItem;
+        private ToolStripMenuItem pasteToolStripMenuItem;
+        private ToolStripMenuItem stampToolStripMenuItem;
+        private ToolStripMenuItem deleteToolStripMenuItem;
+        private ToolStripMenuItem selectAllToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator4;
+        private ToolStripMenuItem bookmarkObjectToolStripMenuItem;
+        private ToolStripMenuItem bookmarkRestoreObjectToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator1;
+        private ToolStripMenuItem editObjectToolStripMenuItem;
+        private ToolStripMenuItem searchToolStripMenuItem;
+        private ToolStripMenuItem toolStripMenuItem4;
+        private ToolStripMenuItem toolStripMenuItem5;
+        private ToolStripMenuItem toolStripMenuItem6;
+        private ToolStripMenuItem keyboardLayoutToolStripMenuItem;
+        private ToolStripMenuItem mergeRoomsHorizontallyToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator7;
+        private ToolStripMenuItem splitSectorObjectOnSelectionToolStripMenuItem;
+        private ToolStripMenuItem clearAllTexturesInRoomToolStripMenuItem;
+        private ToolStripMenuItem openRecentToolStripMenuItem;
+        private ToolStripMenuItem flattenFloorToolStripMenuItem;
+        private ToolStripMenuItem flattenCeilingToolStripMenuItem;
+        private ToolStripMenuItem moveRoomsToolStripMenuItem;
+        private ToolStripMenuItem wholeRoomUpToolStripMenuItem;
+        private ToolStripMenuItem wholeRoomDownToolStripMenuItem;
+        private ToolStripMenuItem moveRoomLeftToolStripMenuItem;
+        private ToolStripMenuItem moveRoomRightToolStripMenuItem;
+        private ToolStripMenuItem moveRoomForwardToolStripMenuItem;
+        private ToolStripMenuItem moveRoomBackToolStripMenuItem;
+        private ToolStripMenuItem newRoomToolStripMenuItem;
+        private ToolStripMenuItem newRoomUpToolStripMenuItem;
+        private ToolStripMenuItem newRoomDownToolStripMenuItem;
+        private ToolStripMenuItem newRoomLeftToolStripMenuItem;
+        private ToolStripMenuItem newRoomRightToolStripMenuItem;
+        private ToolStripMenuItem newRoomFrontToolStripMenuItem;
+        private ToolStripMenuItem newRoomBackToolStripMenuItem;
+        private ToolStripMenuItem editOptionsToolStripMenuItem;
+        private ToolStripMenuItem undoToolStripMenuItem;
+        private ToolStripMenuItem redoToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator2;
+        private ToolStripMenuItem cutToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuItem3;
+        private ToolStripMenuItem clearAllTexturesInRoomToolStripMenuItem1;
+        private ToolStripMenuItem gridWallsIn3SquaresToolStripMenuItem;
+        private ToolStripMenuItem gridWallsIn5SquaresToolStripMenuItem;
+        private ToolStripMenuItem resetGeometryToolStripMenuItem;
+        private ToolStripMenuItem moveRoomUp4ClicksToolStripMenuItem;
+        private ToolStripMenuItem moveRoomDown4ClicksToolStripMenuItem;
+        private ToolStripMenuItem viewToolStripMenuItem;
+        private ToolStripMenuItem toggleFlyModeToolStripMenuItem;
+        private ToolStripMenuItem resetCameraToolStripMenuItem;
+        private ToolStripMenuItem relocateCameraToolStripMenuItem;
+        private ToolStripMenuItem transformRoomsToolStripMenuItem;
+        private ToolStripMenuItem rotateRoomsToolStripMenuItem;
+        private ToolStripMenuItem rotateRoomsCountercockwiseToolStripMenuItem;
+        private ToolStripMenuItem mirrorRoomsOnXAxisToolStripMenuItem;
+        private ToolStripMenuItem mirrorRoomsOnZAxisToolStripMenuItem;
+        private ToolStripMenuItem selectRoomsToolStripMenuItem;
+        private ToolStripMenuItem selectWaterRoomsToolStripMenuItem;
+        private ToolStripMenuItem selectSkyRoomsToolStripMenuItem;
+        private ToolStripMenuItem selectOutsideRoomsToolStripMenuItem;
+        private ToolStripMenuItem selectToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator6;
+        private ToolStripMenuItem selectConnectedRoomsToolStripMenuItem;
+        private ToolStripMenuItem selectRoomsByTagsToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator3;
+        private ToolStripMenuItem setStaticMeshColorToRoomLightToolStripMenuItem;
+        private ToolStripMenuItem getObjectStatisticsToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator5;
+        private ToolStripMenuItem toolStripMenuItem7;
+        private ToolStripMenuItem reloadSoundsToolStripMenuItem;
+        private ToolStripMenuItem makeQuickItemGroupToolStripMenuItem;
+        private ToolStripMenuItem addImportedGeometryToolStripMenuItem;
         private ToolStripMenuItem searchAndReplaceToolStripMenuItem;
         private ToolStripMenuItem findTexturesToolStripMenuItem;
         private ToolStripMenuItem addSphereVolumeToolStripMenuItem;
@@ -2510,12 +2326,12 @@ namespace TombEditor.Forms
         private ToolStripMenuItem toolStripMenuItem9;
         private ToolStripMenuItem addMemoToolStripMenuItem;
         private ToolStripMenuItem statisticsToolStripMenuItem;
-		private ToolStripSeparator toolStripSeparator9;
-		private ToolStripMenuItem toolStripMenuItem10;
-		private ToolStripMenuItem deleteAllToolStripMenuItem;
-		private ToolStripMenuItem deleteAllLightsToolStripMenuItem;
-		private ToolStripMenuItem toolStripMenuItem2;
-		private ToolStripMenuItem deleteAllTriggersToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator9;
+        private ToolStripMenuItem toolStripMenuItem10;
+        private ToolStripMenuItem deleteAllToolStripMenuItem;
+        private ToolStripMenuItem deleteAllLightsToolStripMenuItem;
+        private ToolStripMenuItem toolStripMenuItem2;
+        private ToolStripMenuItem deleteAllTriggersToolStripMenuItem;
         private ToolStripMenuItem selectFloorBelowObjectToolStripMenuItem;
         private ToolStripMenuItem deleteMissingObjectsToolStripMenuItem;
         private ToolStripMenuItem generateObjectNamesToolStripMenuItem;
@@ -2526,5 +2342,6 @@ namespace TombEditor.Forms
         private ToolStripMenuItem dockableToolStripMenuItem;
         private ToolStripMenuItem floatingToolStripMenuItem;
         private ToolStripMenuItem editEventSetsToolStripMenuItem;
+        private ToolStripMenuItem editVolumesToolStripMenuItem;
     }
 }

--- a/TombEditor/Forms/FormMain.resx
+++ b/TombEditor/Forms/FormMain.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/TombEditor/Forms/FormVolume.cs
+++ b/TombEditor/Forms/FormVolume.cs
@@ -236,15 +236,15 @@ namespace TombEditor.Forms
                     break;
 
                 case VolumeEventType.OnBeforeLoadGame:
-                    toolTip.SetToolTip(cbEvents, "Occurs before the game is loaded from a savegame. \nThis event performs continuously.");
+                    toolTip.SetToolTip(cbEvents, "Occurs before the game is loaded from a savegame. \nThis event performs once.");
                     break;
 
                 case VolumeEventType.OnExitToTitle:
-                    toolTip.SetToolTip(cbEvents, "Occurs when exiting to title. \nThis event performs continuously.");
+                    toolTip.SetToolTip(cbEvents, "Occurs when exiting to title. \nThis event performs once.");
                     break;
 
                 case VolumeEventType.OnLaraDeath:
-                    toolTip.SetToolTip(cbEvents, "Occurs when the level finishes upon Lara's death. \nThis event performs continuously.");
+                    toolTip.SetToolTip(cbEvents, "Occurs when the level finishes upon Lara's death. \nThis event performs once.");
                     break;
             }
         }

--- a/TombEditor/Forms/FormVolume.cs
+++ b/TombEditor/Forms/FormVolume.cs
@@ -243,8 +243,8 @@ namespace TombEditor.Forms
                     toolTip.SetToolTip(cbEvents, "Occurs when exiting to title. \nThis event performs once.");
                     break;
 
-                case VolumeEventType.OnLaraDeath:
-                    toolTip.SetToolTip(cbEvents, "Occurs when the level finishes upon Lara's death. \nThis event performs once.");
+                case VolumeEventType.OnPlayerDeath:
+                    toolTip.SetToolTip(cbEvents, "Occurs when the level finishes upon Player's death. \nThis event performs once.");
                     break;
             }
         }
@@ -290,6 +290,9 @@ namespace TombEditor.Forms
 
             foreach (VolumeEventType eventType in Enum.GetValues(typeof(VolumeEventType)))
             {
+                if ((_genericMode && !_genericVolume) && eventType < VolumeEventType.OnLoop)
+                    continue;
+
                 if ((!_genericMode || _genericVolume) && eventType > VolumeEventType.OnVolumeLeave)
                     break;
 
@@ -386,7 +389,12 @@ namespace TombEditor.Forms
             int selectedEvent = Math.Min((int)_instance.EventSet.LastUsedEvent, (int)cbEvents.Items.Count - 1);
 
             cbEvents.SelectedIndex = selectedEvent;
-            triggerManager.Event = _instance.EventSet.Events[(VolumeEventType)selectedEvent];
+
+            if (_genericMode && !_genericVolume)
+                triggerManager.Event = _instance.EventSet.Events[(VolumeEventType)selectedEvent + 3];
+
+            if (!_genericMode || _genericVolume)
+                triggerManager.Event = _instance.EventSet.Events[(VolumeEventType)selectedEvent];
 
             tbName.Text = _instance.EventSet.Name;
 
@@ -573,9 +581,9 @@ namespace TombEditor.Forms
                 _instance.EventSet.LastUsedEvent = (VolumeEventType)cbEvents.SelectedIndex;
                 triggerManager.Event = _instance.EventSet.Events[_instance.EventSet.LastUsedEvent];
             }
-            if (_genericMode && !_genericVolume)
-                if (cbEvents.SelectedIndex < 3)
-                    cbEvents.SelectedIndex = 3;
+            //if (_genericMode && !_genericVolume)
+            //    if (cbEvents.SelectedIndex < 3)
+            //        cbEvents.SelectedIndex = 3;
         }
 
         private void tbName_Validated(object sender, EventArgs e)

--- a/TombEditor/Forms/FormVolume.cs
+++ b/TombEditor/Forms/FormVolume.cs
@@ -243,8 +243,8 @@ namespace TombEditor.Forms
                     toolTip.SetToolTip(cbEvents, "Occurs when exiting to title. \nThis event performs once.");
                     break;
 
-                case VolumeEventType.OnPlayerDeath:
-                    toolTip.SetToolTip(cbEvents, "Occurs when the level finishes upon Player's death. \nThis event performs once.");
+                case VolumeEventType.OnLaraDeath:
+                    toolTip.SetToolTip(cbEvents, "Occurs when the level finishes upon Lara's death. \nThis event performs once.");
                     break;
             }
         }
@@ -290,9 +290,6 @@ namespace TombEditor.Forms
 
             foreach (VolumeEventType eventType in Enum.GetValues(typeof(VolumeEventType)))
             {
-                if ((_genericMode && !_genericVolume) && eventType < VolumeEventType.OnLoop)
-                    continue;
-
                 if ((!_genericMode || _genericVolume) && eventType > VolumeEventType.OnVolumeLeave)
                     break;
 
@@ -389,12 +386,7 @@ namespace TombEditor.Forms
             int selectedEvent = Math.Min((int)_instance.EventSet.LastUsedEvent, (int)cbEvents.Items.Count - 1);
 
             cbEvents.SelectedIndex = selectedEvent;
-
-            if (_genericMode && !_genericVolume)
-                triggerManager.Event = _instance.EventSet.Events[(VolumeEventType)selectedEvent + 3];
-
-            if (!_genericMode || _genericVolume)
-                triggerManager.Event = _instance.EventSet.Events[(VolumeEventType)selectedEvent];
+            triggerManager.Event = _instance.EventSet.Events[(VolumeEventType)selectedEvent];
 
             tbName.Text = _instance.EventSet.Name;
 
@@ -581,9 +573,9 @@ namespace TombEditor.Forms
                 _instance.EventSet.LastUsedEvent = (VolumeEventType)cbEvents.SelectedIndex;
                 triggerManager.Event = _instance.EventSet.Events[_instance.EventSet.LastUsedEvent];
             }
-            //if (_genericMode && !_genericVolume)
-            //    if (cbEvents.SelectedIndex < 3)
-            //        cbEvents.SelectedIndex = 3;
+            if (_genericMode && !_genericVolume)
+                if (cbEvents.SelectedIndex < 3)
+                    cbEvents.SelectedIndex = 3;
         }
 
         private void tbName_Validated(object sender, EventArgs e)

--- a/TombEditor/Forms/FormVolume.cs
+++ b/TombEditor/Forms/FormVolume.cs
@@ -302,21 +302,19 @@ namespace TombEditor.Forms
 
             dgvEvents.Rows.Clear();
 
-            foreach (VolumeEventSet evtSet in _editor.Level.Settings.EventSets)
+            List<VolumeEventSet> filteredList = new();
+
+            if (_genericMode && !_genericVolume)
+                filteredList = _editor.Level.Settings.EventSets.Where(evtSet => evtSet.global).ToList();
+
+            if (!_genericMode || _genericVolume)
+                filteredList = _editor.Level.Settings.EventSets.Where(evtSet => !evtSet.global).ToList();
+
+            foreach (VolumeEventSet evtSet in filteredList)
             {
-                bool check = false;
-                if (_genericMode && !_genericVolume && evtSet.global == true)
-                    check = true;
-
-                if ((!_genericMode || _genericVolume) && evtSet.global == false)
-                    check = true;
-
-                if (check) 
-                {
-                    var row = new DataGridViewRow { Tag = evtSet };
-                    row.Cells.Add(new DataGridViewTextBoxCell() { Value = evtSet.Name });
-                    dgvEvents.Rows.Add(row);
-                }
+                var row = new DataGridViewRow { Tag = evtSet };
+                row.Cells.Add(new DataGridViewTextBoxCell() { Value = evtSet.Name });
+                dgvEvents.Rows.Add(row);
             }
 
             _stopSelectionChangedEvent = false;

--- a/TombEditor/Forms/FormVolume.cs
+++ b/TombEditor/Forms/FormVolume.cs
@@ -234,12 +234,15 @@ namespace TombEditor.Forms
                 case VolumeEventType.OnLoop:
                     toolTip.SetToolTip(cbEvents, "Occurs every game frame, except menus. \nThis event performs continuously.");
                     break;
+
                 case VolumeEventType.OnBeforeLoadGame:
                     toolTip.SetToolTip(cbEvents, "Occurs before the game is loaded from a savegame. \nThis event performs continuously.");
                     break;
+
                 case VolumeEventType.OnExitToTitle:
                     toolTip.SetToolTip(cbEvents, "Occurs when exiting to title. \nThis event performs continuously.");
                     break;
+
                 case VolumeEventType.OnLaraDeath:
                     toolTip.SetToolTip(cbEvents, "Occurs when the level finishes upon Lara's death. \nThis event performs continuously.");
                     break;

--- a/TombEditor/Forms/FormVolume.cs
+++ b/TombEditor/Forms/FormVolume.cs
@@ -308,10 +308,10 @@ namespace TombEditor.Forms
             List<VolumeEventSet> filteredList = new();
 
             if (_genericMode && !_genericVolume)
-                filteredList = _editor.Level.Settings.EventSets.Where(evtSet => evtSet.global).ToList();
+                filteredList = _editor.Level.Settings.EventSets.Where(evtSet => evtSet.isGlobal).ToList();
 
             if (!_genericMode || _genericVolume)
-                filteredList = _editor.Level.Settings.EventSets.Where(evtSet => !evtSet.global).ToList();
+                filteredList = _editor.Level.Settings.EventSets.Where(evtSet => !evtSet.isGlobal).ToList();
 
             foreach (VolumeEventSet evtSet in filteredList)
             {
@@ -462,7 +462,7 @@ namespace TombEditor.Forms
                 evt.Value.Mode = (VolumeEventMode)_editor.Configuration.NodeEditor_DefaultEventMode;
 
             if (_genericMode && !_genericVolume)
-                newSet.global = true;
+                newSet.isGlobal = true;
 
             _editor.Level.Settings.EventSets.Add(newSet);
             _instance.EventSet = newSet;
@@ -594,10 +594,10 @@ namespace TombEditor.Forms
         private void dgvEvents_DragDrop(object sender, DragEventArgs e)
         {
             if (_genericMode && !_genericVolume)
-                _editor.Level.Settings.EventSets.RemoveAll(item => item.global);
+                _editor.Level.Settings.EventSets.RemoveAll(item => item.isGlobal);
             
             if (!_genericMode || _genericVolume)
-                _editor.Level.Settings.EventSets.RemoveAll(item => !item.global);
+                _editor.Level.Settings.EventSets.RemoveAll(item => !item.isGlobal);
 
             foreach (DataGridViewRow row in dgvEvents.Rows)
             {

--- a/TombEditor/Forms/FormVolume.cs
+++ b/TombEditor/Forms/FormVolume.cs
@@ -230,6 +230,15 @@ namespace TombEditor.Forms
                 case VolumeEventType.OnLoop:
                     toolTip.SetToolTip(cbEvents, "Occurs every game frame, except menus. \nThis event performs continuously.");
                     break;
+                case VolumeEventType.OnBeforeLoadGame:
+                    toolTip.SetToolTip(cbEvents, "Occurs before the game is loaded from a savegame. \nThis event performs continuously.");
+                    break;
+                case VolumeEventType.OnExitToTitle:
+                    toolTip.SetToolTip(cbEvents, "Occurs when exiting to title. \nThis event performs continuously.");
+                    break;
+                case VolumeEventType.OnLaraDeath:
+                    toolTip.SetToolTip(cbEvents, "Occurs when the level finishes upon Lara's death. \nThis event performs continuously.");
+                    break;
             }
         }
 

--- a/TombEditor/Forms/FormVolume.cs
+++ b/TombEditor/Forms/FormVolume.cs
@@ -243,8 +243,8 @@ namespace TombEditor.Forms
                     toolTip.SetToolTip(cbEvents, "Occurs when exiting to title. \nThis event performs once.");
                     break;
 
-                case VolumeEventType.OnLaraDeath:
-                    toolTip.SetToolTip(cbEvents, "Occurs when the level finishes upon Lara's death. \nThis event performs once.");
+                case VolumeEventType.OnPlayerDeath:
+                    toolTip.SetToolTip(cbEvents, "Occurs when the level finishes upon Player's death. \nThis event performs once.");
                     break;
             }
         }

--- a/TombEditor/Forms/FormVolume.cs
+++ b/TombEditor/Forms/FormVolume.cs
@@ -39,11 +39,11 @@ namespace TombEditor.Forms
 
         public FormVolume(VolumeInstance instance, bool genericVolume = false)
         {
-            _genericVolume = genericVolume;
             InitializeComponent();
             dgvEvents.Columns.Add(new DataGridViewColumn(new DataGridViewTextBoxCell()) { HeaderText = "Event sets" });
 
             _genericMode = instance == null;
+            _genericVolume = genericVolume;
 
             _editor = Editor.Instance;
             _editor.EditorEventRaised += EditorEventRaised;

--- a/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
@@ -101,7 +101,7 @@ namespace TombLib.LevelData.IO
         /********/public static readonly ChunkId EventSetOnEnd = ChunkId.FromString("TeEventSetOnEnd");
         /********/public static readonly ChunkId EventSetOnBeforeLoad = ChunkId.FromString("TeEventSetOnBeforeLoad");
         /********/public static readonly ChunkId EventSetOnExitToTitle = ChunkId.FromString("TeEventSetOnExitToTitle");
-        /********/public static readonly ChunkId EventSetOnPlayerDeath = ChunkId.FromString("TeEventSetOnLaraDeath");
+        /********/public static readonly ChunkId EventSetOnLaraDeath = ChunkId.FromString("TeEventSetOnLaraDeath");
         /**********/public static readonly ChunkId EventMode = ChunkId.FromString("TeEventMode");
         /**********/public static readonly ChunkId EventFunction = ChunkId.FromString("TeEventFunction");
         /**********/public static readonly ChunkId EventArgument = ChunkId.FromString("TeEventArgument");

--- a/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
@@ -97,7 +97,10 @@ namespace TombLib.LevelData.IO
         /********/public static readonly ChunkId EventSetOnLoad = ChunkId.FromString("TeEventSetOnLoad"); 
         /********/public static readonly ChunkId EventSetOnSave = ChunkId.FromString("TeEventSetOnSave"); 
         /********/public static readonly ChunkId EventSetOnStart = ChunkId.FromString("TeEventSetOnStart");
-        /********/public static readonly ChunkId EventSetOnEnd = ChunkId.FromString("TeEventSetOnEnd"); 
+        /********/public static readonly ChunkId EventSetOnEnd = ChunkId.FromString("TeEventSetOnEnd");
+        /********/public static readonly ChunkId EventSetOnBeforeLoad = ChunkId.FromString("TeEventSetOnBeforeLoad");
+        /********/public static readonly ChunkId EventSetOnExitToTitle = ChunkId.FromString("TeEventSetOnExitToTitle");
+        /********/public static readonly ChunkId EventSetOnLaraDeath = ChunkId.FromString("TeEventSetOnLaraDeath");
         /**********/public static readonly ChunkId EventMode = ChunkId.FromString("TeEventMode");
         /**********/public static readonly ChunkId EventFunction = ChunkId.FromString("TeEventFunction");
         /**********/public static readonly ChunkId EventArgument = ChunkId.FromString("TeEventArgument");

--- a/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
@@ -90,7 +90,7 @@ namespace TombLib.LevelData.IO
         /********/public static readonly ChunkId EventSetName = ChunkId.FromString("TeEventSetName");
         /********/public static readonly ChunkId EventSetLastUsedEventIndex = ChunkId.FromString("TeEventSetLUEI");
         /********/public static readonly ChunkId EventSetActivators = ChunkId.FromString("TeEventSetActivators");
-        /********/public static readonly ChunkId EventSetGlobal = ChunkId.FromString("TeEventSetGlobal");
+        /********/public static readonly ChunkId EventSetIsGlobal = ChunkId.FromString("TeEventSetGlobal");
         /********/public static readonly ChunkId EventSetOnEnter = ChunkId.FromString("TeEventSetOnEnter");
         /********/public static readonly ChunkId EventSetOnLeave = ChunkId.FromString("TeEventSetOnLeave");
         /********/public static readonly ChunkId EventSetOnInside = ChunkId.FromString("TeEventSetOnInside");

--- a/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
@@ -101,7 +101,7 @@ namespace TombLib.LevelData.IO
         /********/public static readonly ChunkId EventSetOnEnd = ChunkId.FromString("TeEventSetOnEnd");
         /********/public static readonly ChunkId EventSetOnBeforeLoad = ChunkId.FromString("TeEventSetOnBeforeLoad");
         /********/public static readonly ChunkId EventSetOnExitToTitle = ChunkId.FromString("TeEventSetOnExitToTitle");
-        /********/public static readonly ChunkId EventSetOnLaraDeath = ChunkId.FromString("TeEventSetOnLaraDeath");
+        /********/public static readonly ChunkId EventSetOnPlayerDeath = ChunkId.FromString("TeEventSetOnLaraDeath");
         /**********/public static readonly ChunkId EventMode = ChunkId.FromString("TeEventMode");
         /**********/public static readonly ChunkId EventFunction = ChunkId.FromString("TeEventFunction");
         /**********/public static readonly ChunkId EventArgument = ChunkId.FromString("TeEventArgument");

--- a/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
@@ -90,6 +90,7 @@ namespace TombLib.LevelData.IO
         /********/public static readonly ChunkId EventSetName = ChunkId.FromString("TeEventSetName");
         /********/public static readonly ChunkId EventSetLastUsedEventIndex = ChunkId.FromString("TeEventSetLUEI");
         /********/public static readonly ChunkId EventSetActivators = ChunkId.FromString("TeEventSetActivators");
+        /********/public static readonly ChunkId EventSetGlobal = ChunkId.FromString("TeEventSetGlobal");
         /********/public static readonly ChunkId EventSetOnEnter = ChunkId.FromString("TeEventSetOnEnter");
         /********/public static readonly ChunkId EventSetOnLeave = ChunkId.FromString("TeEventSetOnLeave");
         /********/public static readonly ChunkId EventSetOnInside = ChunkId.FromString("TeEventSetOnInside");

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -518,7 +518,7 @@ namespace TombLib.LevelData.IO
                                      id3 == Prj2Chunks.EventSetOnLoop   ||
                                      id3 == Prj2Chunks.EventSetOnBeforeLoad ||
                                      id3 == Prj2Chunks.EventSetOnExitToTitle ||
-                                     id3 == Prj2Chunks.EventSetOnLaraDeath)
+                                     id3 == Prj2Chunks.EventSetOnPlayerDeath)
                             {
                                 var evt = new VolumeEvent();
 
@@ -561,8 +561,8 @@ namespace TombLib.LevelData.IO
                                     eventSet.Events[VolumeEventType.OnBeforeLoadGame] = evt;
                                 else if (id3 == Prj2Chunks.EventSetOnExitToTitle)
                                     eventSet.Events[VolumeEventType.OnExitToTitle] = evt;
-                                else if (id3 == Prj2Chunks.EventSetOnLaraDeath)
-                                    eventSet.Events[VolumeEventType.OnLaraDeath] = evt;
+                                else if (id3 == Prj2Chunks.EventSetOnPlayerDeath)
+                                    eventSet.Events[VolumeEventType.OnPlayerDeath] = evt;
                             }
                             else
                                 return false;

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -518,7 +518,7 @@ namespace TombLib.LevelData.IO
                                      id3 == Prj2Chunks.EventSetOnLoop   ||
                                      id3 == Prj2Chunks.EventSetOnBeforeLoad ||
                                      id3 == Prj2Chunks.EventSetOnExitToTitle ||
-                                     id3 == Prj2Chunks.EventSetOnPlayerDeath)
+                                     id3 == Prj2Chunks.EventSetOnLaraDeath)
                             {
                                 var evt = new VolumeEvent();
 
@@ -561,8 +561,8 @@ namespace TombLib.LevelData.IO
                                     eventSet.Events[VolumeEventType.OnBeforeLoadGame] = evt;
                                 else if (id3 == Prj2Chunks.EventSetOnExitToTitle)
                                     eventSet.Events[VolumeEventType.OnExitToTitle] = evt;
-                                else if (id3 == Prj2Chunks.EventSetOnPlayerDeath)
-                                    eventSet.Events[VolumeEventType.OnPlayerDeath] = evt;
+                                else if (id3 == Prj2Chunks.EventSetOnLaraDeath)
+                                    eventSet.Events[VolumeEventType.OnLaraDeath] = evt;
                             }
                             else
                                 return false;

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -502,8 +502,8 @@ namespace TombLib.LevelData.IO
                                 eventSetIndex = chunkIO.ReadChunkInt(chunkSize3);
                             else if (id3 == Prj2Chunks.EventSetName)
                                 eventSet.Name = chunkIO.ReadChunkString(chunkSize3);
-                            else if (id3 == Prj2Chunks.EventSetGlobal)
-                                eventSet.global = chunkIO.ReadChunkBool(chunkSize3);
+                            else if (id3 == Prj2Chunks.EventSetIsGlobal)
+                                eventSet.isGlobal = chunkIO.ReadChunkBool(chunkSize3);
                             else if (id3 == Prj2Chunks.EventSetLastUsedEventIndex)
                                 eventSet.LastUsedEvent = (VolumeEventType)chunkIO.ReadChunkInt(chunkSize3);
                             else if (id3 == Prj2Chunks.EventSetActivators)

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -502,6 +502,8 @@ namespace TombLib.LevelData.IO
                                 eventSetIndex = chunkIO.ReadChunkInt(chunkSize3);
                             else if (id3 == Prj2Chunks.EventSetName)
                                 eventSet.Name = chunkIO.ReadChunkString(chunkSize3);
+                            else if (id3 == Prj2Chunks.EventSetGlobal)
+                                eventSet.global = chunkIO.ReadChunkBool(chunkSize3);
                             else if (id3 == Prj2Chunks.EventSetLastUsedEventIndex)
                                 eventSet.LastUsedEvent = (VolumeEventType)chunkIO.ReadChunkInt(chunkSize3);
                             else if (id3 == Prj2Chunks.EventSetActivators)

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -513,7 +513,10 @@ namespace TombLib.LevelData.IO
                                      id3 == Prj2Chunks.EventSetOnStart  ||
                                      id3 == Prj2Chunks.EventSetOnLoad   ||
                                      id3 == Prj2Chunks.EventSetOnSave   ||
-                                     id3 == Prj2Chunks.EventSetOnLoop)
+                                     id3 == Prj2Chunks.EventSetOnLoop   ||
+                                     id3 == Prj2Chunks.EventSetOnBeforeLoad ||
+                                     id3 == Prj2Chunks.EventSetOnExitToTitle ||
+                                     id3 == Prj2Chunks.EventSetOnLaraDeath)
                             {
                                 var evt = new VolumeEvent();
 
@@ -552,6 +555,12 @@ namespace TombLib.LevelData.IO
                                     eventSet.Events[VolumeEventType.OnSaveGame] = evt;
                                 else if (id3 == Prj2Chunks.EventSetOnLoop)
                                     eventSet.Events[VolumeEventType.OnLoop] = evt;
+                                else if (id3 == Prj2Chunks.EventSetOnBeforeLoad)
+                                    eventSet.Events[VolumeEventType.OnBeforeLoadGame] = evt;
+                                else if (id3 == Prj2Chunks.EventSetOnExitToTitle)
+                                    eventSet.Events[VolumeEventType.OnExitToTitle] = evt;
+                                else if (id3 == Prj2Chunks.EventSetOnLaraDeath)
+                                    eventSet.Events[VolumeEventType.OnLaraDeath] = evt;
                             }
                             else
                                 return false;

--- a/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
@@ -328,7 +328,7 @@ namespace TombLib.LevelData.IO
                                     case VolumeEventType.OnLevelStart:   cid = Prj2Chunks.EventSetOnStart;  break;
                                     case VolumeEventType.OnBeforeLoadGame: cid = Prj2Chunks.EventSetOnBeforeLoad; break;
                                     case VolumeEventType.OnExitToTitle: cid = Prj2Chunks.EventSetOnExitToTitle; break;
-                                    case VolumeEventType.OnPlayerDeath: cid = Prj2Chunks.EventSetOnPlayerDeath; break;
+                                    case VolumeEventType.OnLaraDeath: cid = Prj2Chunks.EventSetOnLaraDeath; break;
                                 }
 
                                 using (var chunkEvent = chunkIO.WriteChunk(cid))

--- a/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
@@ -310,7 +310,7 @@ namespace TombLib.LevelData.IO
                             chunkIO.WriteChunkString(Prj2Chunks.EventSetName, set.Name ?? string.Empty);
                             chunkIO.WriteChunkInt(Prj2Chunks.EventSetLastUsedEventIndex, (int)set.LastUsedEvent);
                             chunkIO.WriteChunkInt(Prj2Chunks.EventSetActivators, (int)set.Activators);
-                            chunkIO.WriteChunkBool(Prj2Chunks.EventSetGlobal, set.global);
+                            chunkIO.WriteChunkBool(Prj2Chunks.EventSetIsGlobal, set.isGlobal);
 
                             foreach (var evt in set.Events)
                             {

--- a/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
@@ -310,6 +310,7 @@ namespace TombLib.LevelData.IO
                             chunkIO.WriteChunkString(Prj2Chunks.EventSetName, set.Name ?? string.Empty);
                             chunkIO.WriteChunkInt(Prj2Chunks.EventSetLastUsedEventIndex, (int)set.LastUsedEvent);
                             chunkIO.WriteChunkInt(Prj2Chunks.EventSetActivators, (int)set.Activators);
+                            chunkIO.WriteChunkBool(Prj2Chunks.EventSetGlobal, set.global);
 
                             foreach (var evt in set.Events)
                             {

--- a/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
@@ -328,7 +328,7 @@ namespace TombLib.LevelData.IO
                                     case VolumeEventType.OnLevelStart:   cid = Prj2Chunks.EventSetOnStart;  break;
                                     case VolumeEventType.OnBeforeLoadGame: cid = Prj2Chunks.EventSetOnBeforeLoad; break;
                                     case VolumeEventType.OnExitToTitle: cid = Prj2Chunks.EventSetOnExitToTitle; break;
-                                    case VolumeEventType.OnLaraDeath: cid = Prj2Chunks.EventSetOnLaraDeath; break;
+                                    case VolumeEventType.OnPlayerDeath: cid = Prj2Chunks.EventSetOnPlayerDeath; break;
                                 }
 
                                 using (var chunkEvent = chunkIO.WriteChunk(cid))

--- a/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
@@ -325,6 +325,9 @@ namespace TombLib.LevelData.IO
                                     case VolumeEventType.OnSaveGame:     cid = Prj2Chunks.EventSetOnSave;   break;
                                     case VolumeEventType.OnLevelEnd:     cid = Prj2Chunks.EventSetOnEnd;    break;
                                     case VolumeEventType.OnLevelStart:   cid = Prj2Chunks.EventSetOnStart;  break;
+                                    case VolumeEventType.OnBeforeLoadGame: cid = Prj2Chunks.EventSetOnBeforeLoad; break;
+                                    case VolumeEventType.OnExitToTitle: cid = Prj2Chunks.EventSetOnExitToTitle; break;
+                                    case VolumeEventType.OnLaraDeath: cid = Prj2Chunks.EventSetOnLaraDeath; break;
                                 }
 
                                 using (var chunkEvent = chunkIO.WriteChunk(cid))

--- a/TombLib/TombLib/LevelData/Instances/VolumeInstance.cs
+++ b/TombLib/TombLib/LevelData/Instances/VolumeInstance.cs
@@ -54,7 +54,7 @@ namespace TombLib.LevelData
         OnLevelEnd,
         OnBeforeLoadGame,
         OnExitToTitle,
-        OnLaraDeath
+        OnPlayerDeath
     }
 
     public class VolumeEvent : ICloneable, IEquatable<VolumeEvent>

--- a/TombLib/TombLib/LevelData/Instances/VolumeInstance.cs
+++ b/TombLib/TombLib/LevelData/Instances/VolumeInstance.cs
@@ -139,7 +139,7 @@ namespace TombLib.LevelData
         public string Name = string.Empty;
         public VolumeEventType LastUsedEvent = VolumeEventType.OnVolumeEnter;
         public VolumeActivators Activators;
-        public bool global = false;
+        public bool isGlobal = false;
 
         // Every volume's events can be reduced to these three.
         // If resulting volume should be one-shot trigger, we'll only use "OnEnter" event.

--- a/TombLib/TombLib/LevelData/Instances/VolumeInstance.cs
+++ b/TombLib/TombLib/LevelData/Instances/VolumeInstance.cs
@@ -139,6 +139,7 @@ namespace TombLib.LevelData
         public string Name = string.Empty;
         public VolumeEventType LastUsedEvent = VolumeEventType.OnVolumeEnter;
         public VolumeActivators Activators;
+        public bool global = false;
 
         // Every volume's events can be reduced to these three.
         // If resulting volume should be one-shot trigger, we'll only use "OnEnter" event.

--- a/TombLib/TombLib/LevelData/Instances/VolumeInstance.cs
+++ b/TombLib/TombLib/LevelData/Instances/VolumeInstance.cs
@@ -51,7 +51,10 @@ namespace TombLib.LevelData
         OnLoadGame,
         OnSaveGame,
         OnLevelStart,
-        OnLevelEnd
+        OnLevelEnd,
+        OnBeforeLoadGame,
+        OnExitToTitle,
+        OnLaraDeath
     }
 
     public class VolumeEvent : ICloneable, IEquatable<VolumeEvent>


### PR DESCRIPTION
Add events: `On Before Load Game`, `On Exit To Title`, `On Lara Death` to run a set of events only in a specific end-of-level case.

Separate management of global event sets and volume event sets. 
