### PR TITLE
Fixed animated group textures not animating

### DIFF
--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -1847,8 +1847,6 @@ namespace TombEditor
             if(!disableUndo)
                 _editor.UndoManager.PushGeometryChanged(_editor.SelectedRoom);
 
-            texture.ParentArea = new Rectangle2();
-
             bool textureApplied = ApplyTextureToFace(room, pos, face, texture);
 
             if (textureApplied)
@@ -2278,8 +2276,6 @@ namespace TombEditor
 
             if (type == SectorFaceType.Ceiling) texture.Mirror();
             RectangleInt2 area = selection.Valid ? selection.Area : _editor.SelectedRoom.LocalArea;
-
-            texture.ParentArea = new Rectangle2();
 
             for (int x = area.X0; x <= area.X1; x++)
                 for (int z = area.Y0; z <= area.Y1; z++)

--- a/TombLib/TombLib/LevelData/Compilers/AnimatedTextureLookupUtility.cs
+++ b/TombLib/TombLib/LevelData/Compilers/AnimatedTextureLookupUtility.cs
@@ -1,0 +1,263 @@
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using TombLib.Utils;
+
+namespace TombLib.LevelData.Compilers
+{
+    internal static class AnimatedTextureLookupUtility
+    {
+        private static float NormalizeLookupCoordinate(float value, float margin)
+            => (float)(Math.Round(value / margin) * margin);
+
+        /// <summary>
+        /// Quantizes a rectangle to the lookup margin so equivalent UV bounds collapse to a stable cache key.
+        /// </summary>
+        /// <param name="rect">The rectangle to normalize.</param>
+        /// <param name="margin">The quantization step used by animated texture lookup comparisons.</param>
+        /// <returns>A rectangle snapped to the lookup grid defined by <paramref name="margin"/>.</returns>
+        public static Rectangle2 NormalizeLookupRectangle(Rectangle2 rect, float margin) => new(
+            NormalizeLookupCoordinate(rect.Start.X, margin),
+            NormalizeLookupCoordinate(rect.Start.Y, margin),
+            NormalizeLookupCoordinate(rect.End.X, margin),
+            NormalizeLookupCoordinate(rect.End.Y, margin)
+        );
+
+        /// <summary>
+        /// Determines whether two textures should be treated as the same logical texture for animated lookup purposes.
+        /// </summary>
+        /// <param name="first">The first texture to compare.</param>
+        /// <param name="second">The second texture to compare.</param>
+        /// <returns><see langword="true"/> when both textures resolve to the same identity; otherwise <see langword="false"/>.</returns>
+        public static bool AreEquivalentTextures(Texture first, Texture second)
+        {
+            if (ReferenceEquals(first, second))
+                return true;
+
+            if (!string.IsNullOrEmpty(first.AbsolutePath) && !string.IsNullOrEmpty(second.AbsolutePath))
+                return first.AbsolutePath.Equals(second.AbsolutePath, StringComparison.OrdinalIgnoreCase);
+
+            if (first is TextureHashed firstHashed)
+                return second is TextureHashed secondHashed && firstHashed.Hash == secondHashed.Hash;
+
+            if (second is TextureHashed)
+                return false;
+
+            return first.Equals(second);
+        }
+
+        /// <summary>
+        /// Builds a stable hash for a texture identity using the same precedence as <see cref="AreEquivalentTextures"/>.
+        /// </summary>
+        /// <param name="texture">The texture whose identity hash should be computed.</param>
+        /// <returns>A hash code suitable for deduplication keys.</returns>
+        public static int GetTextureIdentityHash(Texture texture)
+        {
+            if (!string.IsNullOrEmpty(texture.AbsolutePath))
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(texture.AbsolutePath);
+
+            if (texture is TextureHashed hashed)
+                return hashed.Hash.GetHashCode();
+
+            return texture.GetHashCode();
+        }
+
+        /// <summary>
+        /// Checks whether two rectangles match within the specified per-edge tolerance.
+        /// </summary>
+        /// <param name="first">The first rectangle.</param>
+        /// <param name="second">The second rectangle.</param>
+        /// <param name="margin">The allowed epsilon for each rectangle edge.</param>
+        /// <returns><see langword="true"/> when all corresponding edges are within <paramref name="margin"/>.</returns>
+        public static bool RectanglesMatch(Rectangle2 first, Rectangle2 second, float margin)
+            => MathC.WithinEpsilon(first.X0, second.X0, margin) &&
+               MathC.WithinEpsilon(first.Y0, second.Y0, margin) &&
+               MathC.WithinEpsilon(first.X1, second.X1, margin) &&
+               MathC.WithinEpsilon(first.Y1, second.Y1, margin);
+
+        private static float GetRectangleMatchScore(Rectangle2 first, Rectangle2 second)
+            => Math.Abs(first.X0 - second.X0) +
+               Math.Abs(first.Y0 - second.Y0) +
+               Math.Abs(first.X1 - second.X1) +
+               Math.Abs(first.Y1 - second.Y1);
+
+        /// <summary>
+        /// Finds the closest frame in an animated set whose texture identity and bounds match the requested parent area.
+        /// </summary>
+        /// <param name="set">The animated texture set to scan.</param>
+        /// <param name="texture">The texture area whose source frame is being resolved.</param>
+        /// <param name="parentRect">The full parent rectangle that should match one frame in the set.</param>
+        /// <param name="margin">The matching tolerance for rectangle comparison.</param>
+        /// <returns>The best matching frame, or <see langword="null"/> when no acceptable match exists.</returns>
+        public static AnimatedTextureFrame? FindBestMatchingAnimatedFrame(AnimatedTextureSet set, TextureArea texture, Rectangle2 parentRect, float margin)
+        {
+            AnimatedTextureFrame? bestFrame = null;
+            float bestScore = float.MaxValue;
+
+            foreach (var frame in set.Frames)
+            {
+                if (!AreEquivalentTextures(frame.Texture, texture.Texture))
+                    continue;
+
+                var frameRect = Rectangle2.FromCoordinates(frame.TexCoord0, frame.TexCoord1, frame.TexCoord2, frame.TexCoord3);
+
+                if (!RectanglesMatch(frameRect, parentRect, margin))
+                    continue;
+
+                var score = GetRectangleMatchScore(frameRect, parentRect);
+
+                if (score >= bestScore)
+                    continue;
+
+                bestScore = score;
+                bestFrame = frame;
+
+                if (score == 0.0f)
+                    break;
+            }
+
+            return bestFrame;
+        }
+
+        /// <summary>
+        /// Rebuilds a texture area so its UVs cover the full stored parent area instead of the current sub-area.
+        /// </summary>
+        /// <param name="texture">The texture area whose parent bounds should become the full UV rectangle.</param>
+        /// <returns>A copy of <paramref name="texture"/> expanded to its full parent area.</returns>
+        public static TextureArea CreateFullParentAreaTexture(TextureArea texture)
+        {
+            TextureArea fullTexture = texture;
+            fullTexture.TexCoord0 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y0);
+            fullTexture.TexCoord1 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y1);
+            fullTexture.TexCoord2 = new Vector2(texture.ParentArea.X1, texture.ParentArea.Y1);
+            fullTexture.TexCoord3 = new Vector2(texture.ParentArea.X1, texture.ParentArea.Y0);
+            fullTexture.ParentArea = Rectangle2.Zero;
+            return fullTexture;
+        }
+
+        /// <summary>
+        /// Creates a synthetic animated texture set whose frames are cropped to the same relative sub-area as the input texture.
+        /// </summary>
+        /// <param name="originalSet">The source animated texture set.</param>
+        /// <param name="texture">The texture area that defines the desired sub-area.</param>
+        /// <param name="parentRect">The full parent rectangle expected to match a frame in <paramref name="originalSet"/>.</param>
+        /// <param name="subRect">The actual sub-rectangle that should be projected onto every frame.</param>
+        /// <param name="margin">The matching tolerance for resolving the source frame.</param>
+        /// <param name="subSet">Receives the generated sub-area animation set when the method succeeds.</param>
+        /// <returns><see langword="true"/> when a valid sub-area animation set was generated; otherwise <see langword="false"/>.</returns>
+        public static bool TryCreateSubAreaAnimationSet(
+            AnimatedTextureSet originalSet,
+            TextureArea texture,
+            Rectangle2 parentRect,
+            Rectangle2 subRect,
+            float margin,
+            [NotNullWhen(true)] out AnimatedTextureSet? subSet)
+        {
+            subSet = null;
+
+            AnimatedTextureFrame? matchedFrame = FindBestMatchingAnimatedFrame(originalSet, texture, parentRect, margin);
+
+            if (matchedFrame is null)
+                return false;
+
+            var matchedFrameRect = Rectangle2.FromCoordinates(matchedFrame.TexCoord0, matchedFrame.TexCoord1, matchedFrame.TexCoord2, matchedFrame.TexCoord3);
+
+            if (matchedFrameRect.Width == 0 || matchedFrameRect.Height == 0)
+                return false;
+
+            float relX0 = (subRect.X0 - matchedFrameRect.X0) / matchedFrameRect.Width;
+            float relY0 = (subRect.Y0 - matchedFrameRect.Y0) / matchedFrameRect.Height;
+            float relX1 = (subRect.X1 - matchedFrameRect.X0) / matchedFrameRect.Width;
+            float relY1 = (subRect.Y1 - matchedFrameRect.Y0) / matchedFrameRect.Height;
+
+            subSet = originalSet.Clone();
+
+            foreach (var subFrame in subSet.Frames)
+            {
+                var frameRect = Rectangle2.FromCoordinates(subFrame.TexCoord0, subFrame.TexCoord1, subFrame.TexCoord2, subFrame.TexCoord3);
+
+                float frameWidth = frameRect.Width;
+                float frameHeight = frameRect.Height;
+
+                subFrame.TexCoord0 = new Vector2(frameRect.X0 + relX0 * frameWidth, frameRect.Y0 + relY0 * frameHeight);
+                subFrame.TexCoord1 = new Vector2(frameRect.X0 + relX0 * frameWidth, frameRect.Y0 + relY1 * frameHeight);
+                subFrame.TexCoord2 = new Vector2(frameRect.X0 + relX1 * frameWidth, frameRect.Y0 + relY1 * frameHeight);
+                subFrame.TexCoord3 = new Vector2(frameRect.X0 + relX1 * frameWidth, frameRect.Y0 + relY0 * frameHeight);
+            }
+
+            return true;
+        }
+    }
+
+    internal readonly struct SubAreaKey : IEquatable<SubAreaKey>
+    {
+        private readonly int _destinationKey;
+
+        public readonly Texture Texture;
+        public readonly Rectangle2 ParentRect;
+        public readonly Rectangle2 SubRect;
+
+        /// <summary>
+        /// Creates a cache key for a sub-area lookup that does not vary by texture destination.
+        /// </summary>
+        /// <param name="texture">The texture identity to track.</param>
+        /// <param name="parentRect">The full parent rectangle of the animated frame.</param>
+        /// <param name="subRect">The cropped sub-area rectangle.</param>
+        /// <param name="margin">The rectangle quantization step used for lookup deduplication.</param>
+        public SubAreaKey(Texture texture, Rectangle2 parentRect, Rectangle2 subRect, float margin)
+            : this(texture, 0, parentRect, subRect, margin)
+        { }
+
+        /// <summary>
+        /// Creates a cache key for a sub-area lookup scoped to the classic room versus object destination split.
+        /// </summary>
+        /// <param name="texture">The texture identity to track.</param>
+        /// <param name="isForRoom"><see langword="true"/> for room textures; <see langword="false"/> for object textures.</param>
+        /// <param name="parentRect">The full parent rectangle of the animated frame.</param>
+        /// <param name="subRect">The cropped sub-area rectangle.</param>
+        /// <param name="margin">The rectangle quantization step used for lookup deduplication.</param>
+        public SubAreaKey(Texture texture, bool isForRoom, Rectangle2 parentRect, Rectangle2 subRect, float margin)
+            : this(texture, isForRoom ? 1 : 2, parentRect, subRect, margin)
+        { }
+
+        /// <summary>
+        /// Creates a cache key for a sub-area lookup scoped to a specific texture destination.
+        /// </summary>
+        /// <param name="texture">The texture identity to track.</param>
+        /// <param name="destination">The destination bucket that the generated lookup belongs to.</param>
+        /// <param name="parentRect">The full parent rectangle of the animated frame.</param>
+        /// <param name="subRect">The cropped sub-area rectangle.</param>
+        /// <param name="margin">The rectangle quantization step used for lookup deduplication.</param>
+        public SubAreaKey(Texture texture, TextureDestination destination, Rectangle2 parentRect, Rectangle2 subRect, float margin)
+            : this(texture, (int)destination + 1, parentRect, subRect, margin)
+        { }
+
+        private SubAreaKey(Texture texture, int destinationKey, Rectangle2 parentRect, Rectangle2 subRect, float margin)
+        {
+            Texture = texture;
+            _destinationKey = destinationKey;
+            ParentRect = AnimatedTextureLookupUtility.NormalizeLookupRectangle(parentRect, margin);
+            SubRect = AnimatedTextureLookupUtility.NormalizeLookupRectangle(subRect, margin);
+        }
+
+        /// <summary>
+        /// Compares two sub-area keys using normalized bounds, destination scope, and logical texture identity.
+        /// </summary>
+        /// <param name="other">The key to compare against.</param>
+        /// <returns><see langword="true"/> when both keys refer to the same deduplicated sub-area lookup.</returns>
+        public bool Equals(SubAreaKey other)
+        {
+            if (_destinationKey != other._destinationKey || ParentRect != other.ParentRect || SubRect != other.SubRect)
+                return false;
+
+            return AnimatedTextureLookupUtility.AreEquivalentTextures(Texture, other.Texture);
+        }
+
+        public override bool Equals(object? obj) => obj is SubAreaKey key && Equals(key);
+
+        public override int GetHashCode()
+            => HashCode.Combine(_destinationKey, ParentRect, SubRect, AnimatedTextureLookupUtility.GetTextureIdentityHash(Texture));
+    }
+}

