### PR TITLE
Update timer argument ranges and debug logs

### DIFF
--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/Timers.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/Timers.lua
@@ -307,8 +307,8 @@ end
 -- !Description "Sets colours for timer.\nNote: using this node within “On Volume Inside” or “On Loop” events may cause continuous loops and improper operation."
 -- !Section "Timer"
 -- !Arguments "NewLine, String, 76, [ NoMultiline ], Timer name"
--- !Arguments "Color, 10, {TEN.Color(255, 255, 255)}, Timer's color
--- !Arguments "Numerical, 14, {1}, [ 0 | 1 | 2 | 0.1 ], Color transparency'"
+-- !Arguments "Color, 10, {TEN.Color(255, 255, 255)}, Timer's color"
+-- !Arguments "Numerical, 14, {1}, [ 0 | 1 | 2 | 0.1 ], Color transparency"
 LevelFuncs.Engine.Node.SetTimerColor = function (name, color, tColor)
     if name ~= '' then
         if Timer.IfExists(name) then
@@ -505,7 +505,7 @@ LevelFuncs.Engine.Node.IfRemainingTimeIs = function(name, operator, value)
                 if LevelVars.nodeTimers[name].debug then
                     local floatValue = value + 0.00
                     local remainingTime = timer:GetRemainingTimeInSeconds()
-                    TEN.Util.PrintLog("If the remaining time (".. remainingTime ..") is " .. textCompareOp[operator] .. " " ..  floatValue .. ". . Result: " .. tostring(result), TEN.Util.LogLevel.INFO, true)
+                    TEN.Util.PrintLog("If the remaining time (".. remainingTime ..") is " .. textCompareOp[operator] .. " " ..  floatValue .. ". Result: " .. tostring(result), TEN.Util.LogLevel.INFO, true)
                 end
                 return result
             end


### PR DESCRIPTION
This pull request updates the timer node catalog definitions in `Timers.lua` to allow for longer timer durations and more precise time values, as well as simplifying some timer-related logic and debug logging. The changes mainly expand the allowed range for timer durations and remove unnecessary checks in timer retrieval functions.

**Timer duration and range improvements:**

* Increased the maximum allowed timer duration from 1000 seconds (or 65535 in some cases) to 86400 seconds (24 hours) for all relevant timer arguments, and clarified in the descriptions that values can be rounded to the nearest game frame (1/30 of a second). [[1]](diffhunk://#diff-45fb150dee88bf63c116fd3c077d4b2e2cd98add1e1ea55b97b7f43703fe5098L21-R21) [[2]](diffhunk://#diff-45fb150dee88bf63c116fd3c077d4b2e2cd98add1e1ea55b97b7f43703fe5098L53-R53) [[3]](diffhunk://#diff-45fb150dee88bf63c116fd3c077d4b2e2cd98add1e1ea55b97b7f43703fe5098L88-R88) [[4]](diffhunk://#diff-45fb150dee88bf63c116fd3c077d4b2e2cd98add1e1ea55b97b7f43703fe5098L123-R123) [[5]](diffhunk://#diff-45fb150dee88bf63c116fd3c077d4b2e2cd98add1e1ea55b97b7f43703fe5098L224-R224) [[6]](diffhunk://#diff-45fb150dee88bf63c116fd3c077d4b2e2cd98add1e1ea55b97b7f43703fe5098L251-R251) [[7]](diffhunk://#diff-45fb150dee88bf63c116fd3c077d4b2e2cd98add1e1ea55b97b7f43703fe5098L487-R492) [[8]](diffhunk://#diff-45fb150dee88bf63c116fd3c077d4b2e2cd98add1e1ea55b97b7f43703fe5098L520-R512)

**Timer logic simplification:**

* Removed unnecessary `IsTicking()` checks from the `GetRemainingTime` and `GetTotalTime` functions, so they now always log timer values if the timer exists. [[1]](diffhunk://#diff-45fb150dee88bf63c116fd3c077d4b2e2cd98add1e1ea55b97b7f43703fe5098L400-L402) [[2]](diffhunk://#diff-45fb150dee88bf63c116fd3c077d4b2e2cd98add1e1ea55b97b7f43703fe5098L419-L421)

**Debug logging improvements:**

* Simplified debug logging in `IfRemainingTimeIs` by removing conditional checks based on operator type and timer state; debug logs now always print if enabled.

These changes make timer nodes more flexible for longer durations and ensure timer state and debug information is more consistently available.