### PR TITLE
Add TR1X ladder support

### DIFF
--- a/TombEditor/Command.cs
+++ b/TombEditor/Command.cs
@@ -1974,7 +1974,7 @@ namespace TombEditor
             {
                 if (!EditorActions.CheckForRoomAndSectorSelection(args.Window))
                     return;
-                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion.Native() >= TRVersion.Game.TR2, "Climbing"))
+                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion.SupportsClimbing(), "Climbing"))
                     return;
                 EditorActions.ToggleSectorFlag(args.Editor.SelectedRoom, args.Editor.SelectedSectors.Area, SectorFlags.ClimbPositiveZ);
             });
@@ -1983,7 +1983,7 @@ namespace TombEditor
             {
                 if (!EditorActions.CheckForRoomAndSectorSelection(args.Window))
                     return;
-                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion.Native() >= TRVersion.Game.TR2, "Climbing"))
+                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion.SupportsClimbing(), "Climbing"))
                     return;
                 EditorActions.ToggleSectorFlag(args.Editor.SelectedRoom, args.Editor.SelectedSectors.Area, SectorFlags.ClimbPositiveX);
             });
@@ -1992,7 +1992,7 @@ namespace TombEditor
             {
                 if (!EditorActions.CheckForRoomAndSectorSelection(args.Window))
                     return;
-                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion.Native() >= TRVersion.Game.TR2, "Climbing"))
+                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion.SupportsClimbing(), "Climbing"))
                     return;
                 EditorActions.ToggleSectorFlag(args.Editor.SelectedRoom, args.Editor.SelectedSectors.Area, SectorFlags.ClimbNegativeZ);
             });
@@ -2001,7 +2001,7 @@ namespace TombEditor
             {
                 if (!EditorActions.CheckForRoomAndSectorSelection(args.Window))
                     return;
-                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion.Native() >= TRVersion.Game.TR2, "Climbing"))
+                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion.SupportsClimbing(), "Climbing"))
                     return;
                 EditorActions.ToggleSectorFlag(args.Editor.SelectedRoom, args.Editor.SelectedSectors.Area, SectorFlags.ClimbNegativeX);
             });

--- a/TombEditor/ToolWindows/SectorOptions.cs
+++ b/TombEditor/ToolWindows/SectorOptions.cs
@@ -73,13 +73,13 @@ namespace TombEditor.ToolWindows
                 obj is Editor.GameVersionChangedEvent ||
                 obj is Editor.LevelChangedEvent)
             {
-                bool isTR2 = _editor.Level.Settings.GameVersion.Native() >= TRVersion.Game.TR2;
+                bool climbingSupported = _editor.Level.Settings.GameVersion.SupportsClimbing();
                 bool isTR345 = _editor.Level.Settings.GameVersion.Native() >= TRVersion.Game.TR3;
 
-                butClimbNegativeX.Enabled = isTR2;
-                butClimbNegativeZ.Enabled = isTR2;
-                butClimbPositiveX.Enabled = isTR2;
-                butClimbPositiveZ.Enabled = isTR2;
+                butClimbNegativeX.Enabled = climbingSupported;
+                butClimbNegativeZ.Enabled = climbingSupported;
+                butClimbPositiveX.Enabled = climbingSupported;
+                butClimbPositiveZ.Enabled = climbingSupported;
                 butMonkey.Enabled = isTR345;
                 butFlagBeetle.Enabled = isTR345;
                 butFlagTriggerTriggerer.Enabled = isTR345;

--- a/TombLib/TombLib/LevelData/Compilers/Trx.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Trx.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using TombLib.IO;
 using TombLib.LevelData.Compilers.Util;
+using TombLib.LevelData.SectorEnums;
 
 namespace TombLib.LevelData.Compilers;
 
@@ -46,6 +47,10 @@ public partial class LevelCompilerClassicTR
                     {
                         yield return overwriteEdit;
                     }
+                    if (GetClimbEntry(teRoom, x, z) is TrxSectorEdit climbEdit)
+                    {
+                        yield return climbEdit;
+                    }
                 }
             }
         }
@@ -78,5 +83,27 @@ public partial class LevelCompilerClassicTR
         return portal != null && portal.Opacity != PortalOpacity.SolidFaces
             ? _roomRemapping[portal.AdjoiningRoom]
             : _noRoom;
+    }
+
+    private TrxClimbEntry GetClimbEntry(Room teRoom, ushort x, ushort z)
+    {
+        if (_level.Settings.GameVersion != TRVersion.Game.TR1X)
+        {
+            return null;
+        }
+
+        var teSector = teRoom.Sectors[x, z];
+        if ((teSector.Flags & SectorFlags.ClimbAny) == SectorFlags.None)
+        {
+            return null;
+        }
+
+        return new()
+        {
+            RoomIndex = (short)_roomRemapping[teRoom],
+            X = x,
+            Z = z,
+            Flags = teSector.Flags,
+        };
     }
 }

