### PR TITLE
Keep RoomGeometry allocated

### DIFF
--- a/TombLib/TombLib/LevelData/Room.cs
+++ b/TombLib/TombLib/LevelData/Room.cs
@@ -129,7 +129,7 @@ namespace TombLib.LevelData
         public short AlternateGroup { get; set; } = -1;
 
         // Internal data structures
-        public RoomGeometry RoomGeometry { get; set; }
+        public RoomGeometry RoomGeometry { get;} = new RoomGeometry();
 
         public Room(Level level, int numXSectors, int numZSectors, Vector3 ambientLight, string name = "Unnamed", int ceiling = DefaultHeight)
         {
@@ -193,7 +193,6 @@ namespace TombLib.LevelData
                 }
 
             // Update data structures
-            RoomGeometry = null;
             Blocks = newBlocks;
 
             // Move objects
@@ -322,8 +321,6 @@ namespace TombLib.LevelData
                 result.AlternateRoom = null;
                 result.AlternateGroup = -1;
             }
-
-            result.RoomGeometry = null;
 
             // Copy properties
             result.Properties = Properties.Clone();
@@ -921,7 +918,7 @@ namespace TombLib.LevelData
 
         public void BuildGeometry(bool legacy = false)
         {
-            RoomGeometry = new RoomGeometry(this, legacy);
+            RoomGeometry.Build(this);
         }
 
         public void RebuildLighting(bool highQualityLighting)
@@ -1532,8 +1529,7 @@ namespace TombLib.LevelData
             // Update adjoining rooms
             var roomsToProcess = new List<Room> { this };
             var areaToProcess = new List<RectangleInt2> { area };
