### PR TITLE
More traps catalog updates 

### DIFF
--- a/TombLib/TombLib/Catalogs/Engines/TR2/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR2/Moveables.xml
@@ -84,7 +84,7 @@
     <moveable id="85" name="Spiky moveable wall" essential="false" ten="SPIKY_WALL" />
     <moveable id="86" name="Bounce pad" essential="false" ten="SPRINGBOARD" />
     <moveable id="87" name="Spiky ceiling segment" essential="false" ten="SPIKY_CEILING" />
-    <moveable id="88" name="Tibetan bell" essential="false" ten="SHOOT_SWITCH4" />
+    <moveable id="88" name="Tibetan bell" essential="false" ten="BELL" />
     <moveable id="91" name="Lara and a snowmobile" ten="SNOWMOBILE_LARA_ANIMS" />
     <moveable id="92" name="Wheel knob" essential="false" ten="SWITCH_TYPE1" />
     <moveable id="93" name="Above-water switch" essential="false" ten="SWITCH_TYPE2" />

--- a/TombLib/TombLib/Catalogs/Engines/TR2/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR2/Moveables.xml
@@ -56,7 +56,7 @@
     <moveable id="54" name="Monk with knife-end stick" essential="false" ten="MONK2" />
     <moveable id="55" name="Collapsible floor" essential="false" ten="CRUMBLING_FLOOR" />
     <moveable id="57" name="Loose boards" essential="false" ten="CRUMBLING_FLOOR" />
-    <moveable id="58" name="Swinging sandbag / spiky ball" essential="false" ten="SPIKEBALL" />
+    <moveable id="58" name="Swinging sandbag / spiky ball" essential="false" /> <!-- Multiple Tomb Engine IDs, no definitive remap availiable -->
     <moveable id="59" name="Spikes / Glass shards" essential="false" ten="TEETH_SPIKES" />
     <moveable id="60" name="Boulder" essential="false" ten="CLASSIC_ROLLINGBALL" />
     <moveable id="61" name="Disk (like dart)" hidden="true" />
@@ -73,29 +73,29 @@
     <moveable id="72" name="Breakable window (can shoot out)" essential="false" ten="SMASH_OBJECT1" />
     <moveable id="73" name="Breakable window (must jump through)" essential="false" ten="SMASH_OBJECT2" />
     <moveable id="76" name="Airplane propeller" essential="false" ten="MOVING_BLADE" />
-    <moveable id="77" name="Power saw" essential="false" ten="MOVING_BLADE" />
+    <moveable id="77" name="Power saw" essential="false" ten="CIRCULAR_SAW" />
     <moveable id="78" name="Overhead pulley hook" essential="false" ten="MOVING_BLADE" />
     <moveable id="79" name="Sandbag / Ceiling fragments" essential="false" ten="FALLING_CEILING" />
     <moveable id="80" name="Rolling spindle" essential="false" ten="ROLLING_SPINDLE" />
     <moveable id="81" name="Wall-mounted knife blade" essential="false" ten="WALL_MOUNTED_BLADE" />
     <moveable id="82" name="Statue with knife blade" essential="false" ten="STATUE_WITH_BLADE" />
-    <moveable id="83" name="Multiple boulders / snowballs" essential="false" ten="CLASSIC_ROLLINGBALL" />
+    <moveable id="83" name="Multiple boulders / snowballs" essential="false" ten="MULTIPLE_BOULDERS" />
     <moveable id="84" name="Detachable icicles" essential="false" ten="FALLING_CEILING" />
     <moveable id="85" name="Spiky moveable wall" essential="false" ten="SPIKY_WALL" />
     <moveable id="86" name="Bounce pad" essential="false" ten="SPRINGBOARD" />
     <moveable id="87" name="Spiky ceiling segment" essential="false" ten="SPIKY_CEILING" />
-    <moveable id="88" name="Tibetan bell" essential="false" ten="BELL" />
+    <moveable id="88" name="Tibetan bell" essential="false" ten="SHOOT_SWITCH4" />
     <moveable id="91" name="Lara and a snowmobile" ten="SNOWMOBILE_LARA_ANIMS" />
     <moveable id="92" name="Wheel knob" essential="false" ten="SWITCH_TYPE1" />
     <moveable id="93" name="Above-water switch" essential="false" ten="SWITCH_TYPE2" />
     <moveable id="94" name="Underwater propeller" essential="false" ten="PROPELLER_H" />
     <moveable id="95" name="Air fan" essential="false" ten="ANIMATING1" />