--- a/TombLib/TombLib/LevelData/Compilers/AnimatedTextureLookupUtility.cs
+++ b/TombLib/TombLib/LevelData/Compilers/AnimatedTextureLookupUtility.cs
@@ -18,7 +18,7 @@ namespace TombLib.LevelData.Compilers
         /// <param name="rect">The rectangle to normalize.</param>
         /// <param name="margin">The quantization step used by animated texture lookup comparisons.</param>
         /// <returns>A rectangle snapped to the lookup grid defined by <paramref name="margin"/>.</returns>
-        public static Rectangle2 NormalizeLookupRectangle(Rectangle2 rect, float margin) => new(
+        internal static Rectangle2 NormalizeLookupRectangle(Rectangle2 rect, float margin) => new(
             NormalizeLookupCoordinate(rect.Start.X, margin),
             NormalizeLookupCoordinate(rect.Start.Y, margin),
             NormalizeLookupCoordinate(rect.End.X, margin),
@@ -31,7 +31,7 @@ namespace TombLib.LevelData.Compilers
         /// <param name="first">The first texture to compare.</param>
         /// <param name="second">The second texture to compare.</param>
         /// <returns><see langword="true"/> when both textures resolve to the same identity; otherwise <see langword="false"/>.</returns>
-        public static bool AreEquivalentTextures(Texture first, Texture second)
+        internal static bool AreEquivalentTextures(Texture first, Texture second)
         {
             if (ReferenceEquals(first, second))
                 return true;
@@ -53,7 +53,7 @@ namespace TombLib.LevelData.Compilers
         /// </summary>
         /// <param name="texture">The texture whose identity hash should be computed.</param>
         /// <returns>A hash code suitable for deduplication keys.</returns>
-        public static int GetTextureIdentityHash(Texture texture)
+        internal static int GetTextureIdentityHash(Texture texture)
         {
             if (!string.IsNullOrEmpty(texture.AbsolutePath))
                 return StringComparer.OrdinalIgnoreCase.GetHashCode(texture.AbsolutePath);
@@ -71,7 +71,7 @@ namespace TombLib.LevelData.Compilers
         /// <param name="second">The second rectangle.</param>
         /// <param name="margin">The allowed epsilon for each rectangle edge.</param>
         /// <returns><see langword="true"/> when all corresponding edges are within <paramref name="margin"/>.</returns>
-        public static bool RectanglesMatch(Rectangle2 first, Rectangle2 second, float margin)
+        private static bool RectanglesMatch(Rectangle2 first, Rectangle2 second, float margin)
             => MathC.WithinEpsilon(first.X0, second.X0, margin) &&
                MathC.WithinEpsilon(first.Y0, second.Y0, margin) &&
                MathC.WithinEpsilon(first.X1, second.X1, margin) &&
@@ -91,7 +91,7 @@ namespace TombLib.LevelData.Compilers
         /// <param name="parentRect">The full parent rectangle that should match one frame in the set.</param>
         /// <param name="margin">The matching tolerance for rectangle comparison.</param>
         /// <returns>The best matching frame, or <see langword="null"/> when no acceptable match exists.</returns>
-        public static AnimatedTextureFrame? FindBestMatchingAnimatedFrame(AnimatedTextureSet set, TextureArea texture, Rectangle2 parentRect, float margin)
+        private static AnimatedTextureFrame? FindBestMatchingAnimatedFrame(AnimatedTextureSet set, TextureArea texture, Rectangle2 parentRect, float margin)
         {
             AnimatedTextureFrame? bestFrame = null;
             float bestScore = float.MaxValue;
@@ -126,7 +126,7 @@ namespace TombLib.LevelData.Compilers
         /// </summary>
         /// <param name="texture">The texture area whose parent bounds should become the full UV rectangle.</param>
         /// <returns>A copy of <paramref name="texture"/> expanded to its full parent area.</returns>
-        public static TextureArea CreateFullParentAreaTexture(TextureArea texture)
+        internal static TextureArea CreateFullParentAreaTexture(TextureArea texture)
         {
             TextureArea fullTexture = texture;
             fullTexture.TexCoord0 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y0);
@@ -147,7 +147,7 @@ namespace TombLib.LevelData.Compilers
         /// <param name="margin">The matching tolerance for resolving the source frame.</param>
         /// <param name="subSet">Receives the generated sub-area animation set when the method succeeds.</param>
         /// <returns><see langword="true"/> when a valid sub-area animation set was generated; otherwise <see langword="false"/>.</returns>
-        public static bool TryCreateSubAreaAnimationSet(
+        internal static bool TryCreateSubAreaAnimationSet(
             AnimatedTextureSet originalSet,
             TextureArea texture,
             Rectangle2 parentRect,

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
@@ -73,7 +73,9 @@ namespace TombLib.LevelData.Compilers
 
         private List<ParentAnimatedTexture> _referenceAnimTextures = new List<ParentAnimatedTexture>();
         private List<ParentAnimatedTexture> _actualAnimTextures = new List<ParentAnimatedTexture>();
-        private HashSet<(Rectangle2 parentRect, Rectangle2 subRect)> _processedSubAreas = new HashSet<(Rectangle2, Rectangle2)>();
+
+        private record SubAreaKey(Texture Texture, TextureDestination Destination, Rectangle2 ParentRect, Rectangle2 SubRect);
+        private HashSet<SubAreaKey> _processedSubAreas = new HashSet<SubAreaKey>();
 
         // UVRotate count should be placed after anim texture data to identify how many first anim seqs
         // should be processed using UVRotate engine function
@@ -1268,7 +1270,8 @@ namespace TombLib.LevelData.Compilers
             // Check if this is a sub-area of an animated texture (e.g. applied via group texturing tools).
             // In this case, the actual UV coordinates represent a portion of the full animation frame,
             // so we reconstruct the full frame from ParentArea and match against reference animations.
-            if (!texture.ParentArea.IsZero && _referenceAnimTextures.Count > 0)
+            if (!texture.ParentArea.IsZero && _referenceAnimTextures.Count > 0 &&
+                texture.ParentArea != texture.GetRect(isForTriangle))
             {
                 TextureArea fullTexture = texture;
                 fullTexture.TexCoord0 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y0);
@@ -1322,10 +1325,8 @@ namespace TombLib.LevelData.Compilers
                         if (mfRect.Width == 0 || mfRect.Height == 0)
                             continue;
 
-                        // Skip if this sub-area was already processed
-                        var subAreaKey = (parentRect, subRect);
-
-                        if (!_processedSubAreas.Add(subAreaKey))
+                        // Skip if this sub-area was already processed for this texture and destination
+                        if (!_processedSubAreas.Add(new SubAreaKey(texture.Texture, destination, parentRect, subRect)))
                             continue;
 
                         float relX0 = (subRect.X0 - mfRect.X0) / mfRect.Width;
@@ -1357,9 +1358,7 @@ namespace TombLib.LevelData.Compilers
                         GenerateAnimLookups(new List<AnimatedTextureSet> { subSet }, destination);
 
                         // Retry - the sub-area coordinates should now match the new reference lookups
-                        var result = AddTexture(texture, destination, isForTriangle, blendMode);
-                        result.Animated = true;
-                        return result;
+                        return AddTexture(texture, destination, isForTriangle, blendMode);
                     }
                 }
             }

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
@@ -1270,9 +1270,12 @@ namespace TombLib.LevelData.Compilers
                 texture.ParentArea != texture.GetRect(isForTriangle))
             {
                 TextureArea fullTexture = AnimatedTextureLookupUtility.CreateFullParentAreaTexture(texture);
+                int initialReferenceAnimTextureCount = _referenceAnimTextures.Count;
 
-                foreach (var refTex in _referenceAnimTextures)
+                for (int i = 0; i < initialReferenceAnimTextureCount; i++)
                 {
+                    var refTex = _referenceAnimTextures[i];
+
                     // UVRotate and Video animation types are incompatible with sub-area splitting
                     // because they rely on specific frame arrangement assumptions (vertical strip scrolling
                     // for UVRotate, sequential frame playback for Video) that break when coordinates

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
@@ -73,6 +73,7 @@ namespace TombLib.LevelData.Compilers
 
         private List<ParentAnimatedTexture> _referenceAnimTextures = new List<ParentAnimatedTexture>();
         private List<ParentAnimatedTexture> _actualAnimTextures = new List<ParentAnimatedTexture>();
+        private HashSet<(Rectangle2 parentRect, Rectangle2 subRect)> _processedSubAreas = new HashSet<(Rectangle2, Rectangle2)>();
 
         // UVRotate count should be placed after anim texture data to identify how many first anim seqs
         // should be processed using UVRotate engine function
@@ -1299,11 +1300,7 @@ namespace TombLib.LevelData.Compilers
                             if (frame.Texture != texture.Texture)
                                 continue;
 
-                            var fRect = new Rectangle2(
-                                MathF.Min(frame.TexCoord0.X, MathF.Min(frame.TexCoord1.X, MathF.Min(frame.TexCoord2.X, frame.TexCoord3.X))),
-                                MathF.Min(frame.TexCoord0.Y, MathF.Min(frame.TexCoord1.Y, MathF.Min(frame.TexCoord2.Y, frame.TexCoord3.Y))),
-                                MathF.Max(frame.TexCoord0.X, MathF.Max(frame.TexCoord1.X, MathF.Max(frame.TexCoord2.X, frame.TexCoord3.X))),
-                                MathF.Max(frame.TexCoord0.Y, MathF.Max(frame.TexCoord1.Y, MathF.Max(frame.TexCoord2.Y, frame.TexCoord3.Y))));
+                            var fRect = Rectangle2.FromCoordinates(frame.TexCoord0, frame.TexCoord1, frame.TexCoord2, frame.TexCoord3);
 
                             if (MathC.WithinEpsilon(fRect.X0, parentRect.X0, _animTextureLookupMargin) &&
                                 MathC.WithinEpsilon(fRect.Y0, parentRect.Y0, _animTextureLookupMargin) &&
@@ -1319,11 +1316,17 @@ namespace TombLib.LevelData.Compilers
                             continue;
 
                         // Calculate relative sub-area position within the matched frame
-                        var mfRect = new Rectangle2(
-                            MathF.Min(matchedFrame.TexCoord0.X, MathF.Min(matchedFrame.TexCoord1.X, MathF.Min(matchedFrame.TexCoord2.X, matchedFrame.TexCoord3.X))),
-                            MathF.Min(matchedFrame.TexCoord0.Y, MathF.Min(matchedFrame.TexCoord1.Y, MathF.Min(matchedFrame.TexCoord2.Y, matchedFrame.TexCoord3.Y))),
-                            MathF.Max(matchedFrame.TexCoord0.X, MathF.Max(matchedFrame.TexCoord1.X, MathF.Max(matchedFrame.TexCoord2.X, matchedFrame.TexCoord3.X))),
-                            MathF.Max(matchedFrame.TexCoord0.Y, MathF.Max(matchedFrame.TexCoord1.Y, MathF.Max(matchedFrame.TexCoord2.Y, matchedFrame.TexCoord3.Y))));
+                        var mfRect = Rectangle2.FromCoordinates(matchedFrame.TexCoord0, matchedFrame.TexCoord1, matchedFrame.TexCoord2, matchedFrame.TexCoord3);
+
+                        // Skip degenerate frames with zero-sized extents to avoid NaN/Infinity
+                        if (mfRect.Width == 0 || mfRect.Height == 0)
+                            continue;
+
+                        // Skip if this sub-area was already processed
+                        var subAreaKey = (parentRect, subRect);
+
+                        if (!_processedSubAreas.Add(subAreaKey))
+                            continue;
 
                         float relX0 = (subRect.X0 - mfRect.X0) / mfRect.Width;
                         float relY0 = (subRect.Y0 - mfRect.Y0) / mfRect.Height;
@@ -1336,11 +1339,7 @@ namespace TombLib.LevelData.Compilers
 
                         foreach (var frame in origSet.Frames)
                         {
-                            var frameRect = new Rectangle2(
-                                MathF.Min(frame.TexCoord0.X, MathF.Min(frame.TexCoord1.X, MathF.Min(frame.TexCoord2.X, frame.TexCoord3.X))),
-                                MathF.Min(frame.TexCoord0.Y, MathF.Min(frame.TexCoord1.Y, MathF.Min(frame.TexCoord2.Y, frame.TexCoord3.Y))),
-                                MathF.Max(frame.TexCoord0.X, MathF.Max(frame.TexCoord1.X, MathF.Max(frame.TexCoord2.X, frame.TexCoord3.X))),
-                                MathF.Max(frame.TexCoord0.Y, MathF.Max(frame.TexCoord1.Y, MathF.Max(frame.TexCoord2.Y, frame.TexCoord3.Y))));
+                            var frameRect = Rectangle2.FromCoordinates(frame.TexCoord0, frame.TexCoord1, frame.TexCoord2, frame.TexCoord3);
 
                             float fw = frameRect.Width;
                             float fh = frameRect.Height;

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
@@ -74,7 +74,6 @@ namespace TombLib.LevelData.Compilers
         private List<ParentAnimatedTexture> _referenceAnimTextures = new List<ParentAnimatedTexture>();
         private List<ParentAnimatedTexture> _actualAnimTextures = new List<ParentAnimatedTexture>();
 
-        private record SubAreaKey(Texture Texture, TextureDestination Destination, Rectangle2 ParentRect, Rectangle2 SubRect);
         private HashSet<SubAreaKey> _processedSubAreas = new HashSet<SubAreaKey>();
 
         // UVRotate count should be placed after anim texture data to identify how many first anim seqs
@@ -1260,9 +1259,6 @@ namespace TombLib.LevelData.Compilers
                     {
                         GenerateAnimTexture(refTex, refQuad, destination, isForTriangle);
                         var result = AddTexture(texture, destination, isForTriangle, blendMode);
-                        {
-                            result.Animated = true;
-                        }
                         return new Result() { ConvertToQuad = false, Rotation = result.Rotation, TexInfoIndex = result.TexInfoIndex, Animated = true };
                     }
                 }
@@ -1273,12 +1269,7 @@ namespace TombLib.LevelData.Compilers
             if (!texture.ParentArea.IsZero && _referenceAnimTextures.Count > 0 &&
                 texture.ParentArea != texture.GetRect(isForTriangle))
             {
-                TextureArea fullTexture = texture;
-                fullTexture.TexCoord0 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y0);
-                fullTexture.TexCoord1 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y1);
-                fullTexture.TexCoord2 = new Vector2(texture.ParentArea.X1, texture.ParentArea.Y1);
-                fullTexture.TexCoord3 = new Vector2(texture.ParentArea.X1, texture.ParentArea.Y0);
-                fullTexture.ParentArea = Rectangle2.Zero;
+                TextureArea fullTexture = AnimatedTextureLookupUtility.CreateFullParentAreaTexture(texture);
 
                 foreach (var refTex in _referenceAnimTextures)
                 {
@@ -1295,64 +1286,12 @@ namespace TombLib.LevelData.Compilers
                         var parentRect = texture.ParentArea;
                         var subRect = texture.GetRect(isForTriangle);
 
-                        // Find which frame in the set matches our ParentArea
-                        AnimatedTextureFrame matchedFrame = null;
-
-                        foreach (var frame in origSet.Frames)
-                        {
-                            if (frame.Texture != texture.Texture)
-                                continue;
-
-                            var fRect = Rectangle2.FromCoordinates(frame.TexCoord0, frame.TexCoord1, frame.TexCoord2, frame.TexCoord3);
-
-                            if (MathC.WithinEpsilon(fRect.X0, parentRect.X0, _animTextureLookupMargin) &&
-                                MathC.WithinEpsilon(fRect.Y0, parentRect.Y0, _animTextureLookupMargin) &&
-                                MathC.WithinEpsilon(fRect.X1, parentRect.X1, _animTextureLookupMargin) &&
-                                MathC.WithinEpsilon(fRect.Y1, parentRect.Y1, _animTextureLookupMargin))
-                            {
-                                matchedFrame = frame;
-                                break;
-                            }
-                        }
-
-                        if (matchedFrame == null)
-                            continue;
-
-                        // Calculate relative sub-area position within the matched frame
-                        var mfRect = Rectangle2.FromCoordinates(matchedFrame.TexCoord0, matchedFrame.TexCoord1, matchedFrame.TexCoord2, matchedFrame.TexCoord3);
-
-                        // Skip degenerate frames with zero-sized extents to avoid NaN/Infinity
-                        if (mfRect.Width == 0 || mfRect.Height == 0)
-                            continue;
-
                         // Skip if this sub-area was already processed for this texture and destination
-                        if (!_processedSubAreas.Add(new SubAreaKey(texture.Texture, destination, parentRect, subRect)))
+                        if (!_processedSubAreas.Add(new SubAreaKey(texture.Texture, destination, parentRect, subRect, _animTextureLookupMargin)))
                             continue;
 
-                        float relX0 = (subRect.X0 - mfRect.X0) / mfRect.Width;
-                        float relY0 = (subRect.Y0 - mfRect.Y0) / mfRect.Height;
-                        float relX1 = (subRect.X1 - mfRect.X0) / mfRect.Width;
-                        float relY1 = (subRect.Y1 - mfRect.Y0) / mfRect.Height;
-
-                        // Create a synthetic AnimatedTextureSet with sub-area frames
-                        var subSet = origSet.Clone();
-                        subSet.Frames.Clear();
-
-                        foreach (var frame in origSet.Frames)
-                        {
-                            var frameRect = Rectangle2.FromCoordinates(frame.TexCoord0, frame.TexCoord1, frame.TexCoord2, frame.TexCoord3);
-
-                            float fw = frameRect.Width;
-                            float fh = frameRect.Height;
-
-                            var subFrame = frame.Clone();
-                            subFrame.TexCoord0 = new Vector2(frameRect.X0 + relX0 * fw, frameRect.Y0 + relY0 * fh);
-                            subFrame.TexCoord1 = new Vector2(frameRect.X0 + relX0 * fw, frameRect.Y0 + relY1 * fh);
-                            subFrame.TexCoord2 = new Vector2(frameRect.X0 + relX1 * fw, frameRect.Y0 + relY1 * fh);
-                            subFrame.TexCoord3 = new Vector2(frameRect.X0 + relX1 * fw, frameRect.Y0 + relY0 * fh);
-
-                            subSet.Frames.Add(subFrame);
-                        }
+                        if (!AnimatedTextureLookupUtility.TryCreateSubAreaAnimationSet(origSet, texture, parentRect, subRect, _animTextureLookupMargin, out var subSet))
+                            continue;
 
                         // Generate reference lookups for this sub-area animation set
                         GenerateAnimLookups(new List<AnimatedTextureSet> { subSet }, destination);

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
@@ -1296,8 +1296,9 @@ namespace TombLib.LevelData.Compilers
                         if (!AnimatedTextureLookupUtility.TryCreateSubAreaAnimationSet(origSet, texture, parentRect, subRect, _animTextureLookupMargin, out var subSet))
                             continue;
 
-                        // Generate reference lookups for this sub-area animation set
-                        GenerateAnimLookups(new List<AnimatedTextureSet> { subSet }, destination);
+                        // Generate reference lookups for this sub-area animation set while preserving
+                        // the original animated set identity for downstream metadata consumers.
+                        GenerateAnimLookups(new List<AnimatedTextureSet> { subSet }, destination, origSet);
 
                         // Retry - the sub-area coordinates should now match the new reference lookups
                         return AddTexture(texture, destination, isForTriangle, blendMode);
@@ -1379,7 +1380,7 @@ namespace TombLib.LevelData.Compilers
 
         // Generates list of dummy lookup animated textures.
 
-        private void GenerateAnimLookups(List<AnimatedTextureSet> sets, TextureDestination destination)
+        private void GenerateAnimLookups(List<AnimatedTextureSet> sets, TextureDestination destination, AnimatedTextureSet exportOriginOverride = null)
         {
             foreach (var set in sets)
             {
@@ -1398,7 +1399,7 @@ namespace TombLib.LevelData.Compilers
 
                 while (true)
                 {
-                    var refAnim = new ParentAnimatedTexture(set);
+                    var refAnim = new ParentAnimatedTexture(exportOriginOverride ?? set);
                     int index = 0;
 
                     foreach (var frame in set.Frames)

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
@@ -1264,6 +1264,107 @@ namespace TombLib.LevelData.Compilers
                     }
                 }
 
+            // Check if this is a sub-area of an animated texture (e.g. applied via group texturing tools).
+            // In this case, the actual UV coordinates represent a portion of the full animation frame,
+            // so we reconstruct the full frame from ParentArea and match against reference animations.
+            if (!texture.ParentArea.IsZero && _referenceAnimTextures.Count > 0)
+            {
+                TextureArea fullTexture = texture;
+                fullTexture.TexCoord0 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y0);
+                fullTexture.TexCoord1 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y1);
+                fullTexture.TexCoord2 = new Vector2(texture.ParentArea.X1, texture.ParentArea.Y1);
+                fullTexture.TexCoord3 = new Vector2(texture.ParentArea.X1, texture.ParentArea.Y0);
+                fullTexture.ParentArea = Rectangle2.Zero;
+
+                foreach (var refTex in _referenceAnimTextures)
+                {
+                    // UVRotate and Video animation types are incompatible with sub-area splitting
+                    // because they rely on specific frame arrangement assumptions (vertical strip scrolling
+                    // for UVRotate, sequential frame playback for Video) that break when coordinates
+                    // are transformed to sub-areas.
+                    if (refTex.Origin.IsUvRotate || refTex.Origin.AnimationType == AnimatedTextureAnimationType.Video)
+                        continue;
+
+                    if (GetTexInfo(fullTexture, refTex.CompiledAnimation, destination, false, blendMode, false, _animTextureLookupMargin).HasValue)
+                    {
+                        var origSet = refTex.Origin;
+                        var parentRect = texture.ParentArea;
+                        var subRect = texture.GetRect(isForTriangle);
+
+                        // Find which frame in the set matches our ParentArea
+                        AnimatedTextureFrame matchedFrame = null;
+
+                        foreach (var frame in origSet.Frames)
+                        {
+                            if (frame.Texture != texture.Texture)
+                                continue;
+
+                            var fRect = new Rectangle2(
+                                MathF.Min(frame.TexCoord0.X, MathF.Min(frame.TexCoord1.X, MathF.Min(frame.TexCoord2.X, frame.TexCoord3.X))),
+                                MathF.Min(frame.TexCoord0.Y, MathF.Min(frame.TexCoord1.Y, MathF.Min(frame.TexCoord2.Y, frame.TexCoord3.Y))),
+                                MathF.Max(frame.TexCoord0.X, MathF.Max(frame.TexCoord1.X, MathF.Max(frame.TexCoord2.X, frame.TexCoord3.X))),
+                                MathF.Max(frame.TexCoord0.Y, MathF.Max(frame.TexCoord1.Y, MathF.Max(frame.TexCoord2.Y, frame.TexCoord3.Y))));
+
+                            if (MathC.WithinEpsilon(fRect.X0, parentRect.X0, _animTextureLookupMargin) &&
+                                MathC.WithinEpsilon(fRect.Y0, parentRect.Y0, _animTextureLookupMargin) &&
+                                MathC.WithinEpsilon(fRect.X1, parentRect.X1, _animTextureLookupMargin) &&
+                                MathC.WithinEpsilon(fRect.Y1, parentRect.Y1, _animTextureLookupMargin))
+                            {
+                                matchedFrame = frame;
+                                break;
+                            }
+                        }
+
+                        if (matchedFrame == null)
+                            continue;
+
+                        // Calculate relative sub-area position within the matched frame
+                        var mfRect = new Rectangle2(
+                            MathF.Min(matchedFrame.TexCoord0.X, MathF.Min(matchedFrame.TexCoord1.X, MathF.Min(matchedFrame.TexCoord2.X, matchedFrame.TexCoord3.X))),
+                            MathF.Min(matchedFrame.TexCoord0.Y, MathF.Min(matchedFrame.TexCoord1.Y, MathF.Min(matchedFrame.TexCoord2.Y, matchedFrame.TexCoord3.Y))),
+                            MathF.Max(matchedFrame.TexCoord0.X, MathF.Max(matchedFrame.TexCoord1.X, MathF.Max(matchedFrame.TexCoord2.X, matchedFrame.TexCoord3.X))),
+                            MathF.Max(matchedFrame.TexCoord0.Y, MathF.Max(matchedFrame.TexCoord1.Y, MathF.Max(matchedFrame.TexCoord2.Y, matchedFrame.TexCoord3.Y))));
+
+                        float relX0 = (subRect.X0 - mfRect.X0) / mfRect.Width;
+                        float relY0 = (subRect.Y0 - mfRect.Y0) / mfRect.Height;
+                        float relX1 = (subRect.X1 - mfRect.X0) / mfRect.Width;
+                        float relY1 = (subRect.Y1 - mfRect.Y0) / mfRect.Height;
+
+                        // Create a synthetic AnimatedTextureSet with sub-area frames
+                        var subSet = origSet.Clone();
+                        subSet.Frames.Clear();
+
+                        foreach (var frame in origSet.Frames)
+                        {
+                            var frameRect = new Rectangle2(
+                                MathF.Min(frame.TexCoord0.X, MathF.Min(frame.TexCoord1.X, MathF.Min(frame.TexCoord2.X, frame.TexCoord3.X))),
+                                MathF.Min(frame.TexCoord0.Y, MathF.Min(frame.TexCoord1.Y, MathF.Min(frame.TexCoord2.Y, frame.TexCoord3.Y))),
+                                MathF.Max(frame.TexCoord0.X, MathF.Max(frame.TexCoord1.X, MathF.Max(frame.TexCoord2.X, frame.TexCoord3.X))),
+                                MathF.Max(frame.TexCoord0.Y, MathF.Max(frame.TexCoord1.Y, MathF.Max(frame.TexCoord2.Y, frame.TexCoord3.Y))));
+
+                            float fw = frameRect.Width;
+                            float fh = frameRect.Height;
+
+                            var subFrame = frame.Clone();
+                            subFrame.TexCoord0 = new Vector2(frameRect.X0 + relX0 * fw, frameRect.Y0 + relY0 * fh);
+                            subFrame.TexCoord1 = new Vector2(frameRect.X0 + relX0 * fw, frameRect.Y0 + relY1 * fh);
+                            subFrame.TexCoord2 = new Vector2(frameRect.X0 + relX1 * fw, frameRect.Y0 + relY1 * fh);
+                            subFrame.TexCoord3 = new Vector2(frameRect.X0 + relX1 * fw, frameRect.Y0 + relY0 * fh);
+
+                            subSet.Frames.Add(subFrame);
+                        }
+
+                        // Generate reference lookups for this sub-area animation set
+                        GenerateAnimLookups(new List<AnimatedTextureSet> { subSet }, destination);
+
+                        // Retry - the sub-area coordinates should now match the new reference lookups
+                        var result = AddTexture(texture, destination, isForTriangle, blendMode);
+                        result.Animated = true;
+                        return result;
+                    }
+                }
+            }
+
             var parentTextures = _parentRoomTextureAreas;
             if (destination == TextureDestination.Moveable)
                 parentTextures = _parentMoveableTextureAreas;

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs
@@ -1211,13 +1211,61 @@ namespace TombLib.LevelData.Compilers
 		}
 
 
-		// Generate new parent with incoming texture and immediately add incoming texture as a child
+        // Generate new parent with incoming texture and immediately add incoming texture as a child
 
-		private void AddParent(TextureArea texture, List<ParentTextureArea> parentList, TextureDestination destination, bool isForTriangle, BlendMode blendMode, int frameIndex = -1)
+        private void AddParent(TextureArea texture, List<ParentTextureArea> parentList, TextureDestination destination, bool isForTriangle, BlendMode blendMode, int frameIndex = -1)
         {
             var newParent = new ParentTextureArea(texture, destination);
             parentList.Add(newParent);
             newParent.AddChild(texture, frameIndex >= 0 ? frameIndex : GetNewTextureId(), isForTriangle, blendMode);
+        }
+
+        private Result? TryAddSubAreaAnimatedTexture(TextureArea texture, TextureDestination destination, bool isForTriangle, BlendMode blendMode)
+        {
+            // Check if this is a sub-area of an animated texture (e.g. applied via group texturing tools).
+            // In this case, the actual UV coordinates represent a portion of the full animation frame,
+            // so we reconstruct the full frame from ParentArea and match against reference animations.
+            if (texture.ParentArea.IsZero || _referenceAnimTextures.Count == 0 ||
+                texture.ParentArea == texture.GetRect(isForTriangle))
+                return null;
+
+            TextureArea fullTexture = AnimatedTextureLookupUtility.CreateFullParentAreaTexture(texture);
+            int initialReferenceAnimTextureCount = _referenceAnimTextures.Count;
+
+            for (int i = 0; i < initialReferenceAnimTextureCount; i++)
+            {
+                var refTex = _referenceAnimTextures[i];
+
+                // UVRotate and Video animation types are incompatible with sub-area splitting
+                // because they rely on specific frame arrangement assumptions (vertical strip scrolling
+                // for UVRotate, sequential frame playback for Video) that break when coordinates
+                // are transformed to sub-areas.
+                if (refTex.Origin.IsUvRotate || refTex.Origin.AnimationType == AnimatedTextureAnimationType.Video)
+                    continue;
+
+                if (!GetTexInfo(fullTexture, refTex.CompiledAnimation, destination, false, blendMode, false, _animTextureLookupMargin).HasValue)
+                    continue;
+
+                var origSet = refTex.Origin;
+                var parentRect = texture.ParentArea;
+                var subRect = texture.GetRect(isForTriangle);
+
+                // Skip if this sub-area was already processed for this texture and destination
+                if (!_processedSubAreas.Add(new SubAreaKey(texture.Texture, destination, parentRect, subRect, _animTextureLookupMargin)))
+                    continue;
+
+                if (!AnimatedTextureLookupUtility.TryCreateSubAreaAnimationSet(origSet, texture, parentRect, subRect, _animTextureLookupMargin, out var subSet))
+                    continue;
+
+                // Generate reference lookups for this sub-area animation set while preserving
+                // the original animated set identity for downstream metadata consumers.
+                GenerateAnimLookups(new List<AnimatedTextureSet> { subSet }, destination, origSet);
+
+                // Retry - the sub-area coordinates should now match the new reference lookups
+                return AddTexture(texture, destination, isForTriangle, blendMode);
+            }
+
+            return null;
         }
 
         // Only exposed variation of AddTexture that should be used outside of TexInfoManager itself
@@ -1263,48 +1311,9 @@ namespace TombLib.LevelData.Compilers
                     }
                 }
 
-            // Check if this is a sub-area of an animated texture (e.g. applied via group texturing tools).
-            // In this case, the actual UV coordinates represent a portion of the full animation frame,
-            // so we reconstruct the full frame from ParentArea and match against reference animations.
-            if (!texture.ParentArea.IsZero && _referenceAnimTextures.Count > 0 &&
-                texture.ParentArea != texture.GetRect(isForTriangle))
-            {
-                TextureArea fullTexture = AnimatedTextureLookupUtility.CreateFullParentAreaTexture(texture);
-                int initialReferenceAnimTextureCount = _referenceAnimTextures.Count;
-
-                for (int i = 0; i < initialReferenceAnimTextureCount; i++)
-                {
-                    var refTex = _referenceAnimTextures[i];
-
-                    // UVRotate and Video animation types are incompatible with sub-area splitting
-                    // because they rely on specific frame arrangement assumptions (vertical strip scrolling
-                    // for UVRotate, sequential frame playback for Video) that break when coordinates
-                    // are transformed to sub-areas.
-                    if (refTex.Origin.IsUvRotate || refTex.Origin.AnimationType == AnimatedTextureAnimationType.Video)
-                        continue;
-
-                    if (GetTexInfo(fullTexture, refTex.CompiledAnimation, destination, false, blendMode, false, _animTextureLookupMargin).HasValue)
-                    {
-                        var origSet = refTex.Origin;
-                        var parentRect = texture.ParentArea;
-                        var subRect = texture.GetRect(isForTriangle);
-
-                        // Skip if this sub-area was already processed for this texture and destination
-                        if (!_processedSubAreas.Add(new SubAreaKey(texture.Texture, destination, parentRect, subRect, _animTextureLookupMargin)))
-                            continue;
-
-                        if (!AnimatedTextureLookupUtility.TryCreateSubAreaAnimationSet(origSet, texture, parentRect, subRect, _animTextureLookupMargin, out var subSet))
-                            continue;
-
-                        // Generate reference lookups for this sub-area animation set while preserving
-                        // the original animated set identity for downstream metadata consumers.
-                        GenerateAnimLookups(new List<AnimatedTextureSet> { subSet }, destination, origSet);
-
-                        // Retry - the sub-area coordinates should now match the new reference lookups
-                        return AddTexture(texture, destination, isForTriangle, blendMode);
-                    }
-                }
-            }
+            var subAreaResult = TryAddSubAreaAnimatedTexture(texture, destination, isForTriangle, blendMode);
+            if (subAreaResult.HasValue)
+                return subAreaResult.Value;
 
             var parentTextures = _parentRoomTextureAreas;
             if (destination == TextureDestination.Moveable)

--- a/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
@@ -52,6 +52,7 @@ namespace TombLib.LevelData.Compilers.Util
 
         private List<ParentAnimatedTexture> _referenceAnimTextures = new List<ParentAnimatedTexture>();
         private List<ParentAnimatedTexture> _actualAnimTextures = new List<ParentAnimatedTexture>();
+        private HashSet<(Rectangle2 parentRect, Rectangle2 subRect)> _processedSubAreas = new HashSet<(Rectangle2, Rectangle2)>();
 
         // UVRotate count should be placed after anim texture data to identify how many first anim seqs
         // should be processed using UVRotate engine function
@@ -865,11 +866,7 @@ namespace TombLib.LevelData.Compilers.Util
                             if (frame.Texture != texture.Texture)
                                 continue;
 
-                            var fRect = new Rectangle2(
-                                MathF.Min(frame.TexCoord0.X, MathF.Min(frame.TexCoord1.X, MathF.Min(frame.TexCoord2.X, frame.TexCoord3.X))),
-                                MathF.Min(frame.TexCoord0.Y, MathF.Min(frame.TexCoord1.Y, MathF.Min(frame.TexCoord2.Y, frame.TexCoord3.Y))),
-                                MathF.Max(frame.TexCoord0.X, MathF.Max(frame.TexCoord1.X, MathF.Max(frame.TexCoord2.X, frame.TexCoord3.X))),
-                                MathF.Max(frame.TexCoord0.Y, MathF.Max(frame.TexCoord1.Y, MathF.Max(frame.TexCoord2.Y, frame.TexCoord3.Y))));
+                            var fRect = Rectangle2.FromCoordinates(frame.TexCoord0, frame.TexCoord1, frame.TexCoord2, frame.TexCoord3);
 
                             if (MathC.WithinEpsilon(fRect.X0, parentRect.X0, _animTextureLookupMargin) &&
                                 MathC.WithinEpsilon(fRect.Y0, parentRect.Y0, _animTextureLookupMargin) &&
@@ -885,11 +882,17 @@ namespace TombLib.LevelData.Compilers.Util
                             continue;
 
                         // Calculate relative sub-area position within the matched frame
-                        var mfRect = new Rectangle2(
-                            MathF.Min(matchedFrame.TexCoord0.X, MathF.Min(matchedFrame.TexCoord1.X, MathF.Min(matchedFrame.TexCoord2.X, matchedFrame.TexCoord3.X))),
-                            MathF.Min(matchedFrame.TexCoord0.Y, MathF.Min(matchedFrame.TexCoord1.Y, MathF.Min(matchedFrame.TexCoord2.Y, matchedFrame.TexCoord3.Y))),
-                            MathF.Max(matchedFrame.TexCoord0.X, MathF.Max(matchedFrame.TexCoord1.X, MathF.Max(matchedFrame.TexCoord2.X, matchedFrame.TexCoord3.X))),
-                            MathF.Max(matchedFrame.TexCoord0.Y, MathF.Max(matchedFrame.TexCoord1.Y, MathF.Max(matchedFrame.TexCoord2.Y, matchedFrame.TexCoord3.Y))));
+                        var mfRect = Rectangle2.FromCoordinates(matchedFrame.TexCoord0, matchedFrame.TexCoord1, matchedFrame.TexCoord2, matchedFrame.TexCoord3);
+
+                        // Skip degenerate frames with zero-sized extents to avoid NaN/Infinity
+                        if (mfRect.Width == 0 || mfRect.Height == 0)
+                            continue;
+
+                        // Skip if this sub-area was already processed
+                        var subAreaKey = (parentRect, subRect);
+
+                        if (!_processedSubAreas.Add(subAreaKey))
+                            continue;
 
                         float relX0 = (subRect.X0 - mfRect.X0) / mfRect.Width;
                         float relY0 = (subRect.Y0 - mfRect.Y0) / mfRect.Height;
@@ -902,11 +905,7 @@ namespace TombLib.LevelData.Compilers.Util
 
                         foreach (var frame in origSet.Frames)
                         {
-                            var frameRect = new Rectangle2(
-                                MathF.Min(frame.TexCoord0.X, MathF.Min(frame.TexCoord1.X, MathF.Min(frame.TexCoord2.X, frame.TexCoord3.X))),
-                                MathF.Min(frame.TexCoord0.Y, MathF.Min(frame.TexCoord1.Y, MathF.Min(frame.TexCoord2.Y, frame.TexCoord3.Y))),
-                                MathF.Max(frame.TexCoord0.X, MathF.Max(frame.TexCoord1.X, MathF.Max(frame.TexCoord2.X, frame.TexCoord3.X))),
-                                MathF.Max(frame.TexCoord0.Y, MathF.Max(frame.TexCoord1.Y, MathF.Max(frame.TexCoord2.Y, frame.TexCoord3.Y))));
+                            var frameRect = Rectangle2.FromCoordinates(frame.TexCoord0, frame.TexCoord1, frame.TexCoord2, frame.TexCoord3);
 
                             float fw = frameRect.Width;
                             float fh = frameRect.Height;

--- a/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
@@ -830,6 +830,105 @@ namespace TombLib.LevelData.Compilers.Util
                     }
                 }
 
+            // Check if this is a sub-area of an animated texture (e.g. applied via group texturing tools).
+            // In this case, the actual UV coordinates represent a portion of the full animation frame,
+            // so we reconstruct the full frame from ParentArea and match against reference animations.
+            if (!texture.ParentArea.IsZero && _referenceAnimTextures.Count > 0)
+            {
+                TextureArea fullTexture = texture;
+                fullTexture.TexCoord0 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y0);
+                fullTexture.TexCoord1 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y1);
+                fullTexture.TexCoord2 = new Vector2(texture.ParentArea.X1, texture.ParentArea.Y1);
+                fullTexture.TexCoord3 = new Vector2(texture.ParentArea.X1, texture.ParentArea.Y0);
+                fullTexture.ParentArea = Rectangle2.Zero;
+
+                foreach (var refTex in _referenceAnimTextures)
+                {
+                    // UVRotate and Video animation types are incompatible with sub-area splitting
+                    // because they rely on specific frame arrangement assumptions (vertical strip scrolling
+                    // for UVRotate, sequential frame playback for Video) that break when coordinates
+                    // are transformed to sub-areas.
+                    if (refTex.Origin.IsUvRotate || refTex.Origin.AnimationType == AnimatedTextureAnimationType.Video)
+                        continue;
+
+                    if (GetTexInfo(fullTexture, refTex.CompiledAnimation, isForRoom, false, false, false, remapAnimatedTextures, _animTextureLookupMargin).HasValue)
+                    {
+                        var origSet = refTex.Origin;
+                        var parentRect = texture.ParentArea;
+                        var subRect = texture.GetRect(isForTriangle);
+
+                        // Find which frame in the set matches our ParentArea
+                        AnimatedTextureFrame matchedFrame = null;
+
+                        foreach (var frame in origSet.Frames)
+                        {
+                            if (frame.Texture != texture.Texture)
+                                continue;
+
+                            var fRect = new Rectangle2(
+                                MathF.Min(frame.TexCoord0.X, MathF.Min(frame.TexCoord1.X, MathF.Min(frame.TexCoord2.X, frame.TexCoord3.X))),
+                                MathF.Min(frame.TexCoord0.Y, MathF.Min(frame.TexCoord1.Y, MathF.Min(frame.TexCoord2.Y, frame.TexCoord3.Y))),
+                                MathF.Max(frame.TexCoord0.X, MathF.Max(frame.TexCoord1.X, MathF.Max(frame.TexCoord2.X, frame.TexCoord3.X))),
+                                MathF.Max(frame.TexCoord0.Y, MathF.Max(frame.TexCoord1.Y, MathF.Max(frame.TexCoord2.Y, frame.TexCoord3.Y))));
+
+                            if (MathC.WithinEpsilon(fRect.X0, parentRect.X0, _animTextureLookupMargin) &&
+                                MathC.WithinEpsilon(fRect.Y0, parentRect.Y0, _animTextureLookupMargin) &&
+                                MathC.WithinEpsilon(fRect.X1, parentRect.X1, _animTextureLookupMargin) &&
+                                MathC.WithinEpsilon(fRect.Y1, parentRect.Y1, _animTextureLookupMargin))
+                            {
+                                matchedFrame = frame;
+                                break;
+                            }
+                        }
+
+                        if (matchedFrame == null)
+                            continue;
+
+                        // Calculate relative sub-area position within the matched frame
+                        var mfRect = new Rectangle2(
+                            MathF.Min(matchedFrame.TexCoord0.X, MathF.Min(matchedFrame.TexCoord1.X, MathF.Min(matchedFrame.TexCoord2.X, matchedFrame.TexCoord3.X))),
+                            MathF.Min(matchedFrame.TexCoord0.Y, MathF.Min(matchedFrame.TexCoord1.Y, MathF.Min(matchedFrame.TexCoord2.Y, matchedFrame.TexCoord3.Y))),
+                            MathF.Max(matchedFrame.TexCoord0.X, MathF.Max(matchedFrame.TexCoord1.X, MathF.Max(matchedFrame.TexCoord2.X, matchedFrame.TexCoord3.X))),
+                            MathF.Max(matchedFrame.TexCoord0.Y, MathF.Max(matchedFrame.TexCoord1.Y, MathF.Max(matchedFrame.TexCoord2.Y, matchedFrame.TexCoord3.Y))));
+
+                        float relX0 = (subRect.X0 - mfRect.X0) / mfRect.Width;
+                        float relY0 = (subRect.Y0 - mfRect.Y0) / mfRect.Height;
+                        float relX1 = (subRect.X1 - mfRect.X0) / mfRect.Width;
+                        float relY1 = (subRect.Y1 - mfRect.Y0) / mfRect.Height;
+
+                        // Create a synthetic AnimatedTextureSet with sub-area frames
+                        var subSet = origSet.Clone();
+                        subSet.Frames.Clear();
+
+                        foreach (var frame in origSet.Frames)
+                        {
+                            var frameRect = new Rectangle2(
+                                MathF.Min(frame.TexCoord0.X, MathF.Min(frame.TexCoord1.X, MathF.Min(frame.TexCoord2.X, frame.TexCoord3.X))),
+                                MathF.Min(frame.TexCoord0.Y, MathF.Min(frame.TexCoord1.Y, MathF.Min(frame.TexCoord2.Y, frame.TexCoord3.Y))),
+                                MathF.Max(frame.TexCoord0.X, MathF.Max(frame.TexCoord1.X, MathF.Max(frame.TexCoord2.X, frame.TexCoord3.X))),
+                                MathF.Max(frame.TexCoord0.Y, MathF.Max(frame.TexCoord1.Y, MathF.Max(frame.TexCoord2.Y, frame.TexCoord3.Y))));
+
+                            float fw = frameRect.Width;
+                            float fh = frameRect.Height;
+
+                            var subFrame = frame.Clone();
+                            subFrame.TexCoord0 = new Vector2(frameRect.X0 + relX0 * fw, frameRect.Y0 + relY0 * fh);
+                            subFrame.TexCoord1 = new Vector2(frameRect.X0 + relX0 * fw, frameRect.Y0 + relY1 * fh);
+                            subFrame.TexCoord2 = new Vector2(frameRect.X0 + relX1 * fw, frameRect.Y0 + relY1 * fh);
+                            subFrame.TexCoord3 = new Vector2(frameRect.X0 + relX1 * fw, frameRect.Y0 + relY0 * fh);
+
+                            subSet.Frames.Add(subFrame);
+                        }
+
+                        // Generate reference lookups for this sub-area animation set
+                        GenerateAnimLookups(new List<AnimatedTextureSet> { subSet });
+
+                        // Retry - the sub-area coordinates should now match the new reference lookups
+                        return AddTexture(texture, isForRoom, isForTriangle, topmostAndUnpadded);
+                    }
+                }
+            }
+
             // No animated textures identified, add texture as ordinary one
             return AddTexture(texture, _parentTextures, isForRoom, isForTriangle, topmostAndUnpadded);
         }