-            List<PortalInstance> listOfPortals = Portals.ToList();
-            foreach (var portal in listOfPortals)
+            foreach (var portal in Portals)
             {
                 if (!portal.Area.Intersects(area))
                     continue; // This portal is irrelavant since no changes happend in its area

--- a/TombLib/TombLib/LevelData/Room.cs
+++ b/TombLib/TombLib/LevelData/Room.cs
@@ -917,7 +917,7 @@ namespace TombLib.LevelData
 
         public void BuildGeometry(bool legacy = false)
         {
-            RoomGeometry.Build(this);
+            RoomGeometry.Build(this, legacy);
         }
 
         public void RebuildLighting(bool highQualityLighting)

--- a/TombLib/TombLib/LevelData/Room.cs
+++ b/TombLib/TombLib/LevelData/Room.cs
@@ -313,8 +313,7 @@ namespace TombLib.LevelData
         public Room Clone(Level level, Predicate<ObjectInstance> decideToCopy, bool fullCopy = false)
         {
             // Copy most variables
-            var result = (Room)MemberwiseClone();
-
+            var result = new Room(level,NumXSectors,NumZSectors,this.Properties.AmbientLight);
             if (!fullCopy)
             {
                 result.AlternateBaseRoom = null;

--- a/TombLib/TombLib/LevelData/Room.cs
+++ b/TombLib/TombLib/LevelData/Room.cs
@@ -129,7 +129,7 @@ namespace TombLib.LevelData
         public short AlternateGroup { get; set; } = -1;
 
         // Internal data structures
-        public RoomGeometry RoomGeometry { get;} = new RoomGeometry();
+        public RoomGeometry RoomGeometry { get; } = new RoomGeometry();
 
         public Room(Level level, int numXSectors, int numZSectors, Vector3 ambientLight, string name = "Unnamed", int ceiling = DefaultHeight)
         {
@@ -313,7 +313,7 @@ namespace TombLib.LevelData
         public Room Clone(Level level, Predicate<ObjectInstance> decideToCopy, bool fullCopy = false)
         {
             // Copy most variables
-            var result = new Room(level,NumXSectors,NumZSectors,this.Properties.AmbientLight);
+            var result = new Room(level, NumXSectors, NumZSectors, Properties.AmbientLight);
             if (!fullCopy)
             {
                 result.AlternateBaseRoom = null;

--- a/TombLib/TombLib/LevelData/RoomGeometry.cs
+++ b/TombLib/TombLib/LevelData/RoomGeometry.cs
@@ -41,16 +41,10 @@ namespace TombLib.LevelData
         public Dictionary<Vector3, List<int>> SharedVertices { get; } = new Dictionary<Vector3, List<int>>();
         public SortedList<SectorInfo, VertexRange> VertexRangeLookup { get; } = new SortedList<SectorInfo, VertexRange>();
 
-        private readonly bool _legacy;
-
-        public RoomGeometry(bool legacy = false)
+		// useLegacyCode is used for converting legacy .PRJ files to .PRJ2 files
+		public void Build(Room room, bool useLegacyCode = false)
         {
-            _legacy = legacy;
-
-        }
-        public void Build(Room room, bool legacy = false)
-        {
-            VertexPositions.Clear();
+			VertexPositions.Clear();
             VertexEditorUVs.Clear();
             VertexColors.Clear();
             TriangleTextureAreas.Clear();
@@ -58,8 +52,9 @@ namespace TombLib.LevelData
             SharedVertices.Clear();
             VertexRangeLookup.Clear();
             DoubleSidedTriangleCount = 0;
-            int xMin = 0;
-            int zMin = 0;
+
+            const int xMin = 0;
+            const int zMin = 0;
             int xMax = room.NumXSectors - 1;
             int zMax = room.NumZSectors - 1;
             Block[,] Blocks = room.Blocks;
@@ -83,9 +78,9 @@ namespace TombLib.LevelData
                     {
                         if ((Blocks[x, z].Type == BlockType.Wall || (Blocks[x, z].WallPortal?.HasTexturedFaces ?? false)) &&
                             !(Blocks[x, z].Floor.DiagonalSplit == DiagonalSplit.XpZn || Blocks[x, z].Floor.DiagonalSplit == DiagonalSplit.XnZn))
-                            AddVerticalFaces(room, x, z, FaceDirection.PositiveZ, true, true, true);
+                            AddVerticalFaces(room, x, z, FaceDirection.PositiveZ, true, true, true, useLegacyCode);
                         else
-                            AddVerticalFaces(room, x, z, FaceDirection.PositiveZ, true, true, false);
+                            AddVerticalFaces(room, x, z, FaceDirection.PositiveZ, true, true, false, useLegacyCode);
                     }
 
 
@@ -97,9 +92,9 @@ namespace TombLib.LevelData
                         if ((Blocks[x, z].Type == BlockType.Wall ||
                             (Blocks[x, z].WallPortal?.HasTexturedFaces ?? false)) &&
                             !(Blocks[x, z].Floor.DiagonalSplit == DiagonalSplit.XpZp || Blocks[x, z].Floor.DiagonalSplit == DiagonalSplit.XnZp))
-                            AddVerticalFaces(room, x, z, FaceDirection.NegativeZ, true, true, true);
+                            AddVerticalFaces(room, x, z, FaceDirection.NegativeZ, true, true, true, useLegacyCode);
                         else
-                            AddVerticalFaces(room, x, z, FaceDirection.NegativeZ, true, true, false);
+                            AddVerticalFaces(room, x, z, FaceDirection.NegativeZ, true, true, false, useLegacyCode);
                     }
 
                     // +X direction
@@ -109,9 +104,9 @@ namespace TombLib.LevelData
                     {
                         if ((Blocks[x, z].Type == BlockType.Wall || (Blocks[x, z].WallPortal?.HasTexturedFaces ?? false)) &&
                             !(Blocks[x, z].Floor.DiagonalSplit == DiagonalSplit.XnZn || Blocks[x, z].Floor.DiagonalSplit == DiagonalSplit.XnZp))
-                            AddVerticalFaces(room, x, z, FaceDirection.PositiveX, true, true, true);
+                            AddVerticalFaces(room, x, z, FaceDirection.PositiveX, true, true, true, useLegacyCode);
                         else
-                            AddVerticalFaces(room, x, z, FaceDirection.PositiveX, true, true, false);
+                            AddVerticalFaces(room, x, z, FaceDirection.PositiveX, true, true, false, useLegacyCode);
                     }
 
                     // -X direction
@@ -121,9 +116,9 @@ namespace TombLib.LevelData
                     {
                         if ((Blocks[x, z].Type == BlockType.Wall || (Blocks[x, z].WallPortal?.HasTexturedFaces ?? false)) &&
                             !(Blocks[x, z].Floor.DiagonalSplit == DiagonalSplit.XpZn || Blocks[x, z].Floor.DiagonalSplit == DiagonalSplit.XpZp))
-                            AddVerticalFaces(room, x, z, FaceDirection.NegativeX, true, true, true);
+                            AddVerticalFaces(room, x, z, FaceDirection.NegativeX, true, true, true, useLegacyCode);
                         else
-                            AddVerticalFaces(room, x, z, FaceDirection.NegativeX, true, true, false);
+                            AddVerticalFaces(room, x, z, FaceDirection.NegativeX, true, true, false, useLegacyCode);
                     }
 
                     // Diagonal faces
@@ -131,11 +126,11 @@ namespace TombLib.LevelData
                     {
                         if (Blocks[x, z].Type == BlockType.Wall)
                         {
-                            AddVerticalFaces(room, x, z, FaceDirection.DiagonalFloor, true, true, true);
+                            AddVerticalFaces(room, x, z, FaceDirection.DiagonalFloor, true, true, true, useLegacyCode);
                         }
                         else
                         {
-                            AddVerticalFaces(room, x, z, FaceDirection.DiagonalFloor, true, false, false);
+                            AddVerticalFaces(room, x, z, FaceDirection.DiagonalFloor, true, false, false, useLegacyCode);
                         }
                     }
 
@@ -143,7 +138,7 @@ namespace TombLib.LevelData
                     {
                         if (Blocks[x, z].Type != BlockType.Wall)
                         {
-                            AddVerticalFaces(room, x, z, FaceDirection.DiagonalCeiling, false, true, false);
+                            AddVerticalFaces(room, x, z, FaceDirection.DiagonalCeiling, false, true, false, useLegacyCode);
                         }
                     }
 
@@ -177,9 +172,9 @@ namespace TombLib.LevelData
 
 
                         if (addMiddle || Blocks[x, z].Type == BlockType.BorderWall && Blocks[x, z].WallPortal == null || (Blocks[x, z].WallPortal?.HasTexturedFaces ?? false))
-                            AddVerticalFaces(room, x, z, FaceDirection.PositiveZ, true, true, true);
+                            AddVerticalFaces(room, x, z, FaceDirection.PositiveZ, true, true, true, useLegacyCode);
                         else
-                            AddVerticalFaces(room, x, z, FaceDirection.PositiveZ, true, true, false);
+                            AddVerticalFaces(room, x, z, FaceDirection.PositiveZ, true, true, false, useLegacyCode);
                     }
 
                     // -Z directed border wall
@@ -211,9 +206,9 @@ namespace TombLib.LevelData
                         }
 
                         if (addMiddle || Blocks[x, z].Type == BlockType.BorderWall && Blocks[x, z].WallPortal == null || (Blocks[x, z].WallPortal?.HasTexturedFaces ?? false))
-                            AddVerticalFaces(room, x, z, FaceDirection.NegativeZ, true, true, true);
+                            AddVerticalFaces(room, x, z, FaceDirection.NegativeZ, true, true, true, useLegacyCode);
                         else
-                            AddVerticalFaces(room, x, z, FaceDirection.NegativeZ, true, true, false);
+                            AddVerticalFaces(room, x, z, FaceDirection.NegativeZ, true, true, false, useLegacyCode);
                     }
 
                     // -X directed border wall
@@ -245,9 +240,9 @@ namespace TombLib.LevelData
                         }
 
                         if (addMiddle || Blocks[x, z].Type == BlockType.BorderWall && Blocks[x, z].WallPortal == null || (Blocks[x, z].WallPortal?.HasTexturedFaces ?? false))
-                            AddVerticalFaces(room, x, z, FaceDirection.PositiveX, true, true, true);
+                            AddVerticalFaces(room, x, z, FaceDirection.PositiveX, true, true, true, useLegacyCode);
                         else
-                            AddVerticalFaces(room, x, z, FaceDirection.PositiveX, true, true, false);
+                            AddVerticalFaces(room, x, z, FaceDirection.PositiveX, true, true, false, useLegacyCode);
                     }
 
                     // +X directed border wall
@@ -279,9 +274,9 @@ namespace TombLib.LevelData
                         }
 
                         if (addMiddle || Blocks[x, z].Type == BlockType.BorderWall && Blocks[x, z].WallPortal == null || (Blocks[x, z].WallPortal?.HasTexturedFaces ?? false))