-    <moveable id="96" name="Swinging box / spiky ball" essential="false" ten="SPIKEBALL" />
+    <moveable id="96" name="Swinging box / spiky ball" essential="false" /> <!-- Multiple Tomb Engine IDs, no definitive remap availiable -->
     <moveable id="97" name="Cutscene Object 1" ten="ANIMATING101" />
     <moveable id="98" name="Cutscene Object 2" ten="ANIMATING102" />
     <moveable id="99" name="Cutscene Object 3" ten="ANIMATING103" />
     <moveable id="100" name="Cutscene Object 4" ten="ANIMATING104" />
-    <moveable id="101" name="Rolling storage drums" essential="false" ten="CLASSIC_ROLLINGBALL" />
+    <moveable id="101" name="Rolling storage drums" essential="false" ten="ROLLING_BARRELS" />
     <moveable id="102" name="Zipline handle" essential="false" ten="ZIPLINE_HANDLE" />
     <moveable id="103" name="Above-water switch" essential="false" ten="SWITCH_TYPE3" />
     <moveable id="104" name="Above-water/underwater switch" essential="false" ten="SWITCH_TYPE4" />

--- a/TombLib/TombLib/Catalogs/Engines/TR3/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR3/Moveables.xml
@@ -77,13 +77,13 @@
     <moveable id="81" ai="true" name="AI Check" essential="false" ten="AI_X2"/>
     <moveable id="82" name="Unknown Id #82" essential="false" />
     <moveable id="83" name="Collapsible floor" essential="false" ten="CRUMBLING_FLOOR" />
-    <moveable id="86" name="Heavy swinging thing / Drill bit / Swinging brazier" essential="false" ten="FIRE_PENDULUM" />  
-    <moveable id="87" name="Spikes / Barbed wire" essential="false" ten="TEETH_SPIKES" />
+    <moveable id="86" name="Heavy swinging thing / Drill bit / Swinging brazier" essential="false" />  <!-- Multiple Tomb Engine IDs, no definitive remap availiable -->
+    <moveable id="87" name="Spikes / Barbed wire" essential="false" ten="TEETH_SPIKES" /> 
     <moveable id="88" name="Boulder / Barrel" essential="false" ten="CLASSIC_ROLLINGBALL" />
     <moveable id="89" name="Giant boulder (Temple of Puna)" essential="false" ten="BIG_ROLLINGBALL" /> 
     <moveable id="90" name="Disk (like dart)" hidden="true" ten="DART" />
     <moveable id="91" name="Dart emitter" essential="false" ten="DART_EMITTER" />
-    <moveable id="94" name="Spiked frame / Slamming door" essential="false" ten="SLAMMING_DOORS" />
+    <moveable id="94" name="Spiked frame / Slamming door" essential="false" /> <!-- Multiple Tomb Engine IDs, no definitive remap availiable -->
     <moveable id="97" name="Movable cubical block (pushable)" essential="false" ten="PUSHABLE_OBJECT_CLIMBABLE1" />
     <moveable id="98" name="Movable cubical block (pushable)" essential="false" ten="PUSHABLE_OBJECT_CLIMBABLE2"/>
 	<moveable id="99" name="Movable cubical block (pushable)" essential="false" ten="PUSHABLE_OBJECT_CLIMBABLE3"/>

--- a/TombLib/TombLib/Catalogs/Engines/TombEngine/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TombEngine/Moveables.xml
@@ -366,6 +366,17 @@
     <moveable id="456" name="TURNING_WALL_BLADE" />
     <moveable id="457" name="TURNING_CEILING_BLADE" />
     <moveable id="458" name="FIRE_PENDULUM" />
+	<moveable id="459" name="HEAVY_STAMPER" />
+	<moveable id="460" name="DRILL_BIT" />
+	<moveable id="461" name="SPIKED_FRAME" />
+	<moveable id="462" name="SWINGING_SANDBAG" />
+	<moveable id="463" name="SWINGING_BOX" />
+	<moveable id="464" name="OVERHEAD_PULLY_HOOK" />
+	<moveable id="465" name="SWINGING_IRON_ANCHOR" />
+	<moveable id="466" name="SWINGING_SPIKE_BAG" />
+	<moveable id="467" name="CIRCULAR_SAW" />
+	<moveable id="468" name="ROLLING_BARRELS" />
+	<moveable id="469" name="MULTIPLE_BOULDERS" />
     <moveable id="500" name="PUZZLE_ITEM1" />
     <moveable id="501" name="PUZZLE_ITEM2" />
     <moveable id="502" name="PUZZLE_ITEM3" />

