### PR TITLE
Simplify timer comparison and refine debug logging

### DIFF
--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/Timers.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/Timers.lua
@@ -521,7 +521,7 @@ end
 LevelFuncs.Engine.Node.IfTotalTimeIs = function(name, operator, time)
     if name ~= '' then
         if Timer.IfExists(name) then
-            local result = Timer.Get(name):IfTotalTimeIs(operator, (time))
+            local result = Timer.Get(name):IfTotalTimeIs(operator, time)
             if LevelVars.nodeTimers[name].debug then
                 local totalTime = Timer.Get(name):GetTotalTimeInSeconds()
                 TEN.Util.PrintLog("If the total time (".. totalTime ..") is " .. textCompareOp[operator] .. " " ..  (time + 0.0) .. ". Result: " .. tostring(result), TEN.Util.LogLevel.INFO, true)


### PR DESCRIPTION
This pull request refactors and improves the logging and result handling logic for timer comparison node functions in `Timers.lua`. The changes make the code more concise and ensure that debug logs are printed more consistently and clearly when comparing timer values.

**Improvements to timer comparison logic and debug logging:**

* Refactored `IfRemainingTimeIs` logic to simplify result assignment and consolidate debug log conditions, ensuring logs are only printed when appropriate based on operator and timer state. Use timer:IfRemainingTimeIs(...) directly to compute the result and simplify logic. Adjust debug logging so ticking checks use timer:IsTicking() inline and only compute floatValue/remainingTime when logging is enabled. This reduces redundant variables and clarifies when Equal/NotEqual results are logged (only if the timer is ticking) while other operators are always logged.
* Updated `IfTotalTimeIs` to assign the comparison result to a variable, and added debug logging to print the result and comparison details when debug mode is enabled for the timer.