### PR TITLE
Unswap mesh node

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -11,6 +11,9 @@ Tomb Editor:
 WadTool:
  * Added missing TR2 henchman death sound (ID 838) and appropriate TR2 -> TEN conversion.
  
+TEN nodes:
+ * Added nodes to unswap and previously swapped mesh.
+ 
 Version 1.11
 ============
 

--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -12,7 +12,7 @@ WadTool:
  * Added missing TR2 henchman death sound (ID 838) and appropriate TR2 -> TEN conversion.
  
 TEN nodes:
- * Added nodes to unswap and previously swapped mesh.
+ * Added a node to unswap a previously swapped mesh.
  
 Version 1.11
 ============

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/Moveables.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/Moveables.lua
@@ -555,6 +555,15 @@ LevelFuncs.Engine.Node.SwapMoveableMesh = function(dest, destIndex, srcSlot, src
 	TEN.Objects.GetMoveableByName(dest):SwapMesh(destIndex, srcSlot, srcIndex)
 end
 
+-- !Name "Restore a previously swapped mesh"
+-- !Section "Moveable parameters"
+-- !Description "Restore a previously swapped mesh"
+-- !Arguments "NewLine, 80, Moveables, Moveable to restore" "Numerical, 20, [ 0 | 31 ], Mesh index to restore"
+
+LevelFuncs.Engine.Node.UnswapMoveableMesh = function(dest, destIndex)
+	TEN.Objects.GetMoveableByName(dest):UnswapMesh(destIndex)
+end
+
 -- !Name "If moveable has effect..."
 -- !Section "Moveable state"
 -- !Conditional "True"

--- a/TombLib/TombLib/Catalogs/TEN Node Catalogs/Moveables.lua
+++ b/TombLib/TombLib/Catalogs/TEN Node Catalogs/Moveables.lua
@@ -557,7 +557,7 @@ end
 
 -- !Name "Restore a previously swapped mesh"
 -- !Section "Moveable parameters"
--- !Description "Restore a previously swapped mesh"
+-- !Description "Restores a previously swapped mesh."
 -- !Arguments "NewLine, 80, Moveables, Moveable to restore" "Numerical, 20, [ 0 | 31 ], Mesh index to restore"
 
 LevelFuncs.Engine.Node.UnswapMoveableMesh = function(dest, destIndex)


### PR DESCRIPTION
Adds a missing node to restore a previously swapped mesh. Useful for cutscenes.

To test: create a node like this:

<img width="619" height="251" alt="image" src="https://github.com/user-attachments/assets/6aed160d-2635-4a0e-b7b8-63d95f67b516" />

And then use this new node to restore it.

<img width="565" height="144" alt="image" src="https://github.com/user-attachments/assets/e945b25f-7fb1-4800-b142-f9084051d89a" />