--- a/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
@@ -9,7 +9,7 @@ namespace TombLib.LevelData.Compilers.Util;
 public static class TrxInjector
 {
     private const uint _magic = 'T' | 'R' << 8 | 'X' << 16 | 'J' << 24;
-    private const uint _version = 2;
+    private const uint _version = 4;
     private const uint _injectionType = 0; // Implies no link to a TRX config option
 
     public static void Serialize(TrxInjectionData data, BinaryWriterEx outWriter)
@@ -133,30 +133,41 @@ public static class TrxInjector
 
 public class TrxInjectionData
 {
-    public List<TrxSectorOverwrite> SectorEdits { get; set; } = new();
+    public List<TrxSectorEdit> SectorEdits { get; set; } = new();
 }
 
-public class TrxSectorOverwrite
+public abstract class TrxSectorEdit
 {
-    private const int _overwriteCommand = 7;
-
+    public abstract int Command { get; }
     public short RoomIndex { get; set; }
     public ushort X { get; set; }
     public ushort Z { get; set; }
-    public tr_room_sector BaseSector { get; set; }
-    public short RoomBelowExt { get; set; }
-    public short RoomAboveExt { get; set; }
 
     public void Serialize(BinaryWriterEx writer)
     {
-        // TRX uses -1 for NO_ROOM and supports up to 1024 rooms, including
-        // vertical portal support. The engine expects all values for the sector
-        // here, including heights being in world units.
         writer.Write(RoomIndex);
         writer.Write(X);
         writer.Write(Z);
         writer.Write(1); // "edit" count
-        writer.Write(_overwriteCommand);
+        writer.Write(Command);
+        SerializeImpl(writer);
+    }
+
+    protected abstract void SerializeImpl(BinaryWriterEx writer);
+}
+
+public class TrxSectorOverwrite : TrxSectorEdit
+{
+    public override int Command => 7;
+    public tr_room_sector BaseSector { get; set; }
+    public short RoomBelowExt { get; set; }
+    public short RoomAboveExt { get; set; }
+
+    protected override void SerializeImpl(BinaryWriterEx writer)
+    {
+        // TRX uses -1 for NO_ROOM and supports up to 1024 rooms, including
+        // vertical portal support. The engine expects all values for the sector
+        // here, including heights being in world units.
         writer.Write(BaseSector.FloorDataIndex);
         writer.Write(BaseSector.BoxIndex);
         writer.Write(RoomBelowExt);

--- a/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using TombLib.IO;
+using TombLib.LevelData.SectorEnums;
 using TombLib.Utils;
 
 namespace TombLib.LevelData.Compilers.Util;
@@ -174,5 +175,21 @@ public class TrxSectorOverwrite : TrxSectorEdit
         writer.Write((short)(BaseSector.Floor * Level.FullClickHeight));
         writer.Write(RoomAboveExt);
         writer.Write((short)(BaseSector.Ceiling * Level.FullClickHeight));
+    }
+}
+
+public class TrxClimbEntry : TrxSectorEdit
+{
+    public override int Command => 11;
+    public SectorFlags Flags { get; set; }
+
+    protected override void SerializeImpl(BinaryWriterEx writer)
+    {
+        var direction = 0;
+        direction |= Convert.ToInt32(Flags.HasFlag(SectorFlags.ClimbPositiveZ)) << 0;
+        direction |= Convert.ToInt32(Flags.HasFlag(SectorFlags.ClimbPositiveX)) << 1;
+        direction |= Convert.ToInt32(Flags.HasFlag(SectorFlags.ClimbNegativeZ)) << 2;
+        direction |= Convert.ToInt32(Flags.HasFlag(SectorFlags.ClimbNegativeX)) << 3;
+        writer.Write(direction);
     }
 }

--- a/TombLib/TombLib/LevelData/Enumerations.cs
+++ b/TombLib/TombLib/LevelData/Enumerations.cs
@@ -60,6 +60,9 @@ namespace TombLib.LevelData
 
         public static bool SupportsLensflare(this Game ver)
             => ver.Native() >= Game.TR4;
+
+        public static bool SupportsClimbing(this Game ver)
+            => ver != Game.TR1;
     }
 
     // Only for TR5+


### PR DESCRIPTION
Adds support to inject ladder data into TR1X levels, and makes the relevant UI options available.
Refactored the injector slightly to make additions such as this neater.

Ref: https://github.com/LostArtefacts/TRX/pull/3956