### PR TITLE
Camera nodes

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -7,6 +7,9 @@ Tomb Editor:
  * Added TEN nodes for checking and modifying last used inventory object.
  * Added TEN node to check if a particular sound is playing
  * Added TEN node to generate particles from a static object
+ * Added TEN node to activate a camera.
+ * Added TEN node to attach the game camera to a moveable.
+ * Added TEN node to reset game camera if it has been modified.
  * Added handling for OnUseItem event in node editor.
  * Added drag-n-drop support for object ID controls in node editor.
  * Increased TEN flipmap count up to 255.

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/View.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/View.lua
@@ -59,10 +59,11 @@ end
 -- !Name "Activate camera"
 -- !Section "View"
 -- !Description "Activate camera placed on the map.\nThis camera will be a fixed camera that allows weapons to be fired and the look key to be used."
--- !Arguments "NewLine,Cameras"
+-- !Arguments "NewLine, Cameras, Choose camera to activate." "NewLine, Moveables, Choose moveable to target (default Lara)"
 
-LevelFuncs.Engine.Node.ActivateCamera = function(camName)
-    local cam = TEN.Objects.GetCameraByName(camName):PlayCamera()
+LevelFuncs.Engine.Node.ActivateCamera = function(camName, moveable)
+    local moveableTarget = TEN.Objects.GetMoveableByName(moveable)
+    local cam = TEN.Objects.GetCameraByName(camName):PlayCamera(moveableTarget)
 end
 
 -- !Name "Set screen field of view"

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/View.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/View.lua
@@ -126,3 +126,23 @@ LevelFuncs.Engine.Node.SetPostProcessDisplay = function(postProcessModeEnum, pow
     TEN.View.SetPostProcessStrength(power)
     TEN.View.SetPostProcessTint(tintColor)
 end
+
+-- !Name "Attach camera to moveable"
+-- !Section "View"
+-- !Description "Attaches game camera to a specific moveable."
+-- !Arguments "NewLine, Moveables, 70, Source moveable" , "Number, 30 , [ 0 | 50 | 0 ] , Mesh number of source moveable to attach camera target to"
+-- !Arguments "NewLine, Moveables, 70, Target moveable" , "Number, 30 , [ 0 | 50 | 0 ] , Mesh number of target moveable to attach camera target to"
+
+LevelFuncs.Engine.Node.AttachCameraToMoveable = function(source, sourceMesh, target , targetMesh)
+    local sourcePos = TEN.Objects.GetMoveableByName(source)
+    local targetPos = TEN.Objects.GetMoveableByName(target)
+    sourcePos:AttachObjCamera(sourceMesh, targetPos, targetMesh)
+end
+
+-- !Name "Reset game camera to default position"
+-- !Section "View"
+-- !Description "Reset camera if target has been modified."
+
+LevelFuncs.Engine.Node.ResetObjCam = function()
+	ResetObjCamera()
+end

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/View.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/View.lua
@@ -56,6 +56,15 @@ LevelFuncs.Engine.Node.PlayFlyBy = function(index)
     TEN.View.PlayFlyBy(index)
 end
 
+-- !Name "Activate camera"
+-- !Section "View"
+-- !Description "Activate camera placed on the map.\nThis camera will be a fixed camera that allows weapons to be fired and the look key to be used."
+-- !Arguments "NewLine,Cameras"
+
+LevelFuncs.Engine.Node.ActivateCamera = function(camName)
+    local cam = TEN.Objects.GetCameraByName(camName):PlayCamera()
+end
+
 -- !Name "Set screen field of view"
 -- !Section "View"
 -- !Description "Change screen field of view."

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/View.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/View.lua
@@ -125,13 +125,3 @@ LevelFuncs.Engine.Node.SetPostProcessDisplay = function(postProcessModeEnum, pow
     TEN.View.SetPostProcessStrength(power)
     TEN.View.SetPostProcessTint(tintColor)
 end
-
--- !Name "Change distance fog parameters"
--- !Section "View"
--- !Description "Change level distance fog and set a new minimum and maximum range.\nMinimum fog range is the distance from the camera that the fog starts.\nMaximum range is when the fog is at 100% density"
--- !Arguments "NewLine,Color, 50, Choose fog colour" , "Numerical, 25, [ 0 | 256 | 0 ], Distance (in blocks) fog starts from", "Numerical, 25, [ 0 | 256 | 0 ], Distance (in blocks) fog is completely dense"
-
-LevelFuncs.Engine.Node.ChangeDistanceFog = function(fogColor, minFog, maxFog)
-    local level = TEN.Flow.GetCurrentLevel()
-    level.fog = Flow.Fog.new(fogColor,minFog,maxFog)
-end

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/View.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/View.lua
@@ -133,7 +133,7 @@ end
 -- !Arguments "NewLine, Moveables, 70, Source moveable" , "Number, 30 , [ 0 | 50 | 0 ] , Mesh number of source moveable to attach camera target to"
 -- !Arguments "NewLine, Moveables, 70, Target moveable" , "Number, 30 , [ 0 | 50 | 0 ] , Mesh number of target moveable to attach camera target to"
 
-LevelFuncs.Engine.Node.AttachCameraToMoveable = function(source, sourceMesh, target , targetMesh)
+LevelFuncs.Engine.Node.AttachCameraToMoveable = function(source, sourceMesh, target, targetMesh)
     local sourcePos = TEN.Objects.GetMoveableByName(source)
     local targetPos = TEN.Objects.GetMoveableByName(target)
     sourcePos:AttachObjCamera(sourceMesh, targetPos, targetMesh)


### PR DESCRIPTION
I'd like to merge three new nodes for Tomb Editor:

- "Activate camera" : Activate camera placed on the map.
- "Attach camera to moveable" : Attaches game camera to a specific moveable.
- "Reset game camera to default position" : Reset camera if target has been modified.

I have also removed a node that allows the builder to change the level distance fog until a better implementation is acheived.
