### PR TITLE
Add TRX texture depth options

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -8,6 +8,7 @@ Tomb Editor:
  * Added support for quicksand rooms in TR1X and TR2X levels.
  * Added support for additive blending in TR1X and TR2X levels.
  * Added support for triangular geometry in TR1X and TR2X levels.
+ * Added a texture depth option (8/16/32-bit) for TR1X and TR2X levels.
  * Added support for no caustics room flag in TEN.
  * Fixed node parameter corruption after changing node background color.
 

--- a/TombEditor/Forms/FormLevelSettings.cs
+++ b/TombEditor/Forms/FormLevelSettings.cs
@@ -409,6 +409,12 @@ namespace TombEditor.Forms
             comboTr5Weather.Items.AddRange(Enum.GetValues(typeof(Tr5WeatherType)).Cast<object>().ToArray());
             comboLaraType.Items.AddRange(Enum.GetValues(typeof(Tr5LaraType)).Cast<object>().ToArray());
 
+            // Populate TRX lists
+            comboTrxTextureDepth.Items.AddRange(Enum.GetValues(typeof(TrxTextureBitDepth))
+                .Cast<TrxTextureBitDepth>()
+                .Select(t => GetDisplayName(t))
+                .ToArray());
+
             // Initialize options list
             tabbedContainer.LinkedControl = optionsList;
 
@@ -509,6 +515,7 @@ namespace TombEditor.Forms
             comboTr5Weather.Text = _levelSettings.Tr5WeatherType.ToString(); // Must also accept none enum values.
             comboLaraType.Text = _levelSettings.Tr5LaraType.ToString(); // Must also accept none enum values.
             tbLuaPath.Text = _levelSettings.TenLuaScriptFile;
+            comboTrxTextureDepth.Text = GetDisplayName(_levelSettings.TrxTextureBitDepth);
 
             fontTextureFilePathOptAuto.Checked = string.IsNullOrEmpty(_levelSettings.FontTextureFilePath);
             fontTextureFilePathOptCustom.Checked = !string.IsNullOrEmpty(_levelSettings.FontTextureFilePath);
@@ -721,6 +728,11 @@ namespace TombEditor.Forms
             panelFont.Enabled = currentVersionToCheck;
             panelSky.Enabled = currentVersionToCheck;
 
+            // TRX platform
+            currentVersionToCheck = _levelSettings.GameVersion.IsTRX();
+            panelTrxMisc.Visible = currentVersionToCheck;
+            cbDither16BitTextures.Enabled |= currentVersionToCheck;
+
             // MAIN.SFX options
             currentVersionToCheck = (_levelSettings.GameVersion.UsesMainSfx());
             lblCatalogsPrompt.Text = _catalogsPromptBase + (currentVersionToCheck ? _catalogsPromptMSFX : _catalogsPromptNew);
@@ -731,6 +743,28 @@ namespace TombEditor.Forms
             lblPathsPrompt.TextAlign = currentVersionToCheck ? ContentAlignment.MiddleCenter : ContentAlignment.TopLeft;
             lblPathsPrompt.AutoSize = !currentVersionToCheck;
             lblPathsPrompt.ForeColor = currentVersionToCheck ? Colors.DisabledText : Colors.LightText;
+        }
+
+        private static string GetDisplayName(TrxTextureBitDepth depth)
+        {
+            return depth switch
+            {
+                TrxTextureBitDepth.Bit8 => "8-bit",
+                TrxTextureBitDepth.Bit16 => "16-bit",
+                TrxTextureBitDepth.Bit32 => "32-bit",
+                _ => "Default",
+            };
+        }
+
+        private static TrxTextureBitDepth GetTrxTextureDepth(string name)
+        {
+            return name switch
+            {
+                "8-bit" => TrxTextureBitDepth.Bit8,
+                "16-bit" => TrxTextureBitDepth.Bit16,
+                "32-bit" => TrxTextureBitDepth.Bit32,
+                _ => TrxTextureBitDepth.Default,
+            };
         }
 
         private void FitPreview(Control form, Rectangle screenArea)
@@ -1332,6 +1366,15 @@ namespace TombEditor.Forms
             if (_levelSettings.Tr5WeatherType == weather)
                 return;
             _levelSettings.Tr5WeatherType = weather; // Must also check none enum values
