### PR TITLE
Added Cloning of WadSpriteSequence

### DIFF
--- a/TombLib/TombLib/Wad/Wad2.cs
+++ b/TombLib/TombLib/Wad/Wad2.cs
@@ -186,7 +186,11 @@ namespace TombLib.Wad
                 Statics[(WadStaticId)newId] = st;
             }
             else if (newId is WadSpriteSequenceId)
-                SpriteSequences[(WadSpriteSequenceId)newId] = (WadSpriteSequence)wadObject;
+            {
+                var sp = ((WadSpriteSequence)wadObject).Clone();
+                SpriteSequences[(WadSpriteSequenceId)newId] = sp;
+            }
+                
             else
                 throw new ArgumentException("Argument not of a valid type.");
         }

--- a/TombLib/TombLib/Wad/Wad2.cs
+++ b/TombLib/TombLib/Wad/Wad2.cs
@@ -190,7 +190,6 @@ namespace TombLib.Wad
                 var sp = ((WadSpriteSequence)wadObject).Clone();
                 SpriteSequences[(WadSpriteSequenceId)newId] = sp;
             }
-                
             else
                 throw new ArgumentException("Argument not of a valid type.");
         }

--- a/TombLib/TombLib/Wad/WadSpriteSequence.cs
+++ b/TombLib/TombLib/Wad/WadSpriteSequence.cs
@@ -48,6 +48,15 @@ namespace TombLib.Wad
 
         public string ToString(TRVersion.Game gameVersion) => Id.ToString(gameVersion.Native());
         public override string ToString() => Id.ToString();
+
+        public WadSpriteSequence Clone()
+        {
+            var clone = new WadSpriteSequence(Id);
+            clone.Version = DataVersion.GetNext();
+            clone.Sprites.AddRange(Sprites);
+            return clone;
+        }
+
         IWadObjectId IWadObject.Id => Id;
     }
 }


### PR DESCRIPTION
This PR fixes #981.

There is a clone/copy missing when a Sprite Sequence is added to a wad, which resulted in referencing the "Original" SpriteSequence. Copying The same Sprite Sequence from Wad to another would change the id of the source sprite sequence and the new destination sprite sequence would reference the same sprite sequence.