### PR TITLE
Multiple slot remaps

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -14,6 +14,7 @@ Tomb Editor:
 
 WadTool:
  * Added missing TR2 henchman death sound (ID 838) and appropriate TR2 -> TEN conversion.
+ * Added support for choosing the destination slot when copying classic objects into a TombEngine WAD2, for cases where a classic slot maps to multiple objects.
  
 TEN nodes:
  * Added a node to unswap a previously swapped mesh.

--- a/TombLib/TombLib/Catalogs/Engines/TR2/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR2/Moveables.xml
@@ -56,7 +56,7 @@
     <moveable id="54" name="Monk with knife-end stick" essential="false" ten="MONK2" />
     <moveable id="55" name="Collapsible floor" essential="false" ten="CRUMBLING_FLOOR" />
     <moveable id="57" name="Loose boards" essential="false" ten="CRUMBLING_FLOOR" />
-    <moveable id="58" name="Swinging sandbag / spiky ball" essential="false" /> <!-- Multiple Tomb Engine IDs, no definitive remap availiable -->
+    <moveable id="58" name="Swinging sandbag / spiky ball" essential="false" ten="SWINGING_SANDBAG,SWINGING_SPIKE_BAG" />
     <moveable id="59" name="Spikes / Glass shards" essential="false" ten="TEETH_SPIKES" />
     <moveable id="60" name="Boulder" essential="false" ten="CLASSIC_ROLLINGBALL" />
     <moveable id="61" name="Disk (like dart)" hidden="true" />
@@ -90,7 +90,7 @@
     <moveable id="93" name="Above-water switch" essential="false" ten="SWITCH_TYPE2" />
     <moveable id="94" name="Underwater propeller" essential="false" ten="PROPELLER_H" />
     <moveable id="95" name="Air fan" essential="false" ten="ANIMATING1" />
-    <moveable id="96" name="Swinging box / spiky ball" essential="false" /> <!-- Multiple Tomb Engine IDs, no definitive remap availiable -->
+    <moveable id="96" name="Swinging box / spiky ball" essential="false" ten="SWINGING_BOX,SWINGING_SPIKE_BAG" />
     <moveable id="97" name="Cutscene Object 1" ten="ANIMATING101" />
     <moveable id="98" name="Cutscene Object 2" ten="ANIMATING102" />
     <moveable id="99" name="Cutscene Object 3" ten="ANIMATING103" />

--- a/TombLib/TombLib/Catalogs/Engines/TR3/Moveables.xml
+++ b/TombLib/TombLib/Catalogs/Engines/TR3/Moveables.xml
@@ -77,13 +77,13 @@
     <moveable id="81" ai="true" name="AI Check" essential="false" ten="AI_X2"/>
     <moveable id="82" name="Unknown Id #82" essential="false" />
     <moveable id="83" name="Collapsible floor" essential="false" ten="CRUMBLING_FLOOR" />
-    <moveable id="86" name="Heavy swinging thing / Drill bit / Swinging brazier" essential="false" />  <!-- Multiple Tomb Engine IDs, no definitive remap availiable -->
+    <moveable id="86" name="Heavy swinging thing / Drill bit / Swinging brazier" essential="false" ten="SWINGING_IRON_ANCHOR, DRILL_BIT, FIRE_PENDULUM" />
     <moveable id="87" name="Spikes / Barbed wire" essential="false" ten="TEETH_SPIKES" /> 
     <moveable id="88" name="Boulder / Barrel" essential="false" ten="CLASSIC_ROLLINGBALL" />
     <moveable id="89" name="Giant boulder (Temple of Puna)" essential="false" ten="BIG_ROLLINGBALL" /> 
     <moveable id="90" name="Disk (like dart)" hidden="true" ten="DART" />
     <moveable id="91" name="Dart emitter" essential="false" ten="DART_EMITTER" />
