### PR TITLE
Add catalogue and remap for FUSEBOX_SWITCH

### DIFF
--- a/TombLib/TombLib/Catalogs/Engines/TR3/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR3/Moveables.xml
@@ -284,5 +284,5 @@
     <moveable id="366" name="Yellow shell casing" hidden="true" />
     <moveable id="367" name="Red shell casing" hidden="true" />
     <moveable id="370" name="Tinnos light shaft" essential="false" ten="WATERFALL1" />
-    <moveable id="373" name="Electrical switch box" essential="false" ten="SHOOT_SWITCH2" /> 
+    <moveable id="373" name="Electrical switch box" essential="false" ten="FUSEBOX_SWITCH" /> 
 </moveables>

--- a/TombLib/TombLib/Catalogs/Engines/TombEngine/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TombEngine/Moveables.xml
@@ -642,7 +642,7 @@
     <moveable id="830" name="PULLEY" />
     <moveable id="831" name="CROWDOVE_SWITCH" />
     <moveable id="832" name="MINECART_SWITCH" />
-	<moveable id="833" name="FUSEBOX_SWITCH" />
+    <moveable id="833" name="FUSEBOX_SWITCH" />
     <moveable id="850" name="DOOR_TYPE1" />
     <moveable id="851" name="DOOR_TYPE2" />
     <moveable id="852" name="DOOR_TYPE3" />

--- a/TombLib/TombLib/Catalogs/Engines/TombEngine/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TombEngine/Moveables.xml
@@ -642,6 +642,7 @@
     <moveable id="830" name="PULLEY" />
     <moveable id="831" name="CROWDOVE_SWITCH" />
     <moveable id="832" name="MINECART_SWITCH" />
+	<moveable id="833" name="FUSEBOX_SWITCH" />
     <moveable id="850" name="DOOR_TYPE1" />
     <moveable id="851" name="DOOR_TYPE2" />
     <moveable id="852" name="DOOR_TYPE3" />


### PR DESCRIPTION
This pull request updates the moveable object definitions in the TR3 and TombEngine catalogs to ensure consistent naming and add missing entries. The main changes involve correcting the reference for the electrical switch box in TR3 and adding a new moveable entry for the fusebox switch in TombEngine.

Catalog consistency and object updates:

* Updated the `Electrical switch box` in `TombLib/Catalogs/Engines/TR3/Moveables.xml` to reference the correct technical entry `FUSEBOX_SWITCH` instead of `SHOOT_SWITCH2`.
* Added a new moveable entry for `FUSEBOX_SWITCH` with id 833 in `TombLib/Catalogs/Engines/TombEngine/Moveables.xml` to ensure it is available in the TombEngine catalog.

[Tomb Engine PR](https://github.com/TombEngine/TombEngine/pull/1943)