### PR TITLE
Fix for wadrenderer leaks

### DIFF
--- a/TombEditor/Controls/Panel3D/Panel3DDraw.cs
+++ b/TombEditor/Controls/Panel3D/Panel3DDraw.cs
@@ -1505,13 +1505,7 @@ namespace TombEditor.Controls.Panel3D
         {
             if (moveablesToDraw.Count == 0)
                 return;
-
             var skinnedModelEffect = DeviceManager.DefaultDeviceManager.___LegacyEffects["Model"];
-            skinnedModelEffect.Parameters["AlphaTest"].SetValue(HideTransparentFaces);
-            skinnedModelEffect.Parameters["ColoredVertices"].SetValue(_editor.Level.IsTombEngine);
-            skinnedModelEffect.Parameters["Texture"].SetResource(_wadRenderer.Texture);
-            skinnedModelEffect.Parameters["TextureSampler"].SetResource(BilinearFilter ? _legacyDevice.SamplerStates.AnisotropicWrap : _legacyDevice.SamplerStates.PointWrap);
-
             var camPos = Camera.GetPosition();
 
             var groups = moveablesToDraw.GroupBy(m => m.WadObjectId);
@@ -1576,6 +1570,10 @@ namespace TombEditor.Controls.Panel3D
 
                         var world = model.AnimationTransforms[i] * instance.ObjectMatrix;
                         skinnedModelEffect.Parameters["ModelViewProjection"].SetValue((world * _viewProjection).ToSharpDX());
+                        skinnedModelEffect.Parameters["AlphaTest"].SetValue(HideTransparentFaces);
+                        skinnedModelEffect.Parameters["ColoredVertices"].SetValue(_editor.Level.IsTombEngine);
+                        skinnedModelEffect.Parameters["Texture"].SetResource(_wadRenderer.Texture);
+                        skinnedModelEffect.Parameters["TextureSampler"].SetResource(BilinearFilter ? _legacyDevice.SamplerStates.AnisotropicWrap : _legacyDevice.SamplerStates.PointWrap);
                         skinnedModelEffect.Techniques[0].Passes[0].Apply();
 
                         foreach (var submesh in mesh.Submeshes)
@@ -1735,10 +1733,6 @@ namespace TombEditor.Controls.Panel3D
                 return;
 
             var staticMeshEffect = DeviceManager.DefaultDeviceManager.___LegacyEffects["Model"];
-            staticMeshEffect.Parameters["AlphaTest"].SetValue(HideTransparentFaces);
-            staticMeshEffect.Parameters["ColoredVertices"].SetValue(_editor.Level.IsTombEngine);
-            staticMeshEffect.Parameters["TextureSampler"].SetResource(BilinearFilter ? _legacyDevice.SamplerStates.AnisotropicWrap : _legacyDevice.SamplerStates.PointWrap);
-            staticMeshEffect.Parameters["Texture"].SetResource(_wadRenderer.Texture);
 
             var camPos = Camera.GetPosition();
 
@@ -1790,6 +1784,10 @@ namespace TombEditor.Controls.Panel3D
                         }
 
                         staticMeshEffect.Parameters["ModelViewProjection"].SetValue((instance.ObjectMatrix * _viewProjection).ToSharpDX());
+                        staticMeshEffect.Parameters["AlphaTest"].SetValue(HideTransparentFaces);
+                        staticMeshEffect.Parameters["ColoredVertices"].SetValue(_editor.Level.IsTombEngine);
+                        staticMeshEffect.Parameters["TextureSampler"].SetResource(BilinearFilter ? _legacyDevice.SamplerStates.AnisotropicWrap : _legacyDevice.SamplerStates.PointWrap);
+                        staticMeshEffect.Parameters["Texture"].SetResource(_wadRenderer.Texture);
                         staticMeshEffect.Techniques[0].Passes[0].Apply();
 
                         foreach (var submesh in mesh.Submeshes)

--- a/TombEditor/Controls/Panel3D/Panel3DInit.cs
+++ b/TombEditor/Controls/Panel3D/Panel3DInit.cs
@@ -52,7 +52,7 @@ namespace TombEditor.Controls.Panel3D
                     _ => 64
                 };
 
-                _wadRenderer = new WadRenderer(_legacyDevice, true, true, atlasSize, maxAllocationSize);
+                _wadRenderer = new WadRenderer(_legacyDevice, true, true, atlasSize, maxAllocationSize, false);
 
                 // Initialize vertex buffers
                 _ghostBlockVertexBuffer = SharpDX.Toolkit.Graphics.Buffer.Vertex.New<SolidVertex>(_legacyDevice, 84);