+            UpdateDialog();
+        }
+
+        private void comboTrxTextureDepth_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var depth = GetTrxTextureDepth(comboTrxTextureDepth.Text);
+            if (_levelSettings.TrxTextureBitDepth == depth)
+                return;
+            _levelSettings.TrxTextureBitDepth = depth;
             UpdateDialog();
         }
 

--- a/TombEditor/Forms/FormLevelSettings.designer.cs
+++ b/TombEditor/Forms/FormLevelSettings.designer.cs
@@ -170,6 +170,10 @@
             this.panelTr5LaraType = new System.Windows.Forms.Panel();
             this.comboLaraType = new DarkUI.Controls.DarkComboBox();
             this.lblLaraType = new DarkUI.Controls.DarkLabel();
+            this.panelTrxMisc = new System.Windows.Forms.Panel();
+            this.comboTrxTextureDepth = new DarkUI.Controls.DarkComboBox();
+            this.lblTrxTextureDepth = new DarkUI.Controls.DarkLabel();
+            this.lblTrxMisc = new DarkUI.Controls.DarkLabel();
             this.panel6 = new System.Windows.Forms.Panel();
             this.levelFilePathBut = new DarkUI.Controls.DarkButton();
             this.darkLabel6 = new DarkUI.Controls.DarkLabel();
@@ -224,6 +228,7 @@
             this.tabMisc.SuspendLayout();
             this.panelTr5Weather.SuspendLayout();
             this.panelTr5LaraType.SuspendLayout();
+            this.panelTrxMisc.SuspendLayout();
             this.panel6.SuspendLayout();
             this.panel12.SuspendLayout();
             this.tabPaths.SuspendLayout();
@@ -1943,6 +1948,7 @@
             this.tabMisc.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.tabMisc.Controls.Add(this.panelTr5Weather);
             this.tabMisc.Controls.Add(this.panelTr5LaraType);
+            this.tabMisc.Controls.Add(this.panelTrxMisc);
             this.tabMisc.Controls.Add(this.panel6);
             this.tabMisc.Controls.Add(this.panel12);
             this.tabMisc.ForeColor = System.Drawing.SystemColors.ControlText;
@@ -2011,6 +2017,46 @@
             this.lblLaraType.Size = new System.Drawing.Size(439, 17);
             this.lblLaraType.TabIndex = 3;
             this.lblLaraType.Text = "TR5 Lara type:";
+            // 
+            // panelTrxMisc
+            // 
+            this.panelTrxMisc.Controls.Add(this.comboTrxTextureDepth);
+            this.panelTrxMisc.Controls.Add(this.lblTrxTextureDepth);
+            this.panelTrxMisc.Controls.Add(this.lblTrxMisc);
+            this.panelTrxMisc.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panelTrxMisc.Location = new System.Drawing.Point(0, 364);
+            this.panelTrxMisc.Name = "panelTrxMisc";
+            this.panelTrxMisc.Size = new System.Drawing.Size(778, 51);
+            this.panelTrxMisc.TabIndex = 150;
+            // 
+            // comboTrxTextureDepth
+            // 
+            this.comboTrxTextureDepth.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.comboTrxTextureDepth.FormattingEnabled = true;
+            this.comboTrxTextureDepth.Location = new System.Drawing.Point(129, 23);
+            this.comboTrxTextureDepth.Name = "comboTrxTextureDepth";
+            this.comboTrxTextureDepth.Size = new System.Drawing.Size(81, 23);
+            this.comboTrxTextureDepth.TabIndex = 4;
+            this.comboTrxTextureDepth.SelectedIndexChanged += new System.EventHandler(this.comboTrxTextureDepth_SelectedIndexChanged);
+            // 
+            // lblTrxTextureDepth
+            // 
+            this.lblTrxTextureDepth.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.lblTrxTextureDepth.Location = new System.Drawing.Point(0, 25);
+            this.lblTrxTextureDepth.Name = "lblTrxTextureDepth";
+            this.lblTrxTextureDepth.Size = new System.Drawing.Size(123, 17);
+            this.lblTrxTextureDepth.TabIndex = 3;
+            this.lblTrxTextureDepth.Text = "Texture depth:";
+            // 
+            // lblTrxMisc
+            // 
+            this.lblTrxMisc.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.lblTrxMisc.Location = new System.Drawing.Point(0, 3);
+            this.lblTrxMisc.Name = "lblTrxMisc";
+            this.lblTrxMisc.Size = new System.Drawing.Size(439, 17);
+            this.lblTrxMisc.TabIndex = 3;
+            this.lblTrxMisc.Text = "TRX:";
             // 
             // panel6
             // 
