### PR TITLE
Added two new Editor Events that allow suspending and resuming rendering

### DIFF
--- a/TombEditor/Editor.cs
+++ b/TombEditor/Editor.cs
@@ -1299,6 +1299,8 @@ namespace TombEditor
             public String InfoString { get;internal set; }
         }
 
+        public class SuspendRenderingEvent : IEditorEvent { }
+        public class ResumeRenderingEvent : IEditorEvent { }
         // Auto saving
         private readonly System.Windows.Forms.Timer _autoSavingTimer = new System.Windows.Forms.Timer();
         private volatile bool _currentlyAutoSaving;

--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -57,12 +57,14 @@ namespace TombEditor
 
         public static void SmartBuildGeometry(Room room, RectangleInt2 area)
         {
+            _editor.RaiseEvent(new Editor.SuspendRenderingEvent());
             var watch = new Stopwatch();
             watch.Start();
             room.SmartBuildGeometry(area, _editor.Configuration.Rendering3D_HighQualityLightPreview);
             watch.Stop();
             logger.Debug("Edit geometry time: " + watch.ElapsedMilliseconds + "  ms");
             _editor.RoomGeometryChange(room);
+            _editor.RaiseEvent(new Editor.ResumeRenderingEvent());
         }
 
         private enum SmoothGeometryEditingType

--- a/TombEditor/Forms/FormMain.cs
+++ b/TombEditor/Forms/FormMain.cs
@@ -318,6 +318,10 @@ namespace TombEditor.Forms
             // Quit editor
             if (obj is Editor.EditorQuitEvent)
                 Close();
+            if (obj is Editor.SuspendRenderingEvent)
+                GetWindow<MainView>().SuspendRendering();
+            if(obj is Editor.ResumeRenderingEvent)
+                GetWindow<MainView>().ResumeRendering();
         }
 
         private T GetWindow<T>() where T : DarkDockContent => toolWindows.FirstOrDefault(t => t.GetType().FullName == typeof(T).FullName) as T;

--- a/TombEditor/ToolWindows/MainView.cs
+++ b/TombEditor/ToolWindows/MainView.cs
@@ -522,5 +522,15 @@ namespace TombEditor.ToolWindows
 
             toolTip.SetToolTip(tbStats, limitWarning);
         }
+
+        public void SuspendRendering()
+        {
+            panel3D.AllowRendering = false;
+        }
+
+        public void ResumeRendering()
+        {
+            panel3D.AllowRendering = true;
+        }
     }
 }

--- a/TombEditor/Undo.cs
+++ b/TombEditor/Undo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Threading;
 using System.Threading.Tasks;
 using TombLib;
 using TombLib.LevelData;
@@ -393,6 +394,7 @@ namespace TombEditor
 
             UndoAction = () =>
             {
+                Parent.Editor.RaiseEvent(new Editor.SuspendRenderingEvent());
                 for (int x = Area.X0, i = 0; x < Area.X1; x++, i++)
                     for (int z = Area.Y0, j = 0; z < Area.Y1; z++, j++)
                         Room.Blocks[x, z].ReplaceGeometry(Parent.Editor.Level, Blocks[i, j]);
@@ -400,11 +402,13 @@ namespace TombEditor
                 Room.BuildGeometry();
                 Parent.Editor.RoomGeometryChange(Room);
                 Parent.Editor.RoomSectorPropertiesChange(Room);
-                var relevantRooms = room.Portals.Select(p => p.AdjoiningRoom);
-                Parallel.ForEach(relevantRooms, relevantRoom => relevantRoom.BuildGeometry());
+                var relevantRooms = room.Portals.Select(p => p.AdjoiningRoom).Distinct();
+                Parallel.ForEach(relevantRooms, r => r.BuildGeometry());
+                
 
                 foreach (Room relevantRoom in relevantRooms)
                     Parent.Editor.RoomGeometryChange(relevantRoom);
+                Parent.Editor.RaiseEvent(new Editor.ResumeRenderingEvent());
             };
             RedoInstance = () => new GeometryUndoInstance(Parent, Room);
         }

--- a/TombLib/TombLib.Forms/Controls/RenderingPanel.cs
+++ b/TombLib/TombLib.Forms/Controls/RenderingPanel.cs
@@ -15,6 +15,7 @@ namespace TombLib.Controls
         public RenderingSwapChain SwapChain { get; private set; }
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public RenderingDevice Device { get; private set; }
+        public bool AllowRendering { get; set; } = true;
 
         public RenderingPanel()
         {
@@ -120,5 +121,10 @@ namespace TombLib.Controls
         }
 
         protected virtual Vector4 ClearColor { get; } = new Vector4(0.392f, 0.584f, 0.929f, 1.0f); // "Cornflower blue" by default
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == 0x000F /* WM_PAINT */ && AllowRendering || m.Msg != 0x000F)
+                base.WndProc(ref m);
+        }
     }
 }


### PR DESCRIPTION
When building RoomGeometry of rooms in Parallel (`Parallel.For(Each)`),
the C# Runtime would occasionally fire a `OnPaint` Event to avoid unresponsiveness. See this:
https://stackoverflow.com/questions/4540244/how-is-this-possible-onpaint-processed-while-in-waitone
and this:
https://stackoverflow.com/questions/35535580/why-does-parallel-for-execute-the-winforms-message-pump-and-how-to-prevent-it

This Event causes `Dx11DrawRenderingRoom` to invalidate it's cache and rebuild geometry **while the Room Geometry is still being processed**.

This would not only occur during Undo/Redo, but also during Smart Geometry such as Shovel.

To avoid this, I created two new Events:
`SuspendRenderingEvent` to ignore any drawing attempts and
`ResumRenderingEvent` to reenable rendering.

The `RenderingPanel` class got a new `bool AllowRendering` (default `true`).
It also got an overriden `WndProc`, which checks whether the Message is `WM_PAINT` and `AllowRendering` is true to accept the message.
