### PR TITLE
Dependency cleanup

### DIFF
--- a/DarkUI/DarkUI/DarkUI.csproj
+++ b/DarkUI/DarkUI/DarkUI.csproj
@@ -123,7 +123,4 @@
   <ItemGroup>
     <Content Include="Resources\grip_fill.png" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
-  </ItemGroup>
 </Project>

--- a/DarkUI/Example/Example.csproj
+++ b/DarkUI/Example/Example.csproj
@@ -19,9 +19,6 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Update="Forms\Docking\DockDocument.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/FileAssociation/FileAssociation.csproj
+++ b/FileAssociation/FileAssociation.csproj
@@ -47,6 +47,5 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MiniFileAssociation" Version="1.0.1" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/NgXmlBuilder/NgXmlBuilder.csproj
+++ b/NgXmlBuilder/NgXmlBuilder.csproj
@@ -30,9 +30,6 @@
     <ProjectReference Include="..\TombLib\TombLib\TombLib.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <None Update="NG\ANIMATION_RANGE.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/SoundTool/SoundTool.csproj
+++ b/SoundTool/SoundTool.csproj
@@ -42,7 +42,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="5.0.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/TombEditor/Controls/ImportedGeometryManager.cs
+++ b/TombEditor/Controls/ImportedGeometryManager.cs
@@ -159,7 +159,10 @@ namespace TombEditor.Controls
                 foreach (string path in paths)
                 {
                     if (!path.CheckAndWarnIfNotANSI(this))
+                    {
+                        DarkMessageBox.Show(FindForm(), "Filename or path is invalid. Please use standard characters.", "Wrong filename", MessageBoxIcon.Error);
                         continue;
+                    }
 
                     using (var settingsDialog = new GeometryIOSettingsDialog(new IOGeometrySettings()))
                     {

--- a/TombEditor/Controls/Panel3D/MouseHandler/Panel3DMouse.cs
+++ b/TombEditor/Controls/Panel3D/MouseHandler/Panel3DMouse.cs
@@ -160,6 +160,7 @@ namespace TombEditor.Controls.Panel3D
         {
             // Check if we are done with all common file tasks
             var filesToProcess = EditorActions.DragDropCommonFiles(e, FindForm());
+
             if (filesToProcess == 0)
                 return;
 
@@ -176,6 +177,7 @@ namespace TombEditor.Controls.Panel3D
                     _editor.SelectedRoom = newSectorPicking.Room;
 
                 var obj = e.Data.GetData(e.Data.GetFormats()[0]) as IWadObject;
+
                 if (obj != null)
                 {
                     PositionBasedObjectInstance instance = null;
@@ -200,11 +202,11 @@ namespace TombEditor.Controls.Panel3D
                     {
                         if (!BaseGeometryImporter.FileExtensions.Matches(file))
                             continue;
+
                         if (!file.CheckAndWarnIfNotANSI(this)) 
                         {
                             DarkMessageBox.Show(FindForm(), "Filename or path is invalid. Please use standard characters.", "Wrong filename", MessageBoxIcon.Error);
                             continue;
-
                         }
 
                         EditorActions.AddAndPlaceImportedGeometry(this, newSectorPicking.Pos, file);

--- a/TombEditor/Controls/Panel3D/MouseHandler/Panel3DMouse.cs
+++ b/TombEditor/Controls/Panel3D/MouseHandler/Panel3DMouse.cs
@@ -1,4 +1,5 @@
 ﻿using DarkUI.Controls;
+using DarkUI.Forms;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -200,8 +201,11 @@ namespace TombEditor.Controls.Panel3D
                         if (!BaseGeometryImporter.FileExtensions.Matches(file))
                             continue;
 
-                        if (!file.CheckAndWarnIfNotANSI(this))
+                        if (!file.CheckAndWarnIfNotANSI(this)) {
+                            DarkMessageBox.Show(FindForm(), "Filename or path is invalid. Please use standard characters.", "Wrong filename", MessageBoxIcon.Error);
                             continue;
+
+                        }
 
                         EditorActions.AddAndPlaceImportedGeometry(this, newSectorPicking.Pos, file);
                     }

--- a/TombEditor/Controls/Panel3D/MouseHandler/Panel3DMouse.cs
+++ b/TombEditor/Controls/Panel3D/MouseHandler/Panel3DMouse.cs
@@ -200,8 +200,8 @@ namespace TombEditor.Controls.Panel3D
                     {
                         if (!BaseGeometryImporter.FileExtensions.Matches(file))
                             continue;
-
-                        if (!file.CheckAndWarnIfNotANSI(this)) {
+                        if (!file.CheckAndWarnIfNotANSI(this)) 
+                        {
                             DarkMessageBox.Show(FindForm(), "Filename or path is invalid. Please use standard characters.", "Wrong filename", MessageBoxIcon.Error);
                             continue;
 

--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -1017,10 +1017,13 @@ namespace TombEditor
                 if (form.ShowDialog(owner) == DialogResult.Cancel)
                     return;
 
-                if (!luaInstance.TrySetLuaName(form.Result, owner))
+                if (!luaInstance.CanSetLuaName(form.Result))
                     RenameObject(luaInstance, owner);
                 else
+                {
+                    luaInstance.LuaName = form.Result;
                     _editor.ObjectChange(luaInstance, ObjectChangeType.Change);
+                }
             }
         }
 
@@ -4968,6 +4971,7 @@ namespace TombEditor
 
                 if (!saveFileDialog.FileName.CheckAndWarnIfNotANSI(owner))
                 {
+                    DarkMessageBox.Show(owner, "Filename or path is invalid. Please use standard characters.", "Wrong filename", MessageBoxIcon.Error);
                     ExportRooms(rooms, owner);
                     return;
                 }

--- a/TombEditor/ObjectClipboardData.cs
+++ b/TombEditor/ObjectClipboardData.cs
@@ -83,14 +83,13 @@ namespace TombEditor
                     if (!luaObj.CanSetLuaName(luaObj.LuaName))
                     {
                         luaObj.LuaName = string.Empty;
-                        Editor.Instance.SendMessage("The value of Lua Name is already taken by another object", TombLib.Forms.PopupType.Error, true);
+                        editor.SendMessage("The value of Lua Name is already taken by another object", TombLib.Forms.PopupType.Error, true);
                     }
                     else
                     {
                         luaObj.LuaName = luaObj.LuaName;
                         editor.SelectedRoom.RemoveObject(editor.Level, obj);
                     }
-
                 }
 
                 if (obj is FlybyCameraInstance)

--- a/TombEditor/ObjectClipboardData.cs
+++ b/TombEditor/ObjectClipboardData.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿using DarkUI.Forms;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Windows.Forms;
 using TombLib.IO;
 using TombLib.LevelData;
 using TombLib.LevelData.IO;
@@ -78,9 +80,17 @@ namespace TombEditor
                 {
                     editor.SelectedRoom.AddObject(editor.Level, obj);
                     var luaObj = obj as IHasLuaName;
-                    if (!luaObj.TrySetLuaName(luaObj.LuaName, null))
+                    if (!luaObj.CanSetLuaName(luaObj.LuaName))
+                    {
                         luaObj.LuaName = string.Empty;
-                    editor.SelectedRoom.RemoveObject(editor.Level, obj);
+                        Editor.Instance.SendMessage("The value of Lua Name is already taken by another object", TombLib.Forms.PopupType.Error, true);
+                    }
+                    else
+                    {
+                        luaObj.LuaName = luaObj.LuaName;
+                        editor.SelectedRoom.RemoveObject(editor.Level, obj);
+                    }
+
                 }
 
                 if (obj is FlybyCameraInstance)

--- a/TombEditor/TombEditor.csproj
+++ b/TombEditor/TombEditor.csproj
@@ -140,7 +140,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="5.0.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="EditorCommands.cs" />

--- a/TombIDE/TombIDE.ProjectMaster/TombIDE.ProjectMaster.csproj
+++ b/TombIDE/TombIDE.ProjectMaster/TombIDE.ProjectMaster.csproj
@@ -110,7 +110,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IconUtilities" Version="1.0.2" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx">

--- a/TombIDE/TombIDE.ProjectMaster/TombIDE.ProjectMaster.csproj
+++ b/TombIDE/TombIDE.ProjectMaster/TombIDE.ProjectMaster.csproj
@@ -74,7 +74,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DarkUI\DarkUI\DarkUI.csproj" />
     <ProjectReference Include="..\..\TombLib\TombLib.Forms\TombLib.Forms.csproj" />
     <ProjectReference Include="..\..\TombLib\TombLib.Scripting.ClassicScript\TombLib.Scripting.ClassicScript.csproj" />
     <ProjectReference Include="..\TombIDE.Shared\TombIDE.Shared.csproj" />

--- a/TombIDE/TombIDE.REGSVR/TombIDE.REGSVR.csproj
+++ b/TombIDE/TombIDE.REGSVR/TombIDE.REGSVR.csproj
@@ -36,9 +36,6 @@
     <EmbeddedResource Include="COM\Richtx32.ocx" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\TombIDE.Shared\TombIDE.Shared.csproj" />
   </ItemGroup>
 </Project>

--- a/TombIDE/TombIDE.ScriptingStudio/TombIDE.ScriptingStudio.csproj
+++ b/TombIDE/TombIDE.ScriptingStudio/TombIDE.ScriptingStudio.csproj
@@ -135,9 +135,6 @@
     <EmbeddedResource Remove="StudioBase.resx" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/TombIDE/TombIDE.ScriptingStudio/TombIDE.ScriptingStudio.csproj
+++ b/TombIDE/TombIDE.ScriptingStudio/TombIDE.ScriptingStudio.csproj
@@ -85,7 +85,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DarkUI\DarkUI\DarkUI.csproj" />
     <ProjectReference Include="..\..\TombLib\TombLib.Scripting.GameFlowScript\TombLib.Scripting.GameFlowScript.csproj" />
     <ProjectReference Include="..\..\TombLib\TombLib.Scripting.Tomb1Main\TombLib.Scripting.Tomb1Main.csproj" />
     <ProjectReference Include="..\..\TombLib\TombLib.Scripting.ClassicScript\TombLib.Scripting.ClassicScript.csproj" />

--- a/TombIDE/TombIDE.Shared/TombIDE.Shared.csproj
+++ b/TombIDE/TombIDE.Shared/TombIDE.Shared.csproj
@@ -28,6 +28,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\DarkUI\DarkUI\DarkUI.csproj" />
     <ProjectReference Include="..\..\TombLib\TombLib\TombLib.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/TombIDE/TombIDE.Shared/TombIDE.Shared.csproj
+++ b/TombIDE/TombIDE.Shared/TombIDE.Shared.csproj
@@ -115,9 +115,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <None Update="TIDE\GF3\TRGameflow.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/TombIDE/TombIDE.Shared/TombIDE.Shared.csproj
+++ b/TombIDE/TombIDE.Shared/TombIDE.Shared.csproj
@@ -28,7 +28,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DarkUI\DarkUI\DarkUI.csproj" />
     <ProjectReference Include="..\..\TombLib\TombLib\TombLib.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/TombIDE/TombIDE/TombIDE.csproj
+++ b/TombIDE/TombIDE/TombIDE.csproj
@@ -81,7 +81,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FreeImage.Standard" Version="4.3.8" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\DarkUI\DarkUI\DarkUI.csproj" />

--- a/TombIDE/TombIDE/TombIDE.csproj
+++ b/TombIDE/TombIDE/TombIDE.csproj
@@ -83,7 +83,6 @@
     <PackageReference Include="FreeImage.Standard" Version="4.3.8" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DarkUI\DarkUI\DarkUI.csproj" />
     <ProjectReference Include="..\TombIDE.ProjectMaster\TombIDE.ProjectMaster.csproj" />
     <ProjectReference Include="..\TombIDE.ScriptingStudio\TombIDE.ScriptingStudio.csproj" />
     <ProjectReference Include="..\TombIDE.Shared\TombIDE.Shared.csproj" />

--- a/TombLib/TombLib.Forms/TombLib.Forms.csproj
+++ b/TombLib/TombLib.Forms/TombLib.Forms.csproj
@@ -102,7 +102,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="5.0.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Forms\DarkDataGridViewControls.cs" />

--- a/TombLib/TombLib.Rendering/TombLib.Rendering.csproj
+++ b/TombLib/TombLib.Rendering/TombLib.Rendering.csproj
@@ -166,7 +166,6 @@
     <PackageReference Include="Microsoft.HLSL.CSharpVB" Version="1.0.2" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.2.0" />
     <PackageReference Include="NLog" Version="5.0.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <Import Project="FxCompileEx.targets" />
 </Project>

--- a/TombLib/TombLib.Scripting.ClassicScript/TombLib.Scripting.ClassicScript.csproj
+++ b/TombLib/TombLib.Scripting.ClassicScript/TombLib.Scripting.ClassicScript.csproj
@@ -75,7 +75,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DarkUI\DarkUI\DarkUI.csproj" />
     <ProjectReference Include="..\TombLib.Forms\TombLib.Forms.csproj" />
     <ProjectReference Include="..\TombLib.Scripting\TombLib.Scripting.csproj" />
   </ItemGroup>

--- a/TombLib/TombLib.Scripting.ClassicScript/TombLib.Scripting.ClassicScript.csproj
+++ b/TombLib/TombLib.Scripting.ClassicScript/TombLib.Scripting.ClassicScript.csproj
@@ -113,7 +113,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CoreCLR-NCalc" Version="2.2.101" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\Icons\Constant.png" />

--- a/TombLib/TombLib.Scripting.GameFlowScript/TombLib.Scripting.GameFlowScript.csproj
+++ b/TombLib/TombLib.Scripting.GameFlowScript/TombLib.Scripting.GameFlowScript.csproj
@@ -56,7 +56,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DarkUI\DarkUI\DarkUI.csproj" />
     <ProjectReference Include="..\TombLib.Scripting\TombLib.Scripting.csproj" />
   </ItemGroup>
 </Project>

--- a/TombLib/TombLib.Scripting.GameFlowScript/TombLib.Scripting.GameFlowScript.csproj
+++ b/TombLib/TombLib.Scripting.GameFlowScript/TombLib.Scripting.GameFlowScript.csproj
@@ -31,7 +31,6 @@
     <Compile Include="..\..\GlobalPaths.cs">
       <Link>GlobalPaths.cs</Link>
     </Compile>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
     <Compile Update="Workers\GameFlowNodesProvider.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/TombLib/TombLib.Scripting.Lua/TombLib.Scripting.Lua.csproj
+++ b/TombLib/TombLib.Scripting.Lua/TombLib.Scripting.Lua.csproj
@@ -38,7 +38,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DarkUI\DarkUI\DarkUI.csproj" />
     <ProjectReference Include="..\TombLib.Scripting\TombLib.Scripting.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/TombLib/TombLib.Scripting.Lua/TombLib.Scripting.Lua.csproj
+++ b/TombLib/TombLib.Scripting.Lua/TombLib.Scripting.Lua.csproj
@@ -33,7 +33,6 @@
     <Compile Include="..\..\GlobalPaths.cs">
       <Link>GlobalPaths.cs</Link>
     </Compile>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
     <Compile Update="LuaTextBox.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/TombLib/TombLib.Scripting.Tomb1Main/TombLib.Scripting.Tomb1Main.csproj
+++ b/TombLib/TombLib.Scripting.Tomb1Main/TombLib.Scripting.Tomb1Main.csproj
@@ -32,7 +32,6 @@
     <Compile Include="..\..\GlobalPaths.cs">
       <Link>GlobalPaths.cs</Link>
     </Compile>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
     <Compile Update="Workers\T1MNodesProvider.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/TombLib/TombLib.Scripting.Tomb1Main/TombLib.Scripting.Tomb1Main.csproj
+++ b/TombLib/TombLib.Scripting.Tomb1Main/TombLib.Scripting.Tomb1Main.csproj
@@ -51,7 +51,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DarkUI\DarkUI\DarkUI.csproj" />
     <ProjectReference Include="..\TombLib.Scripting\TombLib.Scripting.csproj" />
   </ItemGroup>
 </Project>

--- a/TombLib/TombLib.Scripting/TombLib.Scripting.csproj
+++ b/TombLib/TombLib.Scripting/TombLib.Scripting.csproj
@@ -24,9 +24,6 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="ICSharpCode.AvalonEdit, Version=6.1.0.0, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Libs\ICSharpCode.AvalonEdit.dll</HintPath>

--- a/TombLib/TombLib/LevelData/Instances/ObjectInstance.cs
+++ b/TombLib/TombLib/LevelData/Instances/ObjectInstance.cs
@@ -1,5 +1,4 @@
-﻿using DarkUI.Forms;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -476,19 +475,12 @@ namespace TombLib.LevelData
             }
         }
 
-        public bool TrySetLuaName(string newName, IWin32Window owner = null)
+        public bool CanSetLuaName(string newName)
         {
-            var result = (string.IsNullOrEmpty(newName) ||
+            return (string.IsNullOrEmpty(newName) ||
                           Room.Level.GetAllObjects().Where(o => o is IHasLuaName &&
                                                           (o as IHasLuaName).LuaName == newName &&
                                                            o != this).Count() == 0);
-            if (!result && owner != null)
-                DarkMessageBox.Show(owner, "The value of Lua Name is already taken by another object", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-
-            if (result)
-                LuaName = newName;
-
-            return result;
         }
 
         public string GetScriptIDOrName(bool shortened = true)

--- a/TombLib/TombLib/LevelData/LuaScriptID.cs
+++ b/TombLib/TombLib/LevelData/LuaScriptID.cs
@@ -6,6 +6,6 @@ namespace TombLib.LevelData
     {
         string LuaName { get; set; }
         void AllocateNewLuaName();
-        bool TrySetLuaName(string newScriptId, IWin32Window owner = null);
+        bool CanSetLuaName(string newScriptId);
     }
 }

--- a/TombLib/TombLib/TombLib.csproj
+++ b/TombLib/TombLib/TombLib.csproj
@@ -425,9 +425,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\DarkUI\DarkUI\DarkUI.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Catalogs\Engines\TRNG\CLICK_DISTANCE_32.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/TombLib/TombLib/TombLib.csproj
+++ b/TombLib/TombLib/TombLib.csproj
@@ -490,7 +490,6 @@
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
     <PackageReference Include="NLog" Version="5.0.0" />
     <PackageReference Include="Pfim" Version="0.10.3" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="GeometryIO\IOBone.cs" />

--- a/TombLib/TombLib/Utils/Configuration.cs
+++ b/TombLib/TombLib/Utils/Configuration.cs
@@ -1,5 +1,4 @@
-﻿using DarkUI.Forms;
-using NLog;
+﻿using NLog;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -38,7 +37,7 @@ namespace TombLib
         public bool Log_WriteToFile { get; set; } = true;
         public int Log_ArchiveN { get; set; } = 0;
 
-        public static void SaveWindowProperties(DarkForm form, ConfigurationBase config)
+        public static void SaveWindowProperties(Form form, ConfigurationBase config)
         {
             var name = "Window_" + form.Name;
 
@@ -57,7 +56,7 @@ namespace TombLib
 
         }
 
-        public static void LoadWindowProperties(DarkForm form, ConfigurationBase config)
+        public static void LoadWindowProperties(Form form, ConfigurationBase config)
         {
             var name = "Window_" + form.Name;
 
@@ -93,7 +92,7 @@ namespace TombLib
             }
         }
 
-        public static void ConfigureWindow(DarkForm form, ConfigurationBase config)
+        public static void ConfigureWindow(Form form, ConfigurationBase config)
         {
             if (form == null || config == null)
                 return;

--- a/TombLib/TombLib/Utils/TextExtensions.cs
+++ b/TombLib/TombLib/Utils/TextExtensions.cs
@@ -1,5 +1,4 @@
-﻿using DarkUI.Forms;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -29,7 +28,6 @@ namespace TombLib.Utils
         {
             if (!source.IsANSI())
             {
-                DarkMessageBox.Show(owner, "Filename or path is invalid. Please use standard characters.", "Wrong filename", MessageBoxIcon.Error);
                 return false;
             }
             else

--- a/WadTool/WadActions.cs
+++ b/WadTool/WadActions.cs
@@ -1579,7 +1579,6 @@ namespace WadTool
                 {
                     DarkMessageBox.Show(owner, "Filename or path is invalid. Please use standard characters.", "Wrong filename", MessageBoxIcon.Error);
                     return ImportMesh(tool, owner);
-
                 }
 
                 try

--- a/WadTool/WadActions.cs
+++ b/WadTool/WadActions.cs
@@ -1518,6 +1518,7 @@ namespace WadTool
 
                 if (!saveFileDialog.FileName.CheckAndWarnIfNotANSI(owner))
                 {
+                    DarkMessageBox.Show(owner, "Filename or path is invalid. Please use standard characters.", "Wrong filename", MessageBoxIcon.Error);
                     ExportMesh(mesh, tool, owner);
                     return;
                 }
@@ -1575,7 +1576,11 @@ namespace WadTool
                     return null;
 
                 if (!dialog.FileName.CheckAndWarnIfNotANSI(owner))
+                {
+                    DarkMessageBox.Show(owner, "Filename or path is invalid. Please use standard characters.", "Wrong filename", MessageBoxIcon.Error);
                     return ImportMesh(tool, owner);
+
+                }
 
                 try
                 {


### PR DESCRIPTION
This PR removes the Codepages Nuget Package (which made problems before due to different versions in different solution projects) and removes DarkUI from TombLib.

One interface (IHasLuaName) had DarkUI as a dependency so it could open a DarkMessageBox.
The interface operation was renamed from `TrySetLuaName` to `CanSetLuaName` to accomodate the Query-Command pattern (instead of silently failing and setting the name).

UI stuff should only go in the App Projects (TombIDE, WadTool, SoundToo, TombEditor) or the UI library projects (TombLib.Forms, DarKUI) so you do not lock into DarkUI even more.