### PR TITLE
Fix TRX WadTool blending modes

### DIFF
--- a/TombLib/TombLib/Utils/Texture.cs
+++ b/TombLib/TombLib/Utils/Texture.cs
@@ -145,20 +145,23 @@ namespace TombLib.Utils
         public static List<string> BlendModeUserNames(LevelSettings settings)
         {
             int blendCount;
+            bool enableExtraModes = settings.GameEnableExtraBlendingModes ?? false;
 
             // For TR4, TRNG and TombEngine we can add all types (if extra blending modes are enabled)
             if (settings.GameVersion == TRVersion.Game.TombEngine)
             {
                 blendCount = 7;
             }
-            else if (((settings.GameEnableExtraBlendingModes ?? false) && settings.GameVersion.Native() == TRVersion.Game.TR4))
+            else if (enableExtraModes && settings.GameVersion.Native() == TRVersion.Game.TR4)
             {
                 blendCount = 6;
             }
             else
             {
-                // Additive blending is for TR3-5 only and TRX
-                if (settings.GameVersion >= TRVersion.Game.TR3)
+                // Additive blending is for TR3-5 only and TRX. Extra modes is however
+                // enabled in WadTool context for TR1-2. For non-TRX versions of those
+                // games, modes will be normalised on compilation in TE.
+                if (settings.GameVersion >= TRVersion.Game.TR3 || enableExtraModes)
                     blendCount = 2;
                 else
                     blendCount = 1; // Type 0 exists everywhere


### PR DESCRIPTION
This allows blending modes to be selected in WadTool for TR1-2, which I missed in 9cf47696c. TE will continue to normalise tex info attributes for non-TRX versions of these games when the levels are compiled.

Without this, it wouldn't be possible to get objects/statics with transparency in TRX levels.

In-game test result below.

<details>

<img width="320" height="600" alt="image" src="https://github.com/user-attachments/assets/1015cea2-e790-4238-93cb-19ce20fac3a7" />
</details>