### PR TITLE
Add TRX reverb, cold and damage room support

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -11,6 +11,8 @@ Tomb Editor:
  * Added indication of the nodes not supported by the current event type.
  * Added On Pickup, On Vehicle Enter and On Vehicle Exit global events in the global event set editor.
  * Added multiple window layout support.
+ * Added support for room reverb in TRX.
+ * Added support for cold and damaging rooms in TRX.
 
 WadTool:
  * Added missing TR2 henchman death sound (ID 838) and appropriate TR2 -> TEN conversion.

--- a/TombEditor/Command.cs
+++ b/TombEditor/Command.cs
@@ -2155,7 +2155,7 @@ namespace TombEditor
 
             AddCommand("SetRoomCold", "Set room to cold (TRNG only)", CommandType.Rooms, delegate (CommandArgs args)
             {
-                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion >= TRVersion.Game.TRNG, "Cold flag"))
+                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion >= TRVersion.Game.TR1X, "Cold flag"))
                     return;
                 if (args.Editor.SelectedRoom != null)
                 {
@@ -2178,7 +2178,7 @@ namespace TombEditor
 
             AddCommand("SetRoomDamage", "Set room to damage (TRNG only)", CommandType.Rooms, delegate (CommandArgs args)
             {
-                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion >= TRVersion.Game.TRNG, "Damage flag"))
+                if (!EditorActions.VersionCheck(args.Editor.Level.Settings.GameVersion >= TRVersion.Game.TR1X, "Damage flag"))
                     return;
                 if (args.Editor.SelectedRoom != null)
                 {

--- a/TombEditor/ToolWindows/RoomOptions.cs
+++ b/TombEditor/ToolWindows/RoomOptions.cs
@@ -53,11 +53,12 @@ namespace TombEditor.ToolWindows
                 bool supportsReverb = _editor.Level.Settings.GameVersion.SupportsReverberation();
                 bool isTR1 = _editor.Level.Settings.GameVersion.Native() == TRVersion.Game.TR1;
                 bool isTEN = _editor.Level.Settings.GameVersion is TRVersion.Game.TombEngine;
+                bool isTRX = _editor.Level.Settings.GameVersion.IsTRX();
 
-                cbHorizon.Enabled = !isTR1 || _editor.Level.IsTRX;
-                cbFlagOutside.Enabled = !isTR1 || _editor.Level.IsTRX;
-                cbFlagCold.Enabled = isNGorTEN;
-                cbFlagDamage.Enabled = isNGorTEN;
+                cbHorizon.Enabled = !isTR1 || isTRX;
+                cbFlagOutside.Enabled = !isTR1 || isTRX;
+                cbFlagCold.Enabled = isNGorTEN || isTRX;
+                cbFlagDamage.Enabled = isNGorTEN || isTRX;
                 cbFlagNoCaustics.Enabled = isTEN;
                 cbNoLensflare.Enabled = supportsLensflare;
                 comboReverberation.Enabled = supportsReverb;

--- a/TombLib/TombLib/LevelData/Compilers/Trx.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Trx.cs
@@ -44,6 +44,11 @@ public partial class LevelCompilerClassicTR
     {
         foreach (var (teRoom, trRoom) in _tempRooms)
         {
+            if (GetRoomPropertyEntry(teRoom, trRoom) is TRXRoomPropertyEntry roomEntry)
+            {
+                yield return roomEntry;
+            }
+
             for (ushort x = 1; x < teRoom.NumXSectors - 1; x++)
             {
                 for (ushort z = 1; z < teRoom.NumZSectors - 1; z++)
@@ -63,6 +68,32 @@ public partial class LevelCompilerClassicTR
                 }
             }
         }
+    }
+
+    private TRXRoomPropertyEntry GetRoomPropertyEntry(Room teRoom, tr_room trRoom)
+    {
+        if (teRoom.Properties.Reverberation == 0
+            && !teRoom.Properties.FlagCold && !teRoom.Properties.FlagDamage)
+        {
+            return null;
+        }
+
+        var flags = trRoom.Flags;
+        if (teRoom.Properties.FlagDamage)
+        {
+            flags |= 0x02;
+        }
+        if (teRoom.Properties.FlagCold)
+        {
+            flags |= 0x04;
+        }
+
+        return new()
+        {
+            RoomIndex = (short)_roomRemapping[teRoom],
+            Flags = flags,
+            ReverbInfo = teRoom.Properties.Reverberation,
+        };
     }
 
     private TrxSectorOverwrite GetSectorOverwrite(Room teRoom, tr_room trRoom, ushort x, ushort z)

--- a/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
@@ -10,7 +10,7 @@ namespace TombLib.LevelData.Compilers.Util;
 public static class TrxInjector
 {
     private const uint _magic = 'T' | 'R' << 8 | 'X' << 16 | 'J' << 24;
-    private const uint _version = 6;
+    private const uint _version = 8;
     private const uint _injectionType = 0; // Implies no link to a TRX config option
 
     public static void Serialize(TrxInjectionData data, BinaryWriterEx outWriter)
@@ -236,6 +236,20 @@ public class TrxTriangulationEntry : TrxSectorEdit
         {
             writer.Write(val);
         }
+    }
+}
+
+public class TRXRoomPropertyEntry : TrxSectorEdit
+{
+    public override int Command => 5;
+
+    public short Flags { get; set; }
+    public byte ReverbInfo { get; set; }
+
+    protected override void SerializeImpl(BinaryWriterEx writer)
+    {
+        writer.Write(Flags);
+        writer.Write(ReverbInfo);
     }
 }
 

--- a/TombLib/TombLib/LevelData/Enumerations.cs
+++ b/TombLib/TombLib/LevelData/Enumerations.cs
@@ -56,7 +56,7 @@ namespace TombLib.LevelData
             => ver.Native() >= Game.TR4;
 
         public static bool SupportsReverberation(this Game ver)
-            => ver.Native() >= Game.TR3;
+            => ver >= Game.TR3;
 
         public static bool SupportsLensflare(this Game ver)
             => ver.Native() >= Game.TR4;


### PR DESCRIPTION
This allows TRX levels to use reverb. It additionally adds support for cold and damaging room flags; these are all handled similarly in terms of the injected data, hence the combined features here.

Refs:
https://github.com/LostArtefacts/TRX/pull/5507
https://github.com/LostArtefacts/TRX/pull/5612
https://github.com/LostArtefacts/TRX/pull/5630
https://github.com/LostArtefacts/TRX/pull/5665