### PR TITLE
Add TRX moveable instance name support

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -15,6 +15,7 @@ Tomb Editor:
  * Added support for cold and damaging rooms in TRX.
  * Added support for mine cart floor data in TRX.
  * Added support for heavy switch, heavy antitrigger, monkey, climb and crawl trigger types in TRX.
+ * Added support for specifying moveable instance names in TRX.
  * Fixed "Map animated textures" checkbox not unchecking in Level Settings dialog.
  * Fixed occasional exceptions after closing Node Editor.
  * Fixed exception while opening texture lists in Remap Texture dialog.

--- a/TombEditor/Command.cs
+++ b/TombEditor/Command.cs
@@ -1293,13 +1293,13 @@ namespace TombEditor
 
             AddCommand("GenerateObjectNames", "Generate Lua names for unnamed objects", CommandType.Objects, delegate (CommandArgs args)
             {
-                if (!EditorActions.VersionCheck(args.Editor.Level.IsTombEngine, "Object naming"))
+                if (!EditorActions.VersionCheck(args.Editor.Level.IsTombEngine || args.Editor.Level.IsTRX, "Object naming"))
                     return;
 
                 int count = 0;
 
-                foreach (var obj in args.Editor.Level.GetAllObjects().OfType<PositionAndScriptBasedObjectInstance>())
-                    if (string.IsNullOrEmpty(obj.LuaName))
+                foreach (var obj in args.Editor.Level.GetAllObjects().OfType<IHasLuaName>())
+                    if (obj.SupportsLuaName() && string.IsNullOrEmpty(obj.LuaName))
                     {
                         obj.AllocateNewLuaName();
                         count++;

--- a/TombEditor/Controls/ContextMenus/MaterialObjectContextMenu.cs
+++ b/TombEditor/Controls/ContextMenus/MaterialObjectContextMenu.cs
@@ -24,7 +24,7 @@ namespace TombEditor.Controls.ContextMenus
                     Items.Add(new ToolStripSeparator());
                 }
 
-                if (_editor.Level.IsTombEngine)
+                if (targetObject is IHasLuaName luaTarget && luaTarget.SupportsLuaName())
                 {
                     Items.Add(new ToolStripMenuItem("Rename object", Properties.Resources.general_edit_16, (o, e) =>
                     {
@@ -153,7 +153,7 @@ namespace TombEditor.Controls.ContextMenus
                 }));
             }
 
-            if (targetObject is PositionAndScriptBasedObjectInstance && _editor.Level.Settings.GameVersion == TRVersion.Game.TombEngine)
+            if (targetObject is IHasLuaName luaObject && luaObject.SupportsLuaName())
             {
                 Items.Add(new ToolStripMenuItem("Copy Lua name to clipboard", null, (o, e) =>
                 {

--- a/TombEditor/EditorActions.cs
+++ b/TombEditor/EditorActions.cs
@@ -1082,13 +1082,11 @@ namespace TombEditor
                 return;
             }
 
-            if (!VersionCheck(_editor.Level.IsTombEngine, "Object name"))
+            if (!VersionCheck(_editor.Level.IsTombEngine || _editor.Level.IsTRX, "Object name"))
                 return;
 
-            if (!(instance is PositionAndScriptBasedObjectInstance))
+            if (instance is not PositionAndScriptBasedObjectInstance luaInstance || !luaInstance.SupportsLuaName())
                 return;
-
-            var luaInstance = instance as PositionAndScriptBasedObjectInstance;
 
             using (var form = new FormInputBox("Edit object name", "Enter new Lua name for this object:", luaInstance.LuaName))
             {
@@ -2365,11 +2363,10 @@ namespace TombEditor
                 if (si.ScriptId == null)
                     si.AllocateNewScriptId();
             }
-            else if (instance is IHasLuaName && _editor.Level.IsTombEngine)
+            else if (instance is IHasLuaName luaInstance && luaInstance.SupportsLuaName())
             {
-                var li = instance as IHasLuaName;
-                if (string.IsNullOrEmpty(li.LuaName))
-                    li.AllocateNewLuaName();
+                if (string.IsNullOrEmpty(luaInstance.LuaName))
+                    luaInstance.AllocateNewLuaName();
             }
 
             if (instance is ObjectGroup)
@@ -2380,7 +2377,7 @@ namespace TombEditor
         // Batch-optimized version that allocates script IDs in bulk.
         public static void AllocateScriptIds(IEnumerable<PositionBasedObjectInstance> instances)
         {
-            if (_editor.Level.IsTombEngine)
+            if (_editor.Level.IsTombEngine || _editor.Level.IsTRX)
             {
                 var existingNames = _editor.Level.GetAllLuaNames();
                 foreach (var instance in instances)
@@ -2401,7 +2398,7 @@ namespace TombEditor
                 if (si.ScriptId == null)
                     si.AllocateNewScriptId();
             }
-            else if (instance is PositionAndScriptBasedObjectInstance scriptObj && _editor.Level.IsTombEngine)
+            else if (instance is PositionAndScriptBasedObjectInstance scriptObj && scriptObj.SupportsLuaName())
             {
                 if (string.IsNullOrEmpty(scriptObj.LuaName))
                     scriptObj.AllocateNewLuaName(luaNameCache);

--- a/TombEditor/Forms/FormMain.cs
+++ b/TombEditor/Forms/FormMain.cs
@@ -141,9 +141,9 @@ namespace TombEditor.Forms
 
                 addBoxVolumeToolStripMenuItem.Visible =
                 addSphereVolumeToolStripMenuItem.Visible =
-                generateObjectNamesToolStripMenuItem.Visible =
                 editEventSetsToolStripMenuItem.Visible =
                 editGlobalEventSetsToolStripMenuItem.Visible = _editor.Level.IsTombEngine;
+                generateObjectNamesToolStripMenuItem.Visible = _editor.Level.IsTombEngine || _editor.Level.IsTRX;
 
                 increaseStepHeightToolStripMenuItem.Visible =
                 decreaseStepHeightToolStripMenuItem.Visible =

--- a/TombEditor/RoomClipboardData.cs
+++ b/TombEditor/RoomClipboardData.cs
@@ -115,8 +115,8 @@ namespace TombEditor
             editor.SelectRoomsAndResetCamera(newRooms);
 
             // Refresh script IDs for all pasted objects
-            if (editor.Level.IsTombEngine)
-                newRooms.ForEach(r => r.Objects.Where(ob => ob is PositionAndScriptBasedObjectInstance).ToList().ForEach(i => ((PositionAndScriptBasedObjectInstance)i).AllocateNewLuaName()));
+            if (editor.Level.IsTombEngine || editor.Level.IsTRX)
+                newRooms.SelectMany(r => r.Objects.OfType<IHasLuaName>().Where(ob => ob.SupportsLuaName())).ToList().ForEach(i => i.AllocateNewLuaName());
             if (editor.Level.IsNG)
                 newRooms.ForEach(r => r.Objects.Where(ob => ob is PositionAndScriptBasedObjectInstance).ToList().ForEach(i => ((PositionAndScriptBasedObjectInstance)i).AllocateNewScriptId()));
         }

--- a/TombLib/TombLib/LevelData/Compilers/Trx.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Trx.cs
@@ -14,6 +14,7 @@ public partial class LevelCompilerClassicTR
     private const int _legacyRoomLimit = 255;
     private const int _noRoom = -1;
     private const int _maxSamples = 1000;
+    private const int _maxLuaNameLength = 4096;
 
     private void WriteLevelTrx()
     {
@@ -35,6 +36,7 @@ public partial class LevelCompilerClassicTR
         injData.SectorEdits.AddRange(GenerateTrxSectorEdits());
         injData.TexPages.AddRange(GenerateTrxTexPages());
         injData.SFX.AddRange(GenerateTrxSFXData());
+        injData.ItemNameEdits.AddRange(GenerateTrxItemNameEdits());
 
         using var writer = new BinaryWriterEx(new FileStream(_dest, FileMode.Append));
         TrxInjector.Serialize(injData, writer);
@@ -355,5 +357,27 @@ public partial class LevelCompilerClassicTR
 
         if (sampleCount > _maxSamples)
             _progressReporter.ReportWarn($"{sampleCount} samples included - limit is {_maxSamples}. This may lead to crashes.");
+    }
+
+    private IEnumerable<TrxItemNameEdit> GenerateTrxItemNameEdits()
+    {
+        foreach (var (moveable, index) in _moveablesTable)
+        {
+            if (string.IsNullOrEmpty(moveable.LuaName))
+                continue;
+
+            var name = TrxInjector.Encode(moveable.LuaName);
+            if (name.Length > _maxLuaNameLength)
+            {
+                _progressReporter.ReportWarn($"Lua name for moveable {index} is too long - max {_maxLuaNameLength} bytes.");
+                continue;
+            }
+
+            yield return new()
+            {
+                Index = (short)index,
+                Name = moveable.LuaName,
+            };
+        }
     }
 }

--- a/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using TombLib.IO;
 using TombLib.LevelData.SectorEnums;
 using TombLib.Utils;
@@ -34,6 +35,9 @@ public static class TrxInjector
         outWriter.Write(zippedData.Length);
         outWriter.Write(zippedData);
     }
+
+    public static byte[] Encode(string text)
+        => Encoding.UTF8.GetBytes(text ?? string.Empty);
 
     private static bool WriteData(TrxInjectionData data, BinaryWriterEx writer)
     {
@@ -82,6 +86,8 @@ public static class TrxInjector
             w => data.SectorEdits.ForEach(s => s.Serialize(w)));
         blockCount += WriteBlock(TrxBlockType.TextureOverwrites, data.TexPages.Count, writer,
             w => data.TexPages.ForEach(t => t.Serialize(w)));
+        blockCount += WriteBlock(TrxBlockType.ItemNameEdits, data.ItemNameEdits.Count, writer,
+            w => data.ItemNameEdits.ForEach(t => t.Serialize(w)));
 
         return blockCount;
     }
@@ -141,6 +147,7 @@ public static class TrxInjector
         SoundEffects = 14,
         SectorEdits = 17,
         TextureOverwrites = 20,
+        ItemNameEdits = 37,
     }
 }
 
@@ -149,6 +156,7 @@ public class TrxInjectionData
     public List<TrxSectorEdit> SectorEdits { get; set; } = new();
     public List<TrxTextureOverwrite> TexPages { get; set; } = new();
     public List<TrxSFXData> SFX { get; set; } = new();
+    public List<TrxItemNameEdit> ItemNameEdits = new();
 }
 
 public abstract class TrxSectorEdit