--- a/TombEditor/Controls/Panel3D/Panel3DInit.cs
+++ b/TombEditor/Controls/Panel3D/Panel3DInit.cs
@@ -53,7 +53,6 @@ namespace TombEditor.Controls.Panel3D
                 };
 
                 _wadRenderer = new WadRenderer(_legacyDevice, true, true, atlasSize, maxAllocationSize, false);
-
                 // Initialize vertex buffers
                 _ghostBlockVertexBuffer = SharpDX.Toolkit.Graphics.Buffer.Vertex.New<SolidVertex>(_legacyDevice, 84);
                 _boxVertexBuffer = new BoundingBox(new Vector3(-_littleCubeRadius), new Vector3(_littleCubeRadius)).GetVertexBuffer(_legacyDevice);

--- a/TombLib/TombLib.Forms/Controls/PanelItemPreview.cs
+++ b/TombLib/TombLib.Forms/Controls/PanelItemPreview.cs
@@ -131,7 +131,7 @@ namespace TombLib.Controls
             {
                 // Reset scrollbar
                 _legacyDevice = DeviceManager.DefaultDeviceManager.___LegacyDevice;
-                _wadRenderer = new WadRenderer(DeviceManager.DefaultDeviceManager.___LegacyDevice, true, true, 256, 128);
+                _wadRenderer = new WadRenderer(DeviceManager.DefaultDeviceManager.___LegacyDevice, true, true, 256, 128, false);
 
                 ResetCamera();
 

--- a/TombLib/TombLib/Graphics/AnimatedModel.cs
+++ b/TombLib/TombLib/Graphics/AnimatedModel.cs
@@ -149,9 +149,13 @@ namespace TombLib.Graphics
             {
                 var anim = mov.Animations.FirstOrDefault(a => a.KeyFrames.Count > 0);
                 if(anim is not null)
-                    model.BuildAnimationPose(Animation.FromWad2(bones,anim).KeyFrames[0]);
-                // Prepare data by loading the first valid animation and uploading data to the GPU
-                model.BuildHierarchy();
+                {
+                    var modelAnim = Animation.FromWad2(bones, anim);
+                    modelAnim.KeyFrames.RemoveAll(f => f != modelAnim.KeyFrames.First());
+                    model.Animations.Add(modelAnim);
+                    model.BuildHierarchy();
+                    model.BuildAnimationPose(Animation.FromWad2(bones, anim).KeyFrames[0]);
+                }
             }
             
             model.UpdateBuffers();

--- a/TombLib/TombLib/Graphics/AnimatedModel.cs
+++ b/TombLib/TombLib/Graphics/AnimatedModel.cs
@@ -133,7 +133,8 @@ namespace TombLib.Graphics
 
             // Build the skeleton
             model.Root = BuildSkeleton(model, null, bones);
-            if(loadAnimations)
+
+            if (loadAnimations)
             {
                 // Prepare animations
                 for (int j = 0; j < mov.Animations.Count; j++)
@@ -145,16 +146,19 @@ namespace TombLib.Graphics
                 if (model.Animations.Count > 0 && model.Animations.Any(a => a.KeyFrames.Count > 0))
                     model.BuildAnimationPose(model.Animations.FirstOrDefault(a => a.KeyFrames.Count > 0)?.KeyFrames[0]);
             }
-            else // we do not need animations, just load the first animation and keyframe
+            else 
             {
+                // We do not need whole animation, just load the first valid animation and first keyframe
                 var anim = mov.Animations.FirstOrDefault(a => a.KeyFrames.Count > 0);
-                if(anim is not null)
+                if (anim is not null)
                 {
                     var modelAnim = Animation.FromWad2(bones, anim);
-                    modelAnim.KeyFrames.RemoveAll(f => f != modelAnim.KeyFrames.First());
+                    if (modelAnim.KeyFrames.Count > 1)
+                        modelAnim.KeyFrames.RemoveRange(1, modelAnim.KeyFrames.Count - 1);
+
                     model.Animations.Add(modelAnim);
                     model.BuildHierarchy();
-                    model.BuildAnimationPose(Animation.FromWad2(bones, anim).KeyFrames[0]);
+                    model.BuildAnimationPose(modelAnim.KeyFrames[0]);
                 }
             }
             

--- a/TombLib/TombLib/Graphics/IRenderableObject.cs
+++ b/TombLib/TombLib/Graphics/IRenderableObject.cs
@@ -1,6 +1,8 @@
-﻿namespace TombLib.Graphics
+﻿using System;
+
+namespace TombLib.Graphics
 {
-    public interface IRenderableObject
+    public interface IRenderableObject: IDisposable
     {
     }
 }

--- a/TombLib/TombLib/Graphics/Mesh.cs
+++ b/TombLib/TombLib/Graphics/Mesh.cs
@@ -1,4 +1,5 @@
 ﻿using SharpDX.Toolkit.Graphics;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -8,7 +9,7 @@ namespace TombLib.Graphics
     public abstract class Mesh<T> : GraphicsResource, IRenderableObject where T : struct, IVertex
     {
         public Buffer<T> VertexBuffer { get; protected set; }
-        public Buffer IndexBuffer { get; protected set; }
+        public SharpDX.Toolkit.Graphics.Buffer IndexBuffer { get; protected set; }
         public VertexInputLayout InputLayout { get; protected set; }
         public List<Material> Materials { get; protected set; }
         public List<T> Vertices { get; protected set; } = new List<T>();
@@ -68,6 +69,13 @@ namespace TombLib.Graphics
                 }
                 lastBaseIndex += submesh.Value.NumIndices;
             }