--- a/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
@@ -52,7 +52,9 @@ namespace TombLib.LevelData.Compilers.Util
 
         private List<ParentAnimatedTexture> _referenceAnimTextures = new List<ParentAnimatedTexture>();
         private List<ParentAnimatedTexture> _actualAnimTextures = new List<ParentAnimatedTexture>();
-        private HashSet<(Rectangle2 parentRect, Rectangle2 subRect)> _processedSubAreas = new HashSet<(Rectangle2, Rectangle2)>();
+
+        private record SubAreaKey(Texture Texture, Rectangle2 ParentRect, Rectangle2 SubRect);
+        private HashSet<SubAreaKey> _processedSubAreas = new HashSet<SubAreaKey>();
 
         // UVRotate count should be placed after anim texture data to identify how many first anim seqs
         // should be processed using UVRotate engine function
@@ -834,7 +836,8 @@ namespace TombLib.LevelData.Compilers.Util
             // Check if this is a sub-area of an animated texture (e.g. applied via group texturing tools).
             // In this case, the actual UV coordinates represent a portion of the full animation frame,
             // so we reconstruct the full frame from ParentArea and match against reference animations.
-            if (!texture.ParentArea.IsZero && _referenceAnimTextures.Count > 0)
+            if (!texture.ParentArea.IsZero && _referenceAnimTextures.Count > 0 &&
+                texture.ParentArea != texture.GetRect(isForTriangle))
             {
                 TextureArea fullTexture = texture;
                 fullTexture.TexCoord0 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y0);