@@ -343,5 +351,19 @@ public class TrxSFXData
             Pitch = details.Pitch,
             Range = details.Range,
         };
+    }
+}
+
+public class TrxItemNameEdit
+{
+    public short Index { get; set; }
+    public string Name { get; set; }
+
+    public void Serialize(BinaryWriterEx writer)
+    {
+        var data = TrxInjector.Encode(Name);
+        writer.Write(Index);
+        writer.Write(data.Length);
+        writer.Write(data);
     }
 }

--- a/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
@@ -178,6 +178,7 @@ namespace TombLib.LevelData.IO
         /**********/public static readonly ChunkId ObjectMovableTombEngine = ChunkId.FromString("TeMovTen");
         /**********/public static readonly ChunkId ObjectMovableTombEngine2 = ChunkId.FromString("TeMovTen2");
         /**********/public static readonly ChunkId ObjectMovableTombEngine3 = ChunkId.FromString("TeMovTn3");
+        /**********/public static readonly ChunkId ObjectMovableTRX = ChunkId.FromString("TeMovTrx");
         /**********/public static readonly ChunkId ObjectItemLuaId = ChunkId.FromString("TeItLuaId"); // DEPRECATED
         /**********/public static readonly ChunkId ObjectStatic = ChunkId.FromString("TeSta");
         /**********/public static readonly ChunkId ObjectStatic2 = ChunkId.FromString("TeSta2");

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -1303,6 +1303,21 @@ namespace TombLib.LevelData.IO
                     addObject(instance);
                     newObjects.TryAdd(objectID, instance);
                 }
