### PR TITLE
Restrict monkeyswing overlap flag to TR4+

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -15,6 +15,7 @@ Tomb Editor:
  * Changed TR2X levels to embed sound effects rather than using main.sfx.
  * Fixed node parameter corruption after changing node background color.
  * Fixed unintended room deletion in 3D mode when no objects are selected.
+ * Fixed enemy monkeyswing pathfinding being added to TR3 levels.
 
 WadTool:
  * Added indication of missing external texture file.

--- a/TombLib/TombLib/LevelData/Compilers/PathfindingDecompiled.cs
+++ b/TombLib/TombLib/LevelData/Compilers/PathfindingDecompiled.cs
@@ -175,7 +175,7 @@ namespace TombLib.LevelData.Compilers
 
                                     if (_level.Settings.GameVersion.Native() >= TRVersion.Game.TR4 && dec_jump)
                                         dec_overlaps[dec_numOverlaps] |= 0x800;
-                                    if (_level.Settings.GameVersion.Native() >= TRVersion.Game.TR3 && dec_monkey)
+                                    if (_level.Settings.GameVersion.Native() >= TRVersion.Game.TR4 && dec_monkey)
                                         dec_overlaps[dec_numOverlaps] |= 0x2000;
 
                                     dec_numOverlaps++;
@@ -216,7 +216,7 @@ namespace TombLib.LevelData.Compilers
 
                                         if (_level.Settings.GameVersion.Native() >= TRVersion.Game.TR4 && dec_jump)
                                             dec_overlaps[dec_numOverlaps] |= 0x800;
-                                        if (_level.Settings.GameVersion.Native() >= TRVersion.Game.TR3 && dec_monkey)
+                                        if (_level.Settings.GameVersion.Native() >= TRVersion.Game.TR4 && dec_monkey)
                                             dec_overlaps[dec_numOverlaps] |= 0x2000;
 
                                         dec_numOverlaps++;


### PR DESCRIPTION
This avoids adding the monkeyswing pathfinding flag to TR3 overlaps, as no enemies there use the mechanism. It avoids engine crashes as the overlap indices are interpreted directly in box lookups.

Resolves #1152.