-    <moveable id="94" name="Spiked frame / Slamming door" essential="false" /> <!-- Multiple Tomb Engine IDs, no definitive remap availiable -->
+    <moveable id="94" name="Spiked frame / Slamming door" essential="false" ten="SPIKED_FRAME, SLAMMING_DOOR" />
     <moveable id="97" name="Movable cubical block (pushable)" essential="false" ten="PUSHABLE_OBJECT_CLIMBABLE1" />
     <moveable id="98" name="Movable cubical block (pushable)" essential="false" ten="PUSHABLE_OBJECT_CLIMBABLE2"/>
 	<moveable id="99" name="Movable cubical block (pushable)" essential="false" ten="PUSHABLE_OBJECT_CLIMBABLE3"/>

--- a/TombLib/TombLib/LevelData/IO/TombEngineConverter.cs
+++ b/TombLib/TombLib/LevelData/IO/TombEngineConverter.cs
@@ -54,7 +54,7 @@ namespace TombLib.LevelData.IO
             if (sourceVersion == TRVersion.Game.TombEngine)
                 return moveable;
 
-            string newSlotName = TrCatalog.GetMoveableTombEngineSlot(sourceVersion, moveable.Id.TypeId);
+            string newSlotName = TrCatalog.GetMoveableTombEngineSlots(sourceVersion, moveable.Id.TypeId).FirstOrDefault() ?? string.Empty;
 
             switch (newSlotName)
             {
@@ -401,7 +401,7 @@ namespace TombLib.LevelData.IO
                     {
                         uint newSlot;
                         string oldId = TrCatalog.GetMoveableName(TRVersion.Game.TR4, moveable.Key.TypeId);
-                        string newId = TrCatalog.GetMoveableTombEngineSlot(TRVersion.Game.TR4, moveable.Key.TypeId);
+                        string newId = TrCatalog.GetMoveableTombEngineSlots(TRVersion.Game.TR4, moveable.Key.TypeId).FirstOrDefault() ?? string.Empty;
 
                         if (string.IsNullOrEmpty(newId))
                         {
@@ -495,7 +495,7 @@ namespace TombLib.LevelData.IO
                         cancelToken.ThrowIfCancellationRequested();
                         uint newSlot;
                         string oldId = TrCatalog.GetMoveableName(TRVersion.Game.TR4, sequence.Key.TypeId);
-                        string newId = TrCatalog.GetMoveableTombEngineSlot(TRVersion.Game.TR4, sequence.Key.TypeId);
+                        string newId = TrCatalog.GetSpriteSequenceTombEngineSlot(TRVersion.Game.TR4, sequence.Key.TypeId);
 
                         if (string.IsNullOrEmpty(newId))
                         {

--- a/TombLib/TombLib/Wad/Catalog/TrCatalog.cs
+++ b/TombLib/TombLib/Wad/Catalog/TrCatalog.cs
@@ -43,7 +43,7 @@ namespace TombLib.Wad.Catalog
             public List<string> Names { get; set; }
             public string Description { get; set; }
             public string Category { get; set; }
-            public string TombEngineSlot { get; set; }
+            public List<string> TombEngineSlots { get; set; }
             public uint SkinId { get; set; }
             public int SubstituteId { get; set; }
             public bool AIObject { get; set; }
@@ -94,6 +94,16 @@ namespace TombLib.Wad.Catalog
 
         private static readonly Dictionary<TRVersion.Game, Game> Games = new Dictionary<TRVersion.Game, Game>();
 
+        private static List<string> ParseTombEngineSlots(string value)
+        {
+            return (value ?? string.Empty)
+                .Split(',')
+                .Select(slot => slot.Trim())
+                .Where(slot => !string.IsNullOrEmpty(slot))
+                .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                .ToList();
+        }
+
         public static int PredictSoundMapSize(TRVersion.Game version, bool IsNg, int numDemoData)
         {
             if (version == TRVersion.Game.TR4 && IsNg && numDemoData != 0)
@@ -121,14 +131,22 @@ namespace TombLib.Wad.Catalog
 
         public static string GetMoveableName(TRVersion.Game version, uint id) => GetMoveable(version, id)?.Names.LastOrDefault() ?? "Moveable #" + id;
         public static string GetMoveableCategory(TRVersion.Game version, uint id) => GetMoveable(version, id)?.Category ?? string.Empty;
-        public static string GetMoveableTombEngineSlot(TRVersion.Game version, uint id) => GetMoveable(version, id)?.TombEngineSlot ?? string.Empty;
         public static uint GetMoveableSkin(TRVersion.Game version, uint id) => GetMoveable(version, id)?.SkinId ?? id;
         public static bool IsMoveableAI(TRVersion.Game version, uint id) => GetMoveable(version, id)?.AIObject ?? false;
         public static bool IsHidden(TRVersion.Game version, uint id) => GetMoveable(version, id)?.IsHidden ?? false;
         public static bool IsEssential(TRVersion.Game version, uint id) => GetMoveable(version, id)?.IsEssential ?? false;
         public static bool IsFreelyRotateable(TRVersion.Game version, uint id) => GetMoveable(version, id)?.FreeRotation ?? false;
 
-        public static string GetSpriteSequenceTombEngineSlot(TRVersion.Game version, uint id)
+		public static IReadOnlyList<string> GetMoveableTombEngineSlots(TRVersion.Game version, uint id)
+		{
+			var moveable = GetMoveable(version, id);
+			if (!moveable.HasValue || moveable.Value.TombEngineSlots == null)
+				return Array.Empty<string>();
+
+			return moveable.Value.TombEngineSlots;
+		}
+
+		public static string GetSpriteSequenceTombEngineSlot(TRVersion.Game version, uint id)
         {
             Game game;
             if (!Games.TryGetValue(version.Native(), out game))
@@ -138,7 +156,7 @@ namespace TombLib.Wad.Catalog
             if (!game.SpriteSequences.TryGetValue(id, out entry))
                 return string.Empty;
 
-            return game.SpriteSequences[id].TombEngineSlot;
+            return game.SpriteSequences[id].TombEngineSlots.FirstOrDefault() ?? string.Empty;
         }
 
         public static uint GetTombEngineSound(TRVersion.Game version, uint id)
@@ -557,7 +575,7 @@ namespace TombLib.Wad.Catalog
                         bool isFreeRotation = bool.Parse(moveableNode.Attributes["freeRot"]?.Value ?? "false");
                         bool hidden = bool.Parse(moveableNode.Attributes["hidden"]?.Value ?? "false");
                         bool essential = bool.Parse(moveableNode.Attributes["essential"]?.Value ?? "true");
-                        string tombEngineSlot = moveableNode.Attributes["ten"]?.Value ?? string.Empty;
+                        var tombEngineSlots = ParseTombEngineSlots(moveableNode.Attributes["ten"]?.Value);
                         string category = moveableNode.Attributes["category"]?.Value ?? string.Empty;
 
                         game.Moveables.Add(id, new Item
@@ -566,7 +584,7 @@ namespace TombLib.Wad.Catalog
                             SkinId = skinId,
                             SubstituteId = substituteId,
                             AIObject = isAI,
-                            TombEngineSlot = tombEngineSlot,
+                            TombEngineSlots = tombEngineSlots,
                             FreeRotation = isFreeRotation,
                             IsHidden = hidden,
                             IsEssential = essential,
@@ -619,10 +637,10 @@ namespace TombLib.Wad.Catalog
                         if (spriteSequenceNode.Name != "sprite_sequence")
                             continue;
 
-                        string tombEngineSlot = spriteSequenceNode.Attributes["ten"]?.Value ?? string.Empty;
+                        var tombEngineSlots = ParseTombEngineSlots(spriteSequenceNode.Attributes["ten"]?.Value);
                         uint id = uint.Parse(spriteSequenceNode.Attributes["id"].Value);
                         string[] names = (spriteSequenceNode.Attributes["name"]?.Value ?? "").Split('|');
-                        game.SpriteSequences.Add(id, new Item { Names = new List<string>(names), TombEngineSlot = tombEngineSlot });
+                        game.SpriteSequences.Add(id, new Item { Names = new List<string>(names), TombEngineSlots = tombEngineSlots });
                     }
                 }
 

--- a/WadTool/Forms/FormSelectSlot.cs
+++ b/WadTool/Forms/FormSelectSlot.cs
@@ -18,8 +18,9 @@ namespace WadTool
 
         private Wad2 _wad;
         private List<uint> _additionalObjectsToHide;
+        private HashSet<uint> _allowedObjectIds;
 
-        public FormSelectSlot(Wad2 wad, IWadObjectId currentId, List<uint> additionalObjectsToHide = null)
+        public FormSelectSlot(Wad2 wad, IWadObjectId currentId, List<uint> additionalObjectsToHide = null, IEnumerable<uint> allowedObjectIds = null)
         {
             InitializeComponent();
 
@@ -29,6 +30,7 @@ namespace WadTool
 
             _wad = wad;
             _additionalObjectsToHide = additionalObjectsToHide;
+            _allowedObjectIds = allowedObjectIds == null ? null : new HashSet<uint>(allowedObjectIds);
 
             if (TypeClass == typeof(WadMoveableId))
                 chosenId.Value = ((WadMoveableId)currentId).TypeId;
@@ -48,16 +50,21 @@ namespace WadTool
         {
             // Decide on ID type
             if (TypeClass == typeof(WadMoveableId))
-                PopulateSlots(TrCatalog.GetAllMoveables(GameVersion).Where(item => !_wad.Moveables.Any(moveable => moveable.Key.TypeId == item.Key) && !(_additionalObjectsToHide?.Any(add => add == item.Key) ?? false)).ToList());
+                PopulateSlots(TrCatalog.GetAllMoveables(GameVersion).Where(item => IsAllowedObjectId(item.Key) && !_wad.Moveables.Any(moveable => moveable.Key.TypeId == item.Key) && !(_additionalObjectsToHide?.Any(add => add == item.Key) ?? false)).ToList());
             else if (TypeClass == typeof(WadStaticId))
-                PopulateSlots(TrCatalog.GetAllStatics(GameVersion).Where(item => !_wad.Statics.Any(stat => stat.Key.TypeId == item.Key) && !(_additionalObjectsToHide?.Any(add => add == item.Key) ?? false)).ToList());
+                PopulateSlots(TrCatalog.GetAllStatics(GameVersion).Where(item => IsAllowedObjectId(item.Key) && !_wad.Statics.Any(stat => stat.Key.TypeId == item.Key) && !(_additionalObjectsToHide?.Any(add => add == item.Key) ?? false)).ToList());
             else if (TypeClass == typeof(WadSpriteSequenceId))
-                PopulateSlots(TrCatalog.GetAllSpriteSequences(GameVersion).Where(item => !_wad.SpriteSequences.Any(sprite => sprite.Key.TypeId == item.Key) && !(_additionalObjectsToHide?.Any(add => add == item.Key) ?? false)).ToList());
+                PopulateSlots(TrCatalog.GetAllSpriteSequences(GameVersion).Where(item => IsAllowedObjectId(item.Key) && !_wad.SpriteSequences.Any(sprite => sprite.Key.TypeId == item.Key) && !(_additionalObjectsToHide?.Any(add => add == item.Key) ?? false)).ToList());
             else
                 throw new NotImplementedException("The " + TypeClass + " is not implemented yet.");
 
             // Make sure it redraws
             lstSlots.Invalidate();
+        }
+
+        private bool IsAllowedObjectId(uint objectId)
+        {
+            return _allowedObjectIds == null || _allowedObjectIds.Contains(objectId);
         }
 
         private void PopulateSlots(List<KeyValuePair<uint, string>> objectSlotSuggestions)

--- a/WadTool/WadActions.cs
+++ b/WadTool/WadActions.cs
@@ -594,7 +594,7 @@ namespace WadTool
 
             foreach (var moveable in src.Moveables)
             {
-                string compatibleSlot = TrCatalog.GetMoveableTombEngineSlot(src.GameVersion, moveable.Key.TypeId);
+                string compatibleSlot = TrCatalog.GetMoveableTombEngineSlots(src.GameVersion, moveable.Key.TypeId).FirstOrDefault() ?? string.Empty;
                 if (compatibleSlot == string.Empty)
                     continue;
 
@@ -757,6 +757,7 @@ namespace WadTool
 
             // Figure out the new ids if there are any id collisions
             var newIds = objectIdsToMove.ToArray();
+            var allowedMoveableSlots = new Dictionary<int, HashSet<uint>>();
 
             // If destination is TombEngine, try to remap object IDs
             if (sourceWad.GameVersion != TRVersion.Game.TombEngine && destinationWad.GameVersion == TRVersion.Game.TombEngine)
@@ -768,18 +769,26 @@ namespace WadTool
                     {
                         var moveableId = (WadMoveableId)objectId;
 
-                        // Try to get a compatible slot
-                        string newSlot = TrCatalog.GetMoveableTombEngineSlot(sourceWad.GameVersion, moveableId.TypeId);
-                        if (newSlot == "")
+                        var compatibleSlots = TrCatalog.GetMoveableTombEngineSlots(sourceWad.GameVersion, moveableId.TypeId);
+                        if (compatibleSlots.Count == 0)
                             continue;
 
-                        // Get the new ID
-                        uint? newId = TrCatalog.GetItemIndex(destinationWad.GameVersion, newSlot, out bool isMoveable);
-                        if (!newId.HasValue)
+                        var allowedSlots = new HashSet<uint>();
+                        foreach (var compatibleSlot in compatibleSlots)
+                        {
+                            uint? mappedId = TrCatalog.GetItemIndex(destinationWad.GameVersion, compatibleSlot, out bool isMoveable);
+                            if (mappedId.HasValue && isMoveable)
+                            {
+                                allowedSlots.Add(mappedId.Value);
+                            }
+                        }
+
+                        if (allowedSlots.Count == 0)
                             continue;
 
-                        // Save the new ID
-                        newIds[i] = new WadMoveableId(newId.Value);
+                        allowedMoveableSlots[i] = allowedSlots;
+
+                        newIds[i] = new WadMoveableId(allowedSlots.First());
                     }
                 }
             }
@@ -789,7 +798,11 @@ namespace WadTool
                 if (!sourceWad.Contains(objectIdsToMove[i]))
                     continue;
 
-                if (!alwaysChooseId)
+                var mustChooseCompatibleMoveableSlot = newIds[i] is WadMoveableId &&
+                    allowedMoveableSlots.TryGetValue(i, out var filteredSlots) &&
+                    filteredSlots.Count > 1;
+
+                if (!alwaysChooseId && !mustChooseCompatibleMoveableSlot)
                 {
                     if (!destinationWad.Contains(newIds[i]))
                     {
@@ -798,7 +811,7 @@ namespace WadTool
                     }
                 }
 
-                bool askConfirm = !alwaysChooseId;
+                bool askConfirm = !alwaysChooseId && !mustChooseCompatibleMoveableSlot;
 
                 // Ask for the new slot
                 do
@@ -824,7 +837,11 @@ namespace WadTool
                     }
                     else if (dialogResult == DialogResult.No)
                     {
-                        using (var form = new FormSelectSlot(destinationWad, newIds[i], listInProgress))
+                        IEnumerable<uint> allowedSlots = null;
+                        if (newIds[i] is WadMoveableId && allowedMoveableSlots.TryGetValue(i, out filteredSlots))
+                            allowedSlots = filteredSlots;
+
+                        using (var form = new FormSelectSlot(destinationWad, newIds[i], listInProgress, allowedSlots))
                         {
                             if (form.ShowDialog(owner) != DialogResult.OK)
                                 return null;


### PR DESCRIPTION
Allows to specify multiple TEN remap entries in the trcatalog. To do it, format xml entry like this:

`<moveable id="86" name="Heavy swinging thing / Drill bit / Swinging brazier" essential="false" ten="SLOT1, SLOT2, SLOT3" />`