### PR TITLE
Fix TR1 and TR2 static mesh flags

### DIFF
--- a/TombLib/TombLib/LevelData/Compilers/Wad.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Wad.cs
@@ -583,7 +583,12 @@ namespace TombLib.LevelData.Compilers
                 if (_level.Settings.GameVersion > TRVersion.Game.TR3)
                     newStaticMesh.Flags = (ushort)oldStaticMesh.Flags;
                 else
-                    newStaticMesh.Flags = 2; // bit 0: no collision, bit 1: visibility
+                {
+                    if (oldStaticMesh.CollisionBox.Minimum == Vector3.Zero && oldStaticMesh.CollisionBox.Maximum == Vector3.Zero)
+                        newStaticMesh.Flags |= 1;
+                    if (oldStaticMesh.VisibilityBox.Minimum != Vector3.Zero || oldStaticMesh.VisibilityBox.Maximum != Vector3.Zero)
+                        newStaticMesh.Flags |= 2;
+                }
 
                 newStaticMesh.Mesh = (ushort)_meshPointers.Count;
 


### PR DESCRIPTION
This corrects the no-collision and visibility flags on static meshes for TR1 and TR2. Test levels attached produced from this change.

[FixedStatics.zip](https://github.com/user-attachments/files/17413035/FixedStatics.zip)

Resolves #912.