--- a/TombLib/TombLib/Catalogs/TEN Sound Catalogs/TEN_ALL_SOUNDS.xml
+++ b/TombLib/TombLib/Catalogs/TEN Sound Catalogs/TEN_ALL_SOUNDS.xml
@@ -23251,5 +23251,43 @@
 			<Global>false</Global>
 			<Indexed>false</Indexed>
 		</WadSoundInfo>
+		<WadSoundInfo>
+			<Id>1200</Id>
+			<Name>TR2_Rolling_Barrel_Roll</Name>
+			<Volume>80</Volume>
+			<RangeInSectors>10</RangeInSectors>
+			<Chance>100</Chance>
+			<PitchFactor>0</PitchFactor>
+			<DisablePanning>false</DisablePanning>
+			<RandomizePitch>false</RandomizePitch>
+			<RandomizeVolume>false</RandomizeVolume>
+			<LoopBehaviour>Looped</LoopBehaviour>
+			<Samples>
+				<WadSample>
+					<FileName>tr2_rolling_barrel_roll_01.wav</FileName>
+				</WadSample>
+			</Samples>
+			<Global>true</Global>
+			<Indexed>true</Indexed>
+		</WadSoundInfo>
+		<WadSoundInfo>
+			<Id>1201</Id>
+			<Name>TR2_Rolling_Barrel_Stop</Name>
+			<Volume>100</Volume>
+			<RangeInSectors>10</RangeInSectors>
+			<Chance>100</Chance>
+			<PitchFactor>0</PitchFactor>
+			<DisablePanning>false</DisablePanning>
+			<RandomizePitch>false</RandomizePitch>
+			<RandomizeVolume>false</RandomizeVolume>
+			<LoopBehaviour>None</LoopBehaviour>
+			<Samples>
+				<WadSample>
+					<FileName>tr2_rolling_barrel_stop_01.wav</FileName>
+				</WadSample>
+			</Samples>
+			<Global>true</Global>
+			<Indexed>true</Indexed>
+		</WadSoundInfo>
 	</SoundInfos>
 </WadSounds>

--- a/TombLib/TombLib/Catalogs/TEN Sound Catalogs/TEN_TR2.xml
+++ b/TombLib/TombLib/Catalogs/TEN Sound Catalogs/TEN_TR2.xml
@@ -3752,5 +3752,43 @@
 			<Global>true</Global>
 			<Indexed>true</Indexed>
 		</WadSoundInfo>
+		<WadSoundInfo>
+			<Id>1200</Id>
+			<Name>TR2_Rolling_Barrel_Roll</Name>
+			<Volume>80</Volume>
+			<RangeInSectors>10</RangeInSectors>
+			<Chance>100</Chance>
+			<PitchFactor>0</PitchFactor>
+			<DisablePanning>false</DisablePanning>
+			<RandomizePitch>false</RandomizePitch>
+			<RandomizeVolume>false</RandomizeVolume>
+			<LoopBehaviour>Looped</LoopBehaviour>
+			<Samples>
+				<WadSample>
+					<FileName>tr2_rolling_barrel_roll_01.wav</FileName>
+				</WadSample>
+			</Samples>
+			<Global>true</Global>
+			<Indexed>true</Indexed>
+		</WadSoundInfo>
+		<WadSoundInfo>
+			<Id>1201</Id>
+			<Name>TR2_Rolling_Barrel_Stop</Name>
+			<Volume>100</Volume>
+			<RangeInSectors>10</RangeInSectors>
+			<Chance>100</Chance>
+			<PitchFactor>0</PitchFactor>
+			<DisablePanning>false</DisablePanning>
+			<RandomizePitch>false</RandomizePitch>
+			<RandomizeVolume>false</RandomizeVolume>
+			<LoopBehaviour>None</LoopBehaviour>
+			<Samples>
+				<WadSample>
+					<FileName>tr2_rolling_barrel_stop_01.wav</FileName>
+				</WadSample>
+			</Samples>
+			<Global>true</Global>
+			<Indexed>true</Indexed>
+		</WadSoundInfo>
 	</SoundInfos>
 </WadSounds>


