### PR TITLE
Fix TR2 pickup definitions

### DIFF
--- a/TombLib/TombLib/Catalogs/Engines/TR2/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR2/Moveables.xml
@@ -170,10 +170,8 @@
     <moveable id="202" name="Lock 2" ten="KEY_HOLE2" />
     <moveable id="203" name="Lock 3" ten="KEY_HOLE3" />
     <moveable id="204" name="Lock 4" ten="KEY_HOLE4" />
-    <moveable id="205" name="Pickup 1" ten="PICKUP_ITEM1" />
-    <moveable id="206" name="Pickup 2" ten="PICKUP_ITEM2" />
-    <moveable id="207" name="Pickup 3" ten="PICKUP_ITEM3" />
-    <moveable id="208" name="Pickup 4" ten="PICKUP_ITEM4" />
+    <moveable id="207" name="Pickup 1" id2="205" ten="PICKUP_ITEM1" />
+    <moveable id="208" name="Pickup 2" id2="206" ten="PICKUP_ITEM2" />
     <moveable id="209" name="Dragon explosion effect (expanding netted bubble)" hidden="true" ten="SPHERE_OF_DOOM" />
     <moveable id="210" name="Dragon explosion effect (expanding netted bubble)" hidden="true" ten="SPHERE_OF_DOOM2" />
     <moveable id="211" name="Dragon explosion effect (expanding solid bubble)" hidden="true"  ten="SPHERE_OF_DOOM3" />

--- a/TombLib/TombLib/Catalogs/Engines/TR2/SpriteSequences.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR2/SpriteSequences.xml
@@ -30,8 +30,8 @@
     <sprite_sequence id="194" name="Key 2" />
     <sprite_sequence id="195" name="Key 3" />
     <sprite_sequence id="196" name="Key 4" />
-    <sprite_sequence id="205" name="Pickup 5" />
-    <sprite_sequence id="206" name="Pickup 6" />
+    <sprite_sequence id="205" name="Pickup 1" />
+    <sprite_sequence id="206" name="Pickup 2" />
     <sprite_sequence id="220" name="Extra Fire (Ice Palace)" />
     <sprite_sequence id="224" name="Gray disk" />
     <sprite_sequence id="229" name="Grenade blast" zoom="-2.4" />


### PR DESCRIPTION
OG TR2 has two pickup/quest items only so this corrects the XML definitions as such.