### PR TITLE
Extend TRX trigger type support

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -11,6 +11,7 @@ Tomb Editor:
  * Added indication of the nodes not supported by the current event type.
  * Added On Pickup, On Vehicle Enter and On Vehicle Exit global events in the global event set editor.
  * Added multiple window layout support.
+ * Added support for heavy switch, heavy antitrigger, monkey, climb and crawl trigger types in TRX.
 
 WadTool:
  * Added missing TR2 henchman death sound (ID 838) and appropriate TR2 -> TEN conversion.

--- a/TombLib/TombLib/LevelData/Compilers/FloorData.cs
+++ b/TombLib/TombLib/LevelData/Compilers/FloorData.cs
@@ -524,7 +524,8 @@ namespace TombLib.LevelData.Compilers
                     _progressReporter.ReportWarn("Level uses 'Monkey' trigger type, which was replaced with 'Condition' in this game engine.");
 
                 if ((_level.Settings.GameVersion != TRVersion.Game.TR5) &&
-                    (setupTrigger.TriggerType > TriggerType.ConditionNg && setupTrigger.TriggerType < TriggerType.Monkey))
+                    (setupTrigger.TriggerType > TriggerType.ConditionNg && setupTrigger.TriggerType < TriggerType.Monkey)
+                    && (!_level.Settings.GameVersion.IsTRX() || setupTrigger.TriggerType == TriggerType.Skeleton  || setupTrigger.TriggerType == TriggerType.TightRope))
                     _progressReporter.ReportWarn("Level uses trigger type '" + setupTrigger.TriggerType + "', which is not supported in this game engine.");
 
                 ushort triggerSetup;

--- a/TombLib/TombLib/NG/NgParameterInfo.cs
+++ b/TombLib/TombLib/NG/NgParameterInfo.cs
@@ -24,7 +24,7 @@ namespace TombLib.NG
             yield return TriggerType.Dummy;
             yield return TriggerType.Antitrigger;
 
-            if (levelSettings.GameVersion.Native() >= TRVersion.Game.TR4)
+            if (levelSettings.GameVersion >= TRVersion.Game.TR4)
             {
                 yield return TriggerType.HeavySwitch;
                 yield return TriggerType.HeavyAntitrigger;
@@ -34,7 +34,7 @@ namespace TombLib.NG
                 yield return TriggerType.ConditionNg;
             else
             {
-                if (levelSettings.GameVersion.Native() >= TRVersion.Game.TR4)
+                if (levelSettings.GameVersion >= TRVersion.Game.TR4)
                     yield return TriggerType.Monkey;
 
                 if (levelSettings.GameVersion == TRVersion.Game.TR5)
@@ -43,6 +43,12 @@ namespace TombLib.NG
                 if (levelSettings.GameVersion is TRVersion.Game.TR5 or TRVersion.Game.TombEngine)
                 {
                     yield return TriggerType.TightRope;
+                    yield return TriggerType.Crawl;
+                    yield return TriggerType.Climb;
+                }
+
+                if (levelSettings.GameVersion.IsTRX())
+                {
                     yield return TriggerType.Crawl;
                     yield return TriggerType.Climb;
                 }


### PR DESCRIPTION
This adds support for heavy switch, heavy antitrigger, monkey, climb and crawl trigger types in TRX.

Ref: https://github.com/LostArtefacts/TRX/pull/5522