@@ -888,10 +891,8 @@ namespace TombLib.LevelData.Compilers.Util
                         if (mfRect.Width == 0 || mfRect.Height == 0)
                             continue;
 
-                        // Skip if this sub-area was already processed
-                        var subAreaKey = (parentRect, subRect);
-
-                        if (!_processedSubAreas.Add(subAreaKey))
+                        // Skip if this sub-area was already processed for this texture
+                        if (!_processedSubAreas.Add(new SubAreaKey(texture.Texture, parentRect, subRect)))
                             continue;
 
                         float relX0 = (subRect.X0 - mfRect.X0) / mfRect.Width;

--- a/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
 using TombLib.IO;
+using TombLib.LevelData.Compilers;
 using TombLib.Utils;
 using TombLib.Wad;
 
@@ -53,7 +54,6 @@ namespace TombLib.LevelData.Compilers.Util
         private List<ParentAnimatedTexture> _referenceAnimTextures = new List<ParentAnimatedTexture>();
         private List<ParentAnimatedTexture> _actualAnimTextures = new List<ParentAnimatedTexture>();
 
-        private record SubAreaKey(Texture Texture, Rectangle2 ParentRect, Rectangle2 SubRect);
         private HashSet<SubAreaKey> _processedSubAreas = new HashSet<SubAreaKey>();
 
         // UVRotate count should be placed after anim texture data to identify how many first anim seqs
