### PR TITLE
Fixed wrong cast to ushort for submesh indices

### DIFF
--- a/TombLib/TombLib/Graphics/Model.cs
+++ b/TombLib/TombLib/Graphics/Model.cs
@@ -44,7 +44,7 @@ namespace TombLib.Graphics
             newVertex.Color = color;
 
             mesh.Vertices.Add(newVertex);
-            submesh.Indices.Add((ushort)(mesh.Vertices.Count - 1));
+            submesh.Indices.Add(mesh.Vertices.Count - 1);
         }
 
         public void Dispose()

--- a/TombLib/TombLib/Graphics/ObjectMesh.cs
+++ b/TombLib/TombLib/Graphics/ObjectMesh.cs
@@ -66,7 +66,7 @@ namespace TombLib.Graphics
             newVertex.Color = color;
 
             mesh.Vertices.Add(newVertex);
-            submesh.Indices.Add((ushort)(mesh.Vertices.Count - 1));
+            submesh.Indices.Add(mesh.Vertices.Count - 1);
         }
 
         public static ObjectMesh FromWad2(GraphicsDevice device, WadMesh msh, Func<WadTexture, VectorInt2> allocateTexture, bool correct)


### PR DESCRIPTION
When generating index buffers for `ObjectMesh`, the resulting index is cast to `ushort` which results in a wrap-around into 0 to 65535.