### PR TITLE
Fix (and de-harcode) texture sounds "limit" when loading a PRJ2

### DIFF
--- a/TombLib/TombLib/LevelData/Enumerations.cs
+++ b/TombLib/TombLib/LevelData/Enumerations.cs
@@ -89,7 +89,9 @@ namespace TombLib.LevelData
             Custom5 = 18,
             Custom6 = 19,
             Custom7 = 20,
-            Custom8 = 21
+            Custom8 = 21,
+
+            Count
         }
 
         // Helper UI function which gets the names of all available footstep sounds
@@ -109,7 +111,7 @@ namespace TombLib.LevelData
             if (settings.GameVersion != TRVersion.Game.TombEngine)
                 result = result.Where(e => !e.Contains("Custom") || e == "Custom 1" || e == "Custom 2").ToList();
 
-            return result;
+            return result.Where(e => e != "Count").ToList();
         }
     }
 

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -405,8 +405,8 @@ namespace TombLib.LevelData.IO
                                     for (int x = 0; x < levelTexture.FootStepSoundWidth; ++x)
                                     {
                                         byte textureSoundByte = chunkIO.Raw.ReadByte();
-                                        if (textureSoundByte > 15)
-                                            textureSoundByte = 15;
+                                        if (textureSoundByte > 21)
+                                            textureSoundByte = 21;
                                         levelTexture.SetFootStepSound(x, y, (TextureFootStep.Type)textureSoundByte);
                                     }
                             }

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -405,8 +405,8 @@ namespace TombLib.LevelData.IO
                                     for (int x = 0; x < levelTexture.FootStepSoundWidth; ++x)
                                     {
                                         byte textureSoundByte = chunkIO.Raw.ReadByte();
-                                        if (textureSoundByte > 21)
-                                            textureSoundByte = 21;
+                                        if (textureSoundByte > (byte)Enum.GetNames(typeof(TextureFootStep.Type)).Length)
+                                            textureSoundByte = (byte)Enum.GetNames(typeof(TextureFootStep.Type)).Length;
                                         levelTexture.SetFootStepSound(x, y, (TextureFootStep.Type)textureSoundByte);
                                     }
                             }

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -404,9 +404,10 @@ namespace TombLib.LevelData.IO
                                 for (int y = 0; y < levelTexture.FootStepSoundHeight; ++y)
                                     for (int x = 0; x < levelTexture.FootStepSoundWidth; ++x)
                                     {
+                                        byte maxSoundByte = (byte)(TextureFootStep.Type.Count - 1);
                                         byte textureSoundByte = chunkIO.Raw.ReadByte();
-                                        if (textureSoundByte > (byte)Enum.GetNames(typeof(TextureFootStep.Type)).Length)
-                                            textureSoundByte = (byte)Enum.GetNames(typeof(TextureFootStep.Type)).Length;
+                                        if (textureSoundByte > maxSoundByte)
+                                            textureSoundByte = maxSoundByte;
                                         levelTexture.SetFootStepSound(x, y, (TextureFootStep.Type)textureSoundByte);
                                     }
                             }


### PR DESCRIPTION
This fixes #814 : loading a PRJ2 was discarding any texture sound ID above 15.

This PR "raises the limit", and also de-hardcodes it by referring to the enum's length instead.
However I'm not sure if it's ok to de-hardcode: I don't know anything about chunks, so I'm not sure why this check was added in the beginning, maybe there's something I'm not seeing.

Just in case de-hardcoding is a bad idea, I first commited the "limit raise" from 15 to 22, then I commited the de-harcoding (so you can still cherry-pick the 1st one).