@@ -571,7 +571,7 @@ namespace TombLib.LevelData.Compilers.Util
                 MaxTileSize = _minimumTileSize;
             }
 
-            GenerateAnimLookups(_level.Settings.AnimatedTextureSets);  // Generate anim texture lookup table
+            GenerateAnimLookups(_level.Settings.AnimatedTextureSets, true);  // Generate anim texture lookup table
             _generateTexInfos = true;    // Set manager ready state 
         }
 
@@ -839,12 +839,7 @@ namespace TombLib.LevelData.Compilers.Util
             if (!texture.ParentArea.IsZero && _referenceAnimTextures.Count > 0 &&
                 texture.ParentArea != texture.GetRect(isForTriangle))
             {
-                TextureArea fullTexture = texture;
-                fullTexture.TexCoord0 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y0);
-                fullTexture.TexCoord1 = new Vector2(texture.ParentArea.X0, texture.ParentArea.Y1);
-                fullTexture.TexCoord2 = new Vector2(texture.ParentArea.X1, texture.ParentArea.Y1);
-                fullTexture.TexCoord3 = new Vector2(texture.ParentArea.X1, texture.ParentArea.Y0);
-                fullTexture.ParentArea = Rectangle2.Zero;
+                TextureArea fullTexture = AnimatedTextureLookupUtility.CreateFullParentAreaTexture(texture);
 
                 foreach (var refTex in _referenceAnimTextures)
                 {
@@ -861,67 +856,15 @@ namespace TombLib.LevelData.Compilers.Util
                         var parentRect = texture.ParentArea;
                         var subRect = texture.GetRect(isForTriangle);
 
-                        // Find which frame in the set matches our ParentArea
-                        AnimatedTextureFrame matchedFrame = null;
-
-                        foreach (var frame in origSet.Frames)
-                        {
-                            if (frame.Texture != texture.Texture)
-                                continue;
-
-                            var fRect = Rectangle2.FromCoordinates(frame.TexCoord0, frame.TexCoord1, frame.TexCoord2, frame.TexCoord3);
-
-                            if (MathC.WithinEpsilon(fRect.X0, parentRect.X0, _animTextureLookupMargin) &&
-                                MathC.WithinEpsilon(fRect.Y0, parentRect.Y0, _animTextureLookupMargin) &&
-                                MathC.WithinEpsilon(fRect.X1, parentRect.X1, _animTextureLookupMargin) &&
-                                MathC.WithinEpsilon(fRect.Y1, parentRect.Y1, _animTextureLookupMargin))
-                            {
-                                matchedFrame = frame;
-                                break;
-                            }
-                        }
-
-                        if (matchedFrame == null)
-                            continue;
-
-                        // Calculate relative sub-area position within the matched frame
-                        var mfRect = Rectangle2.FromCoordinates(matchedFrame.TexCoord0, matchedFrame.TexCoord1, matchedFrame.TexCoord2, matchedFrame.TexCoord3);
-
-                        // Skip degenerate frames with zero-sized extents to avoid NaN/Infinity
-                        if (mfRect.Width == 0 || mfRect.Height == 0)
-                            continue;
-
                         // Skip if this sub-area was already processed for this texture
-                        if (!_processedSubAreas.Add(new SubAreaKey(texture.Texture, parentRect, subRect)))
+                        if (!_processedSubAreas.Add(new SubAreaKey(texture.Texture, isForRoom, parentRect, subRect, _animTextureLookupMargin)))
                             continue;
 
-                        float relX0 = (subRect.X0 - mfRect.X0) / mfRect.Width;
-                        float relY0 = (subRect.Y0 - mfRect.Y0) / mfRect.Height;
-                        float relX1 = (subRect.X1 - mfRect.X0) / mfRect.Width;
-                        float relY1 = (subRect.Y1 - mfRect.Y0) / mfRect.Height;
-
-                        // Create a synthetic AnimatedTextureSet with sub-area frames
-                        var subSet = origSet.Clone();
-                        subSet.Frames.Clear();
-
-                        foreach (var frame in origSet.Frames)
-                        {
-                            var frameRect = Rectangle2.FromCoordinates(frame.TexCoord0, frame.TexCoord1, frame.TexCoord2, frame.TexCoord3);
-
-                            float fw = frameRect.Width;
-                            float fh = frameRect.Height;
-
-                            var subFrame = frame.Clone();
-                            subFrame.TexCoord0 = new Vector2(frameRect.X0 + relX0 * fw, frameRect.Y0 + relY0 * fh);
-                            subFrame.TexCoord1 = new Vector2(frameRect.X0 + relX0 * fw, frameRect.Y0 + relY1 * fh);
-                            subFrame.TexCoord2 = new Vector2(frameRect.X0 + relX1 * fw, frameRect.Y0 + relY1 * fh);
-                            subFrame.TexCoord3 = new Vector2(frameRect.X0 + relX1 * fw, frameRect.Y0 + relY0 * fh);
-
-                            subSet.Frames.Add(subFrame);
-                        }
+                        if (!AnimatedTextureLookupUtility.TryCreateSubAreaAnimationSet(origSet, texture, parentRect, subRect, _animTextureLookupMargin, out var subSet))
+                            continue;
 
                         // Generate reference lookups for this sub-area animation set
-                        GenerateAnimLookups(new List<AnimatedTextureSet> { subSet });
+                        GenerateAnimLookups(new List<AnimatedTextureSet> { subSet }, isForRoom);
 
                         // Retry - the sub-area coordinates should now match the new reference lookups
                         return AddTexture(texture, isForRoom, isForTriangle, topmostAndUnpadded);
@@ -998,7 +941,7 @@ namespace TombLib.LevelData.Compilers.Util
 
         // Generates list of dummy lookup animated textures.
 
-        private void GenerateAnimLookups(List<AnimatedTextureSet> sets)
+        private void GenerateAnimLookups(List<AnimatedTextureSet> sets, bool isForRoom)
         {
             foreach (var set in sets)
             {
@@ -1065,7 +1008,7 @@ namespace TombLib.LevelData.Compilers.Util
                         // Make frame, including repeat versions
                         for (int i = 0; i < frame.Repeat; i++)
                         {
-                            AddTexture(newFrame, refAnim.CompiledAnimation, true, (triangleVariation > 0), set.AnimationType == AnimatedTextureAnimationType.UVRotate, index, set.IsUvRotate);
+                            AddTexture(newFrame, refAnim.CompiledAnimation, isForRoom, (triangleVariation > 0), set.AnimationType == AnimatedTextureAnimationType.UVRotate, index, set.IsUvRotate);
                             index++;
                         }
                     }

--- a/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
@@ -866,8 +866,9 @@ namespace TombLib.LevelData.Compilers.Util
                         if (!AnimatedTextureLookupUtility.TryCreateSubAreaAnimationSet(origSet, texture, parentRect, subRect, _animTextureLookupMargin, out var subSet))
                             continue;
 
-                        // Generate reference lookups for this sub-area animation set
-                        GenerateAnimLookups(new List<AnimatedTextureSet> { subSet }, isForRoom);
+                        // Generate reference lookups for this sub-area animation set while preserving
+                        // the original animated set identity for downstream exporters such as TRNG.
+                        GenerateAnimLookups(new List<AnimatedTextureSet> { subSet }, isForRoom, origSet);
 
                         // Retry - the sub-area coordinates should now match the new reference lookups
                         return AddTexture(texture, isForRoom, isForTriangle, topmostAndUnpadded);
@@ -944,7 +945,7 @@ namespace TombLib.LevelData.Compilers.Util
 
         // Generates list of dummy lookup animated textures.
 
-        private void GenerateAnimLookups(List<AnimatedTextureSet> sets, bool isForRoom)
+        private void GenerateAnimLookups(List<AnimatedTextureSet> sets, bool isForRoom, AnimatedTextureSet exportOriginOverride = null)
         {
             foreach (var set in sets)
             {
@@ -963,7 +964,7 @@ namespace TombLib.LevelData.Compilers.Util
 
                 while (true)
                 {
-                    var refAnim = new ParentAnimatedTexture(set);
+                    var refAnim = new ParentAnimatedTexture(exportOriginOverride ?? set);
                     int index = 0;
 
                     foreach (var frame in set.Frames)

--- a/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs
@@ -840,9 +840,12 @@ namespace TombLib.LevelData.Compilers.Util
                 texture.ParentArea != texture.GetRect(isForTriangle))
             {
                 TextureArea fullTexture = AnimatedTextureLookupUtility.CreateFullParentAreaTexture(texture);
+                int initialReferenceAnimTextureCount = _referenceAnimTextures.Count;
 
-                foreach (var refTex in _referenceAnimTextures)
+                for (int i = 0; i < initialReferenceAnimTextureCount; i++)
                 {
+                    var refTex = _referenceAnimTextures[i];
+
                     // UVRotate and Video animation types are incompatible with sub-area splitting
                     // because they rely on specific frame arrangement assumptions (vertical strip scrolling
                     // for UVRotate, sequential frame playback for Video) that break when coordinates


### PR DESCRIPTION
This pull request introduces robust support for animated texture sub-areas - enabling tools that apply textures to only a portion of an animated frame (such as group texturing) to work seamlessly. The changes include a new utility for matching and generating sub-area animation sets, cache key structures for deduplication, and integration with both the general and TombEngine-specific texture managers. Additionally, some redundant code related to resetting texture parent areas was removed.

**Animated texture sub-area support:**

* Added `AnimatedTextureLookupUtility` with methods for matching, quantizing, and generating sub-area animation sets, as well as a `SubAreaKey` struct for deduplicating sub-area lookups. (`TombLib/TombLib/LevelData/Compilers/AnimatedTextureLookupUtility.cs`)
* Integrated sub-area animated texture matching and lookup generation into both `TexInfoManager` and `TombEngineTexInfoManager`, including logic to handle only compatible animation types and prevent redundant processing via `_processedSubAreas`. (`TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs`, `TombLib/TombLib/LevelData/Compilers/TombEngine/TombEngineTexInfoManager.cs`) [[1]](diffhunk://#diff-de9a5765e42dfd86a8dc265951cb7d58cf2d7ebec3d3d8ff06f273e326474a2cR57-R58) [[2]](diffhunk://#diff-de9a5765e42dfd86a8dc265951cb7d58cf2d7ebec3d3d8ff06f273e326474a2cR836-R877) [[3]](diffhunk://#diff-de9a5765e42dfd86a8dc265951cb7d58cf2d7ebec3d3d8ff06f273e326474a2cL902-R947) [[4]](diffhunk://#diff-5418aab4a937ac6bcca0b7367178dc2acf0e08843ed33ba18d5a1b3b3637315aR77-R78) [[5]](diffhunk://#diff-5418aab4a937ac6bcca0b7367178dc2acf0e08843ed33ba18d5a1b3b3637315aR1262-L1263)
* Modified the animated lookup generation to accept a `isForRoom` parameter, ensuring correct scoping of generated lookups. (`TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs`) [[1]](diffhunk://#diff-de9a5765e42dfd86a8dc265951cb7d58cf2d7ebec3d3d8ff06f273e326474a2cL902-R947) [[2]](diffhunk://#diff-de9a5765e42dfd86a8dc265951cb7d58cf2d7ebec3d3d8ff06f273e326474a2cL571-R574)

**Code cleanup and bug fixes:**

* Removed unnecessary resetting of `texture.ParentArea` before applying textures, preventing accidental loss of parent area information needed for sub-area matching. (`TombEditor/EditorActions.cs`) [[1]](diffhunk://#diff-72602b2279ac96c1f53f7f0c96e059e4dee87d1a38497cddcd63655ea20b2066L1850-L1851) [[2]](diffhunk://#diff-72602b2279ac96c1f53f7f0c96e059e4dee87d1a38497cddcd63655ea20b2066L2282-L2283)

**Dependency management:**

* Added missing `using` directive for the new utility in `TexInfoManager`. (`TombLib/TombLib/LevelData/Compilers/Util/TexInfoManager.cs`)