-                            AddVerticalFaces(room, x, z, FaceDirection.NegativeX, true, true, true);
+                            AddVerticalFaces(room, x, z, FaceDirection.NegativeX, true, true, true, useLegacyCode);
                         else
-                            AddVerticalFaces(room, x, z, FaceDirection.NegativeX, true, true, false);
+                            AddVerticalFaces(room, x, z, FaceDirection.NegativeX, true, true, false, useLegacyCode);
                     }
 
                     // Floor polygons
@@ -554,7 +549,7 @@ namespace TombLib.LevelData
             }
         }
 
-        private void AddVerticalFaces(Room room, int x, int z, FaceDirection faceDirection, bool hasFloorPart, bool hasCeilingPart, bool hasMiddlePart)
+        private void AddVerticalFaces(Room room, int x, int z, FaceDirection faceDirection, bool hasFloorPart, bool hasCeilingPart, bool hasMiddlePart, bool useLegacyCode)
         {
             //                                                 *Walkable floor*
             //                            yQaA (Start of QA)  0################0  yQaB (Start of QA)
@@ -1502,7 +1497,7 @@ namespace TombLib.LevelData
                 ZB = zB,
             };
 
-            if (_legacy)
+            if (useLegacyCode)
             {
                 #region LEGACY GEOMETRY CODE
 

--- a/TombLib/TombLib/LevelData/RoomGeometry.cs
+++ b/TombLib/TombLib/LevelData/RoomGeometry.cs
@@ -41,10 +41,10 @@ namespace TombLib.LevelData
         public Dictionary<Vector3, List<int>> SharedVertices { get; } = new Dictionary<Vector3, List<int>>();
         public SortedList<SectorInfo, VertexRange> VertexRangeLookup { get; } = new SortedList<SectorInfo, VertexRange>();
 
-		// useLegacyCode is used for converting legacy .PRJ files to .PRJ2 files
-		public void Build(Room room, bool useLegacyCode = false)
+        // useLegacyCode is used for converting legacy .PRJ files to .PRJ2 files
+        public void Build(Room room, bool useLegacyCode = false)
         {
-			VertexPositions.Clear();
+            VertexPositions.Clear();
             VertexEditorUVs.Clear();
             VertexColors.Clear();
             TriangleTextureAreas.Clear();

--- a/TombLib/TombLib/LevelData/RoomGeometry.cs
+++ b/TombLib/TombLib/LevelData/RoomGeometry.cs
@@ -43,10 +43,21 @@ namespace TombLib.LevelData
 
         private readonly bool _legacy;
 
-        public RoomGeometry(Room room, bool legacy = false)
+        public RoomGeometry(bool legacy = false)
         {
             _legacy = legacy;
 
+        }
+        public void Build(Room room, bool legacy = false)
+        {
+            VertexPositions.Clear();
+            VertexEditorUVs.Clear();
+            VertexColors.Clear();
+            TriangleTextureAreas.Clear();
+            TriangleSectorInfo.Clear();
+            SharedVertices.Clear();
+            VertexRangeLookup.Clear();
+            DoubleSidedTriangleCount = 0;
             int xMin = 0;
             int zMin = 0;
             int xMax = room.NumXSectors - 1;
@@ -317,7 +328,6 @@ namespace TombLib.LevelData
             // Lighting
             Relight(room);
         }
-
         private enum FaceDirection
         {
             PositiveZ, NegativeZ, PositiveX, NegativeX, DiagonalFloor, DiagonalCeiling, DiagonalWall


### PR DESCRIPTION
Keeps RoomGeometry allocated for a single room.

Instead of Destroying and Recreating the RoomGeometry, this PR keeps the RoomGeometry created once per room.
This has the advantage that a single geometry edit does not result in a cascade of object destructions and constructions.
This also keeps the capacity of the Lists within RoomGeometry, i.e. the Lists keep their memory instead of constructed with a low capacity and then reallocating often during vertex insertion.