+        }
+
+        public void Dispose()
+        {
+            base.Dispose();
+            VertexBuffer?.Dispose();
+            IndexBuffer?.Dispose();
         }
     }
 }

--- a/TombLib/TombLib/Graphics/Model.cs
+++ b/TombLib/TombLib/Graphics/Model.cs
@@ -35,7 +35,7 @@ namespace TombLib.Graphics
 
         public void Dispose()
         {
-            foreach(var m in Meshes)
+            foreach (var m in Meshes)
                 m.Dispose();
         }
     }

--- a/TombLib/TombLib/Graphics/Model.cs
+++ b/TombLib/TombLib/Graphics/Model.cs
@@ -14,7 +14,7 @@ namespace TombLib.Graphics
         Room
     }
 
-    public abstract class Model<T, U> : IRenderableObject, IDisposable where U : struct
+    public abstract class Model<T, U> : IRenderableObject, IDisposable where U : unmanaged where T : IDisposable
     {
         public BoundingBox BoundingBox { get; set; }
         public List<T> Meshes { get; set; }
@@ -35,7 +35,8 @@ namespace TombLib.Graphics
 
         public void Dispose()
         {
-            
+            foreach(var m in Meshes)
+                m.Dispose();
         }
     }
 }

--- a/TombLib/TombLib/Graphics/ObjectMesh.cs
+++ b/TombLib/TombLib/Graphics/ObjectMesh.cs
@@ -10,7 +10,7 @@ using Buffer = SharpDX.Toolkit.Graphics.Buffer;
 
 namespace TombLib.Graphics
 {
-    public class ObjectMesh : Mesh<ObjectVertex>, IDisposable
+    public class ObjectMesh : Mesh<ObjectVertex>
     {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
@@ -40,17 +40,6 @@ namespace TombLib.Graphics
                 logger.Error("Input Layout of Mesh " + Name + " could not be created!");
             if (IndexBuffer == null)
                 logger.Error("Index Buffer of Mesh " + Name + " could not be created!");
-        }
-
-        protected override void Dispose(bool disposeManagedResources)
-        {
-            VertexBuffer?.Dispose();
-            IndexBuffer?.Dispose();
-        }
-
-        ~ObjectMesh()
-        {
-            Dispose(true);
         }
 
         private static void PutObjectVertexAndIndex(Vector3 v, Vector3 n,

--- a/TombLib/TombLib/Graphics/WadRenderer.cs
+++ b/TombLib/TombLib/Graphics/WadRenderer.cs
@@ -53,7 +53,6 @@ namespace TombLib.Graphics
                 return;
 
             _disposing = true;
-
             Texture?.Dispose();
             Texture = null;
 
@@ -78,7 +77,7 @@ namespace TombLib.Graphics
             InitializeTexture();
         }
 
-        private void ReclaimTextureSpace<T, U>(Model<T, U> model) where U : struct
+        private void ReclaimTextureSpace<T, U>(Model<T, U> model) where U : unmanaged where T: IDisposable
         {
             // TODO Some mechanism to reclaim texture space without rebuilding the atlas would be good.
             // Currently texture space is only freed when the atlas fills up completely and must be rebuilt.
@@ -227,7 +226,7 @@ namespace TombLib.Graphics
                     var toSubresource = newTexture.GetSubResourceIndex(i, 0);
                     GraphicsDevice.Copy(Texture, fromSubresource, newTexture, toSubresource);
                 }
-
+                Texture?.Dispose();
                 Texture = newTexture;
             }
         }

--- a/TombLib/TombLib/Graphics/WadRenderer.cs
+++ b/TombLib/TombLib/Graphics/WadRenderer.cs
@@ -27,14 +27,16 @@ namespace TombLib.Graphics
         private int _textureAtlasSize { get; }
         private int _maxTextureAllocationSize { get; }
         public int TextureAtlasSize { get => _textureAtlasSize; }
+        private bool _loadAnimations { get; }
 