@@ -2304,6 +2350,7 @@
             this.tabMisc.ResumeLayout(false);
             this.panelTr5Weather.ResumeLayout(false);
             this.panelTr5LaraType.ResumeLayout(false);
+            this.panelTrxMisc.ResumeLayout(false);
             this.panel6.ResumeLayout(false);
             this.panel6.PerformLayout();
             this.panel12.ResumeLayout(false);
@@ -2393,6 +2440,10 @@
         private DarkUI.Controls.DarkTextBox levelFilePathTxt;
         private DarkUI.Controls.DarkDataGridView textureFileDataGridView;
         private DarkUI.Controls.DarkLabel darkLabel4;
+        private System.Windows.Forms.Panel panelTrxMisc;
+        private DarkUI.Controls.DarkComboBox comboTrxTextureDepth;
+        private DarkUI.Controls.DarkLabel lblTrxTextureDepth;
+        private DarkUI.Controls.DarkLabel lblTrxMisc;
         private TombLib.Controls.DarkDataGridViewControls textureFileDataGridViewControls;
         private System.Windows.Forms.DataGridViewTextBoxColumn objectFileDataGridViewPathColumn;
         private DarkUI.Controls.DarkDataGridViewButtonColumn objectFileDataGridViewSearchColumn;

--- a/TombLib/TombLib/LevelData/Compilers/Trx.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Trx.cs
@@ -30,6 +30,7 @@ public partial class LevelCompilerClassicTR
 
         var injData = new TrxInjectionData();
         injData.SectorEdits.AddRange(GenerateTrxSectorEdits());
+        injData.TexPages.AddRange(GenerateTrxTexPages());
 
         using var writer = new BinaryWriterEx(new FileStream(_dest, FileMode.Append));
         TrxInjector.Serialize(injData, writer);
@@ -152,5 +153,116 @@ public partial class LevelCompilerClassicTR
         }
 
         return result;
+    }
+
+    private IEnumerable<TrxTextureOverwrite> GenerateTrxTexPages()
+    {
+        var depth = _level.Settings.TrxTextureBitDepth;
+        var version = _level.Settings.GameVersion;
+
+        if (depth == TrxTextureBitDepth.Default)
+            yield break;
+
+        if (version == TRVersion.Game.TR1X && depth == TrxTextureBitDepth.Bit8)
+            yield break;
+
+        if (version == TRVersion.Game.TR2X && depth == TrxTextureBitDepth.Bit16)
+            yield break;
+
+        const int size = 256 * 256;
+        const int bpp32 = 4;
+        const int pageSize32 = size * bpp32;
+
+        int numPages = _texture32Data.Length / pageSize32;
+
+        byte[] data8 = null;
+        ushort[] data16 = null;
+        tr_color[] palette = null;
+
+        if (depth == TrxTextureBitDepth.Bit8)
+        {
+            data8 = PackTextureMap32To8Bit(_texture32Data, out palette);
+        }
+        else if (depth == TrxTextureBitDepth.Bit16)
+        {
+            var packed = PackTextureMap32To16Bit(_texture32Data, _level.Settings);
+            data16 = new ushort[size * numPages];
+            Buffer.BlockCopy(packed, 0, data16, 0, data16.Length * sizeof(ushort));
+        }
+
+        for (ushort page = 0; page < numPages; page++)
+        {
+            var pixels = depth switch
+            {
+                TrxTextureBitDepth.Bit8 => Build8BitPage(page, size, data8, palette),
+                TrxTextureBitDepth.Bit16 => Build16BitPage(page, size, data16),
+                _ => Build32BitPage(page, size, pageSize32),
+            };
+            yield return new()
+            {
+                Page = page,
+                Data = pixels,
+            };
+        }
+    }
+
+    private static uint[] Build8BitPage(int page, int size, byte[] data, tr_color[] palette)
+    {
+        var pixels = new uint[size];
+        var baseIndex = page * size;
+
+        for (var i = 0; i < size; i++)
+        {
+            var idx = data[baseIndex + i];
+            if (idx == 0)
+                continue;
+
+            var c = palette[idx];
+            pixels[i] = (uint)(
+                (0xFF << 24) |
+                (c.Blue << 16) |
+                (c.Green << 8) |
+                c.Red);
+        }
+
+        return pixels;
+    }
+
+    private static uint[] Build16BitPage(int page, int size, ushort[] data)
+    {
+        var pixels = new uint[size];
+        var baseIndex = page * size;
+
+        for (var i = 0; i < size; i++)
+        {
+            var c = data[baseIndex + i];
+
+            var a = (c & 0x8000) != 0 ? 0xFF : 0;
+            var r = ((c >> 10) & 0x1F) * 255 / 31;
+            var g = ((c >> 5) & 0x1F) * 255 / 31;
+            var b = (c & 0x1F) * 255 / 31;
+
+            pixels[i] = (uint)((a << 24) | (b << 16) | (g << 8) | r);
+        }
+
+        return pixels;
+    }
+
+    private uint[] Build32BitPage(int page, int size, int pageSize)
+    {
+        var pixels = new uint[size];
+        Buffer.BlockCopy(_texture32Data, page * pageSize, pixels, 0, pageSize);
+
+        for (var i = 0; i < size; i++)
+        {
+            // Swap Red and Blue channels
+            var c = pixels[i];
+            pixels[i] =
+                (c & 0xFF00FF00) | // A + G
+                ((c & 0x000000FF) << 16) |
+                ((c & 0x00FF0000) >> 16);
+        }
+
+        return pixels;
     }
 }