### PR DESCRIPTION
This pull request updates the moveable objects catalogs for TR2, TR3, and TombEngine to improve the accuracy of object remapping and expand support for additional moveable types. The most significant changes include clarifying ambiguous mappings, correcting existing remaps, and adding new moveable definitions for TombEngine.

**Clarifications and Remapping Adjustments:**

* In `TR2/Moveables.xml` and `TR3/Moveables.xml`, several moveables with ambiguous or multiple possible TombEngine mappings (such as "Swinging sandbag / spiky ball", "Swinging box / spiky ball", "Heavy swinging thing / Drill bit / Swinging brazier", and "Spiked frame / Slamming door") have had their `ten` (TombEngine) mappings removed and replaced with comments explaining the ambiguity. This ensures no incorrect remaps are assumed when there is no definitive mapping. [[1]](diffhunk://#diff-80a5cc3738fd31538eac5dfae47649f36b70f3bbf73b1093ff7ff71b79bfdf0bL59-R59) [[2]](diffhunk://#diff-80a5cc3738fd31538eac5dfae47649f36b70f3bbf73b1093ff7ff71b79bfdf0bL93-R98) [[3]](diffhunk://#diff-62da3145a22e628ae8d7fae339378e54d26b76776be05fbeeb60d55f60123d19L80-R86)

* Specific remaps in `TR2/Moveables.xml` have been corrected for better accuracy:
  - "Power saw" now maps to `CIRCULAR_SAW` instead of `MOVING_BLADE`.
  - "Multiple boulders / snowballs" now maps to `MULTIPLE_BOULDERS` instead of `CLASSIC_ROLLINGBALL`.
  - "Rolling storage drums" now maps to `ROLLING_BARRELS` instead of `CLASSIC_ROLLINGBALL`. [[1]](diffhunk://#diff-80a5cc3738fd31538eac5dfae47649f36b70f3bbf73b1093ff7ff71b79bfdf0bL76-R82) [[2]](diffhunk://#diff-80a5cc3738fd31538eac5dfae47649f36b70f3bbf73b1093ff7ff71b79bfdf0bL93-R98)

**Expansion of TombEngine Moveables:**

* Several new moveable definitions have been added to `TombEngine/Moveables.xml`, including `HEAVY_STAMPER`, `DRILL_BIT`, `SPIKED_FRAME`, `SWINGING_SANDBAG`, `SWINGING_BOX`, `OVERHEAD_PULLY_HOOK`, `SWINGING_IRON_ANCHOR`, `SWINGING_SPIKE_BAG`, `CIRCULAR_SAW`, `ROLLING_BARRELS`, and `MULTIPLE_BOULDERS`. This expands the range of objects available in TombEngine and supports more accurate remapping from TR2/TR3.

**Summary of Most Important Changes:**

**Ambiguous or Multiple Mappings Clarified:**
- Removed ambiguous `ten` mappings from moveables like "Swinging sandbag / spiky ball", "Swinging box / spiky ball", "Heavy swinging thing / Drill bit / Swinging brazier", and "Spiked frame / Slamming door" in TR2 and TR3 catalogs, with comments explaining the lack of a definitive remap. [[1]](diffhunk://#diff-80a5cc3738fd31538eac5dfae47649f36b70f3bbf73b1093ff7ff71b79bfdf0bL59-R59) [[2]](diffhunk://#diff-80a5cc3738fd31538eac5dfae47649f36b70f3bbf73b1093ff7ff71b79bfdf0bL93-R98) [[3]](diffhunk://#diff-62da3145a22e628ae8d7fae339378e54d26b76776be05fbeeb60d55f60123d19L80-R86)

**Remapping Corrections:**
- Corrected remaps for "Power saw" to `CIRCULAR_SAW`, "Multiple boulders / snowballs" to `MULTIPLE_BOULDERS`, and "Rolling storage drums" to `ROLLING_BARRELS` in `TR2/Moveables.xml`. [[1]](diffhunk://#diff-80a5cc3738fd31538eac5dfae47649f36b70f3bbf73b1093ff7ff71b79bfdf0bL76-R82) [[2]](diffhunk://#diff-80a5cc3738fd31538eac5dfae47649f36b70f3bbf73b1093ff7ff71b79bfdf0bL93-R98)

**TombEngine Moveables Expansion:**
- Added new moveable definitions in `TombEngine/Moveables.xml` for various objects, supporting more granular and accurate object mapping.

Linked PR: [HERE](https://github.com/TombEngine/TombEngine/pull/1717)