+                else if (id3 == Prj2Chunks.ObjectMovableTRX)
+                {
+                    var instance = new MoveableInstance();
+                    instance.Position = chunkIO.Raw.ReadVector3();
+                    instance.RotationY = chunkIO.Raw.ReadSingle();
+                    instance.WadObjectId = new WadMoveableId(chunkIO.Raw.ReadUInt32());
+                    instance.Ocb = chunkIO.Raw.ReadInt16();
+                    instance.Invisible = chunkIO.Raw.ReadBoolean();
+                    instance.ClearBody = chunkIO.Raw.ReadBoolean();
+                    instance.CodeBits = chunkIO.Raw.ReadByte();
+                    instance.Color = chunkIO.Raw.ReadVector3();
+                    instance.LuaName = chunkIO.Raw.ReadStringUTF8();
+                    addObject(instance);
+                    newObjects.TryAdd(objectID, instance);
+                }
                 else if (id3 == Prj2Chunks.ObjectStatic ||
                          id3 == Prj2Chunks.ObjectStatic2)
                 {

--- a/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
@@ -573,6 +573,7 @@ namespace TombLib.LevelData.IO
                 // It's not clear why Monty decided to deviate for 2 different chunk versions.
 
                 var isTEN = level == null || level.IsTombEngine;
+                var isTRX = level != null && level.IsTRX;
 
                 foreach (var o in objects)
                 {
@@ -598,6 +599,21 @@ namespace TombLib.LevelData.IO
                                 chunkIO.Raw.WriteStringUTF8(instance.LuaName != null ? instance.LuaName : "");
                                 WriteLuaProperties(chunkIO, instance.LuaProperties);
                             }
+                        }
+                        else if (isTRX)
+                        {
+                            using var chunk = chunkIO.WriteChunk(Prj2Chunks.ObjectMovableTRX, LEB128.MaximumSize2Byte);
+                            var instance = (MoveableInstance)o;
+                            LEB128.Write(chunkIO.Raw, objectInstanceLookup.TryGetOrDefault(instance, -1));
+                            chunkIO.Raw.Write(instance.Position);
+                            chunkIO.Raw.Write(instance.RotationY);
+                            chunkIO.Raw.Write(instance.WadObjectId.TypeId);
+                            chunkIO.Raw.Write(instance.Ocb);
+                            chunkIO.Raw.Write(instance.Invisible);
+                            chunkIO.Raw.Write(instance.ClearBody);
+                            chunkIO.Raw.Write(instance.CodeBits);
+                            chunkIO.Raw.Write(instance.Color);
+                            chunkIO.Raw.WriteStringUTF8(instance.LuaName ?? string.Empty);
                         }
                         else
                         {

--- a/TombLib/TombLib/LevelData/Instances/ObjectInstance.cs
+++ b/TombLib/TombLib/LevelData/Instances/ObjectInstance.cs
@@ -453,7 +453,7 @@ namespace TombLib.LevelData
         {
             string prefix;
             if (this is MoveableInstance moveable)
-                prefix = moveable.WadObjectId.ShortName(TRVersion.Game.TombEngine).ToLower() + "_";
+                prefix = moveable.WadObjectId.ShortName(Room.Level.Settings.GameVersion.Native()).ToLower() + "_";
             else if (this is StaticInstance)
                 prefix = "static_mesh_";
             else if (this is SinkInstance)
@@ -481,6 +481,13 @@ namespace TombLib.LevelData
             }
         }
 