--- a/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
@@ -79,6 +79,8 @@ public static class TrxInjector
 
         blockCount += WriteBlock(TrxBlockType.SectorEdits, data.SectorEdits.Count, writer,
             w => data.SectorEdits.ForEach(s => s.Serialize(w)));
+        blockCount += WriteBlock(TrxBlockType.TextureOverwrites, data.TexPages.Count, writer,
+            w => data.TexPages.ForEach(t => t.Serialize(w)));
 
         return blockCount;
     }
@@ -129,12 +131,14 @@ public static class TrxInjector
     private enum TrxBlockType
     {
         SectorEdits = 17,
+        TextureOverwrites = 20,
     }
 }
 
 public class TrxInjectionData
 {
     public List<TrxSectorEdit> SectorEdits { get; set; } = new();
+    public List<TrxTextureOverwrite> TexPages { get; set; } = new();
 }
 
 public abstract class TrxSectorEdit
@@ -220,6 +224,29 @@ public class TrxTriangulationEntry : TrxSectorEdit
         foreach (var val in data)
         {
             writer.Write(val);
+        }
+    }
+}
+
+public class TrxTextureOverwrite
+{
+    public ushort Page { get; set; }
+    public byte X { get; set; }
+    public byte Y { get; set; }
+    public ushort Width { get; set; } = 256;
+    public ushort Height { get; set; } = 256;
+    public uint[] Data { get; set; }
+
+    public void Serialize(BinaryWriterEx writer)
+    {
+        writer.Write(Page);
+        writer.Write(X);
+        writer.Write(Y);
+        writer.Write(Width);
+        writer.Write(Height);
+        for (int i = 0; i < Data.Length; i++)
+        {
+            writer.Write(Data[i]);
         }
     }
 }

--- a/TombLib/TombLib/LevelData/Enumerations.cs
+++ b/TombLib/TombLib/LevelData/Enumerations.cs
@@ -69,6 +69,9 @@ namespace TombLib.LevelData
 
         public static bool SupportsSplits(this Game ver)
             => ver >= Game.TR3;
+
+        public static bool IsTRX(this Game ver)
+            => ver == Game.TR1X || ver == Game.TR2X;
     }
 
     // Only for TR5+
@@ -86,6 +89,15 @@ namespace TombLib.LevelData
         Normal = 0,
         Rain = 1,
         Snow = 2
+    }
+
+    // Only for TRX
+    public enum TrxTextureBitDepth : byte
+    {
+        Default,
+        Bit8,
+        Bit16,
+        Bit32,
     }
 
     // Only for TEN