-        public WadRenderer(GraphicsDevice graphicsDevice, bool compactTexture, bool correctTexture, int atlasSize, int maxAllocationSize)
+        public WadRenderer(GraphicsDevice graphicsDevice, bool compactTexture, bool correctTexture, int atlasSize, int maxAllocationSize, bool loadAnimations)
         {
             GraphicsDevice = graphicsDevice;
             _compactTexture = compactTexture;
             _correctTexture = correctTexture;
             _textureAtlasSize = atlasSize;
             _maxTextureAllocationSize = maxAllocationSize;
+            _loadAnimations = loadAnimations;
             AddPacker();
         }
 
@@ -99,7 +101,7 @@ namespace TombLib.Graphics
             // The data is either new or has changed, unfortunately we need to reload it
             try
             {
-                model = AnimatedModel.FromWadMoveable(GraphicsDevice, moveable, AllocateTexture, _correctTexture);
+                model = AnimatedModel.FromWadMoveable(GraphicsDevice, moveable, AllocateTexture, _correctTexture, _loadAnimations);
             }
             catch (TextureAtlasFullException exc)
             {

--- a/TombLib/TombLib/Wad/WadTexture.cs
+++ b/TombLib/TombLib/Wad/WadTexture.cs
@@ -50,5 +50,9 @@ namespace TombLib.Wad
 
             return hint;
         }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/WadTool/Controls/PanelRenderingAnimationEditor.cs
+++ b/WadTool/Controls/PanelRenderingAnimationEditor.cs
@@ -85,7 +85,7 @@ namespace WadTool.Controls
             ResetCamera();
 
             _editor = editor;
-            _wadRenderer = new WadRenderer(deviceManager.___LegacyDevice, false, true, 1024, 512);
+            _wadRenderer = new WadRenderer(deviceManager.___LegacyDevice, false, true, 1024, 512, true);
             _model = _wadRenderer.GetMoveable(editor.Moveable);
 
             Configuration = _editor.Tool.Configuration;

--- a/WadTool/Controls/PanelRenderingMesh.cs
+++ b/WadTool/Controls/PanelRenderingMesh.cs
@@ -147,7 +147,7 @@ namespace WadTool.Controls
                     return;
 
                 _wadRenderer.Dispose();
-                _wadRenderer = new WadRenderer(_device, false, value, 4096, 2048);
+                _wadRenderer = new WadRenderer(_device, false, value, 4096, 2048, false);
                 _bilinear = value;
                 Invalidate();
             }
@@ -293,7 +293,7 @@ namespace WadTool.Controls
             // Legacy rendering
             {
                 _device = deviceManager.___LegacyDevice;
-                _wadRenderer = new WadRenderer(deviceManager.___LegacyDevice, false, false, 1024, 512);
+                _wadRenderer = new WadRenderer(deviceManager.___LegacyDevice, false, false, 1024, 512, false);
 
                 _fontTexture = deviceManager.Device.CreateTextureAllocator(new RenderingTextureAllocator.Description { Size = new VectorInt3(512, 512, 2) });
                 _fontDefault = deviceManager.Device.CreateFont(new RenderingFont.Description

--- a/WadTool/Controls/PanelRenderingSkeleton.cs
+++ b/WadTool/Controls/PanelRenderingSkeleton.cs
@@ -90,7 +90,7 @@ namespace WadTool.Controls
 
             // Legacy rendering
             {
-                _wadRenderer = new WadRenderer(_device, false, true, 1024, 512);
+                _wadRenderer = new WadRenderer(_device, false, true, 1024, 512, false);
                 new BasicEffect(_device); // This effect is used for editor special meshes like sinks, cameras, light meshes, etc
                 _rasterizerWireframe = RasterizerState.New(_device, new SharpDX.Direct3D11.RasterizerStateDescription
                 {

--- a/WadTool/Controls/PanelRenderingStaticEditor.cs
+++ b/WadTool/Controls/PanelRenderingStaticEditor.cs
@@ -112,7 +112,7 @@ namespace WadTool.Controls
             {
                 _device = deviceManager.___LegacyDevice;
                 _deviceManager = deviceManager;
-                _wadRenderer = new WadRenderer(_device, false, true, 4096, 2048);
+                _wadRenderer = new WadRenderer(_device, false, true, 4096, 2048, false);
                 new BasicEffect(_device); // This effect is used for editor special meshes like sinks, cameras, light meshes, etc
                 _rasterizerWireframe = RasterizerState.New(_device, new SharpDX.Direct3D11.RasterizerStateDescription
                 {


### PR DESCRIPTION
- Adds parameter to WadRenderer to load animation data from wad. ItemPreview does not need animations. Animations would occupy hundreds of MB for a large wad.
- Fixes the disposal of the `Mesh<T,U>` class, which did not clean up the vertex and index buffers before
- Fixes the `WadRenderer` texture atlas disposal when the texture atlas needs to be resized
  - Shader parameters were moved to after the model-to-be-rendered was retrieved so an invalid texture is not used anymore. Potentially fixes wrong texture display when loading a new wad or level