+        public bool SupportsLuaName()
+        {
+            if (Room?.Level == null)
+                return false;
+            return Room.Level.IsTombEngine || (Room.Level.IsTRX && this is MoveableInstance);
+        }
+
         public bool CanSetLuaName(string newName)
         {
             return (string.IsNullOrEmpty(newName) ||
@@ -494,12 +501,21 @@ namespace TombLib.LevelData
             if (Room == null)
                 return " <NO ROOM>";
 
-            if (shortened)
-                return (Room.Level.IsNG ? (ScriptId.HasValue ? " <" + ScriptId.Value + ">" : "") : "") +
-                       (Room.Level.IsTombEngine ? (!string.IsNullOrEmpty(LuaName) ? " [" + LuaName + "]" : "") : "");
-            else
-                return (Room.Level.IsNG ? (ScriptId.HasValue ? ", Script ID = " + ScriptId.Value : "") : "") +
-                       (Room.Level.IsTombEngine ? (!string.IsNullOrEmpty(LuaName) ? ", Lua name = " + LuaName : "") : "");
+            if (Room.Level.IsNG && ScriptId.HasValue)
+            {
+                return shortened
+                    ? $" <{ScriptId.Value}>"
+                    : $", Script ID = {ScriptId.Value}";
+            }
+            
+            if ((Room.Level.IsTombEngine || Room.Level.IsTRX) && !string.IsNullOrEmpty(LuaName))
+            {
+                return shortened
+                    ? $" [{LuaName}]"
+                    : $", Lua name = {LuaName}";
+            }
+
+            return string.Empty;
         }
     }
 

--- a/TombLib/TombLib/LevelData/LuaScriptID.cs
+++ b/TombLib/TombLib/LevelData/LuaScriptID.cs
@@ -6,6 +6,7 @@ namespace TombLib.LevelData
     {
         string LuaName { get; set; }
         void AllocateNewLuaName();
+        bool SupportsLuaName();
         bool CanSetLuaName(string newScriptId);
     }
 }


### PR DESCRIPTION
This adds support for specifying moveable instance names in TRX levels. It does not extend to other instance types, such as statics, cameras etc as that is not currently supported engine-side.

I've tested with a TRX level, and have also double checked TEN naming functionality given the refactors here.

Ref: https://github.com/LostArtefacts/TRX/pull/5716