--- a/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
@@ -43,6 +43,7 @@ namespace TombLib.LevelData.IO
         /**/public static readonly ChunkId Dither16BitTextures = ChunkId.FromString("TeDitherTextures");
         /**/public static readonly ChunkId TexturePadding = ChunkId.FromString("TeTexturePadding");
         /**/public static readonly ChunkId TextureCompression = ChunkId.FromString("TeTextureCompression");
+        /**/public static readonly ChunkId TrxTextureBitDepth = ChunkId.FromString("TeTrxTextureDepth");
         /**/public static readonly ChunkId AgressiveTexturePacking = ChunkId.FromString("TeAgressiveTexturePacking");
         /**/public static readonly ChunkId AgressiveFloordataPacking = ChunkId.FromString("TeAgressiveFloordataPacking");
         /**/public static readonly ChunkId RemapAnimatedTextures = ChunkId.FromString("TeRemapAnimTextures");

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -314,6 +314,8 @@ namespace TombLib.LevelData.IO
                     settings.AgressiveTexturePacking = chunkIO.ReadChunkBool(chunkSize);
                 else if (id == Prj2Chunks.TextureCompression)
                     settings.CompressTextures = chunkIO.ReadChunkBool(chunkSize);
+                else if (id == Prj2Chunks.TrxTextureBitDepth)
+                    settings.TrxTextureBitDepth = (TrxTextureBitDepth)chunkIO.ReadChunkInt(chunkSize);
                 else if (id == Prj2Chunks.RearrangeRooms)
                     settings.RearrangeVerticalRooms = chunkIO.ReadChunkBool(chunkSize);
                 else if (id == Prj2Chunks.RemoveUnusedObjects)

--- a/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
@@ -173,6 +173,7 @@ namespace TombLib.LevelData.IO
                 chunkIO.WriteChunkBool(Prj2Chunks.Dither16BitTextures, settings.Dither16BitTextures);
                 chunkIO.WriteChunkBool(Prj2Chunks.AgressiveTexturePacking, settings.AgressiveTexturePacking);
                 chunkIO.WriteChunkBool(Prj2Chunks.TextureCompression, settings.CompressTextures);
+                chunkIO.WriteChunkInt(Prj2Chunks.TrxTextureBitDepth, (int)settings.TrxTextureBitDepth);
                 chunkIO.WriteChunkBool(Prj2Chunks.AgressiveFloordataPacking, settings.AgressiveFloordataPacking);
                 chunkIO.WriteChunkVector3(Prj2Chunks.DefaultAmbientLight, settings.DefaultAmbientLight);
                 chunkIO.WriteChunkInt(Prj2Chunks.DefaultLightQuality, (long)settings.DefaultLightQuality);

--- a/TombLib/TombLib/LevelData/Level.cs
+++ b/TombLib/TombLib/LevelData/Level.cs
@@ -457,7 +457,6 @@ namespace TombLib.LevelData
 
         public bool IsTombEngine => Settings?.GameVersion == TRVersion.Game.TombEngine;
 
-        public bool IsTRX => Settings?.GameVersion == TRVersion.Game.TR1X
-            || Settings?.GameVersion == TRVersion.Game.TR2X;
+        public bool IsTRX => Settings?.GameVersion.IsTRX() ?? false;
     }
 }

--- a/TombLib/TombLib/LevelData/LevelSettings.cs
+++ b/TombLib/TombLib/LevelData/LevelSettings.cs
@@ -229,6 +229,9 @@ namespace TombLib.LevelData
         public Tr5LaraType Tr5LaraType { get; set; } = Tr5LaraType.Normal;
         public Tr5WeatherType Tr5WeatherType { get; set; } = Tr5WeatherType.Normal;
 
+        // For TRX only
+        public TrxTextureBitDepth TrxTextureBitDepth { get; set; } = TrxTextureBitDepth.Default;
+
         public LevelSettings Clone()
         {
             LevelSettings result = (LevelSettings)MemberwiseClone();


### PR DESCRIPTION
This allows TRX levels to choose 8, 16 or 32-bit texture depth output. This works by writing full page overwrites as part of the injection data. If the chosen option matches the target's default output, no extra data is added.

Example results below.
<details>

![tex](https://github.com/user-attachments/assets/82a9246b-29ab-4277-8609-0b050320f776)
</details>