### PR TITLE
Add TRX flyby camera support

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -15,6 +15,7 @@ Tomb Editor:
  * Added support for cold and damaging rooms in TRX.
  * Added support for mine cart floor data in TRX.
  * Added support for heavy switch, heavy antitrigger, monkey, climb and crawl trigger types in TRX.
+ * Added support for flyby cameras in TRX.
  * Fixed "Map animated textures" checkbox not unchecking in Level Settings dialog.
  * Fixed occasional exceptions after closing Node Editor.
  * Fixed exception while opening texture lists in Remap Texture dialog.

--- a/TombEditor/Forms/FormFlybyCamera.cs
+++ b/TombEditor/Forms/FormFlybyCamera.cs
@@ -201,6 +201,9 @@ namespace TombEditor.Forms
             if (_editor.Level is null)
                 return false;
 
+            if (_editor.Level.IsTRX)
+                return _editor.Level.Settings.TrxConvertFlybysToCinematicFrames;
+
             return _editor.Level.Settings.GameVersion.Native() <= TRVersion.Game.TR3;
         }
 

--- a/TombEditor/Forms/FormLevelSettings.cs
+++ b/TombEditor/Forms/FormLevelSettings.cs
@@ -522,6 +522,7 @@ namespace TombEditor.Forms
             comboLaraType.Text = _levelSettings.Tr5LaraType.ToString(); // Must also accept none enum values.
             tbLuaPath.Text = _levelSettings.TenLuaScriptFile;
             comboTrxTextureDepth.Text = GetDisplayName(_levelSettings.TrxTextureBitDepth);
+            cbTrxConvertFlybysToCinematicFrames.Checked = _levelSettings.TrxConvertFlybysToCinematicFrames;
 
             fontTextureFilePathOptAuto.Checked = string.IsNullOrEmpty(_levelSettings.FontTextureFilePath);
             fontTextureFilePathOptCustom.Checked = !string.IsNullOrEmpty(_levelSettings.FontTextureFilePath);
@@ -1400,6 +1401,12 @@ namespace TombEditor.Forms
             if (_levelSettings.TrxTextureBitDepth == depth)
                 return;
             _levelSettings.TrxTextureBitDepth = depth;
+            UpdateDialog();
+        }
+
+        private void cbTrxUseFlybysForCinematics_CheckedChanged(object sender, EventArgs e)
+        {
+            _levelSettings.TrxConvertFlybysToCinematicFrames = cbTrxConvertFlybysToCinematicFrames.Checked;
             UpdateDialog();
         }
 

--- a/TombEditor/Forms/FormLevelSettings.designer.cs
+++ b/TombEditor/Forms/FormLevelSettings.designer.cs
@@ -173,6 +173,7 @@
             this.tabTrx = new System.Windows.Forms.TabPage();
             this.comboTrxTextureDepth = new DarkUI.Controls.DarkComboBox();
             this.lblTrxTextureDepth = new DarkUI.Controls.DarkLabel();
+            this.cbTrxConvertFlybysToCinematicFrames = new DarkUI.Controls.DarkCheckBox();
             this.panel6 = new System.Windows.Forms.Panel();
             this.levelFilePathBut = new DarkUI.Controls.DarkButton();
             this.darkLabel6 = new DarkUI.Controls.DarkLabel();
@@ -2021,6 +2022,7 @@
             this.tabTrx.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.tabTrx.Controls.Add(this.comboTrxTextureDepth);
             this.tabTrx.Controls.Add(this.lblTrxTextureDepth);
+            this.tabTrx.Controls.Add(this.cbTrxConvertFlybysToCinematicFrames);
             this.tabTrx.Location = new System.Drawing.Point(4, 22);
             this.tabTrx.Name = "tabTrx";
             this.tabTrx.Size = new System.Drawing.Size(778, 505);
@@ -2037,6 +2039,16 @@
             this.comboTrxTextureDepth.Size = new System.Drawing.Size(81, 23);
             this.comboTrxTextureDepth.TabIndex = 4;
             this.comboTrxTextureDepth.SelectedIndexChanged += new System.EventHandler(this.comboTrxTextureDepth_SelectedIndexChanged);
+            // 
+            // cbTrxConvertFlybysToCinematicFrames
+            // 
+            this.cbTrxConvertFlybysToCinematicFrames.AutoSize = true;
+            this.cbTrxConvertFlybysToCinematicFrames.Location = new System.Drawing.Point(3, 40);
+            this.cbTrxConvertFlybysToCinematicFrames.Name = "cbTrxConvertFlybysToCinematicFrames";
+            this.cbTrxConvertFlybysToCinematicFrames.Size = new System.Drawing.Size(120, 17);
+            this.cbTrxConvertFlybysToCinematicFrames.Tag = "";
+            this.cbTrxConvertFlybysToCinematicFrames.Text = "Convert flyby cameras into cinematic frames";
+            this.cbTrxConvertFlybysToCinematicFrames.CheckedChanged += new System.EventHandler(this.cbTrxUseFlybysForCinematics_CheckedChanged);
             // 
             // lblTrxTextureDepth
             // 
@@ -2432,6 +2444,7 @@
         private System.Windows.Forms.TabPage tabTrx;
         private DarkUI.Controls.DarkComboBox comboTrxTextureDepth;
         private DarkUI.Controls.DarkLabel lblTrxTextureDepth;
+        private DarkUI.Controls.DarkCheckBox cbTrxConvertFlybysToCinematicFrames;
         private TombLib.Controls.DarkDataGridViewControls textureFileDataGridViewControls;
         private System.Windows.Forms.DataGridViewTextBoxColumn objectFileDataGridViewPathColumn;
         private DarkUI.Controls.DarkDataGridViewButtonColumn objectFileDataGridViewSearchColumn;

--- a/TombLib/TombLib/LevelData/Compilers/LevelCompilerClassicTR.cs
+++ b/TombLib/TombLib/LevelData/Compilers/LevelCompilerClassicTR.cs
@@ -586,6 +586,9 @@ namespace TombLib.LevelData.Compilers
         {
             var result = new List<tr_cinematicFrame>();
 
+            if (_level.IsTRX && !_level.Settings.TrxConvertFlybysToCinematicFrames)
+                return result;
+
             var allObjects = _level.GetAllObjects().OfType<PositionBasedObjectInstance>().ToList();
             if (allObjects.Count == 0)
                 return result;

--- a/TombLib/TombLib/LevelData/Compilers/Trx.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Trx.cs
@@ -32,12 +32,21 @@ public partial class LevelCompilerClassicTR
         ReportProgress(98, "Writing TRX data");
 
         var injData = new TrxInjectionData();
+        injData.FlybyCameras.AddRange(GenerateFlybyCameras());
         injData.SectorEdits.AddRange(GenerateTrxSectorEdits());
         injData.TexPages.AddRange(GenerateTrxTexPages());
         injData.SFX.AddRange(GenerateTrxSFXData());
 
         using var writer = new BinaryWriterEx(new FileStream(_dest, FileMode.Append));
         TrxInjector.Serialize(injData, writer);
+    }
+
+    private IEnumerable<tr4_flyby_camera> GenerateFlybyCameras()
+    {
+        if (_level.Settings.TrxConvertFlybysToCinematicFrames)
+            yield break;
+        foreach (var flyby in _flyByCameras)
+            yield return flyby;
     }
 
     private IEnumerable<TrxSectorEdit> GenerateTrxSectorEdits()

--- a/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
@@ -39,6 +39,7 @@ public static class TrxInjector
     {
         var chunks = new List<TrxChunk>()
         {
+            CreateChunk(TrxChunkType.CameraData, data, WriteCameraData),
             CreateChunk(TrxChunkType.DataEdits, data, WriteEdits),
             CreateChunk(TrxChunkType.SFX, data, WriteSFXData),
         };
@@ -72,6 +73,32 @@ public static class TrxInjector
             BlockCount = blockCount,
             Data = stream.ToArray(),
         };
+    }
+
+    private static int WriteCameraData(TrxInjectionData data, BinaryWriterEx writer)
+    {
+        int blockCount = 0;
+
+        blockCount += WriteBlock(TrxBlockType.FlybyCameras, data.FlybyCameras.Count, writer,
+            w => data.FlybyCameras.ForEach(c =>
+            {
+                w.Write(c.X);
+                w.Write(c.Y);
+                w.Write(c.Z);
+                w.Write(c.DirectionX);
+                w.Write(c.DirectionY);
+                w.Write(c.DirectionZ);
+                w.Write(c.Sequence);
+                w.Write(c.Index);
+                w.Write(c.FOV);
+                w.Write(c.Roll);
+                w.Write(c.Timer);
+                w.Write(c.Speed);
+                w.Write(c.Flags);
+                w.Write(c.Room);
+            }));
+
+        return blockCount;
     }
 
     private static int WriteEdits(TrxInjectionData data, BinaryWriterEx writer)
@@ -134,6 +161,7 @@ public static class TrxInjector
     {
         SFX = 5,
         DataEdits = 6,
+        CameraData = 7,
     }
 
     private enum TrxBlockType
@@ -141,11 +169,13 @@ public static class TrxInjector
         SoundEffects = 14,
         SectorEdits = 17,
         TextureOverwrites = 20,
+        FlybyCameras = 38,
     }
 }
 
 public class TrxInjectionData
 {
+    public List<tr4_flyby_camera> FlybyCameras { get; set; } = new();
     public List<TrxSectorEdit> SectorEdits { get; set; } = new();
     public List<TrxTextureOverwrite> TexPages { get; set; } = new();
     public List<TrxSFXData> SFX { get; set; } = new();

--- a/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Chunks.cs
@@ -44,6 +44,7 @@ namespace TombLib.LevelData.IO
         /**/public static readonly ChunkId TexturePadding = ChunkId.FromString("TeTexturePadding");
         /**/public static readonly ChunkId TextureCompression = ChunkId.FromString("TeTextureCompression");
         /**/public static readonly ChunkId TrxTextureBitDepth = ChunkId.FromString("TeTrxTextureDepth");
+        /**/public static readonly ChunkId TrxConvertFlybysToCinematicFrames = ChunkId.FromString("TeTrxConvertFlybysToCinematicFrames");
         /**/public static readonly ChunkId AgressiveTexturePacking = ChunkId.FromString("TeAgressiveTexturePacking");
         /**/public static readonly ChunkId AgressiveFloordataPacking = ChunkId.FromString("TeAgressiveFloordataPacking");
         /**/public static readonly ChunkId RemapAnimatedTextures = ChunkId.FromString("TeRemapAnimTextures");

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -317,6 +317,8 @@ namespace TombLib.LevelData.IO
                     settings.CompressTextures = chunkIO.ReadChunkBool(chunkSize);
                 else if (id == Prj2Chunks.TrxTextureBitDepth)
                     settings.TrxTextureBitDepth = (TrxTextureBitDepth)chunkIO.ReadChunkInt(chunkSize);
+                else if (id == Prj2Chunks.TrxConvertFlybysToCinematicFrames)
+                    settings.TrxConvertFlybysToCinematicFrames = chunkIO.ReadChunkBool(chunkSize);
                 else if (id == Prj2Chunks.RearrangeRooms)
                     settings.RearrangeVerticalRooms = chunkIO.ReadChunkBool(chunkSize);
                 else if (id == Prj2Chunks.RemoveUnusedObjects)

--- a/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
@@ -175,6 +175,7 @@ namespace TombLib.LevelData.IO
                 chunkIO.WriteChunkBool(Prj2Chunks.AgressiveTexturePacking, settings.AgressiveTexturePacking);
                 chunkIO.WriteChunkBool(Prj2Chunks.TextureCompression, settings.CompressTextures);
                 chunkIO.WriteChunkInt(Prj2Chunks.TrxTextureBitDepth, (int)settings.TrxTextureBitDepth);
+                chunkIO.WriteChunkBool(Prj2Chunks.TrxConvertFlybysToCinematicFrames, settings.TrxConvertFlybysToCinematicFrames);
                 chunkIO.WriteChunkBool(Prj2Chunks.AgressiveFloordataPacking, settings.AgressiveFloordataPacking);
                 chunkIO.WriteChunkVector3(Prj2Chunks.DefaultAmbientLight, settings.DefaultAmbientLight);
                 chunkIO.WriteChunkInt(Prj2Chunks.DefaultLightQuality, (long)settings.DefaultLightQuality);

--- a/TombLib/TombLib/LevelData/LevelSettings.cs
+++ b/TombLib/TombLib/LevelData/LevelSettings.cs
@@ -232,6 +232,7 @@ namespace TombLib.LevelData
 
         // For TRX only
         public TrxTextureBitDepth TrxTextureBitDepth { get; set; } = TrxTextureBitDepth.Default;
+        public bool TrxConvertFlybysToCinematicFrames { get; set; } = false;
 
         public LevelSettings Clone()
         {

--- a/TombLib/TombLib/NG/NgParameterInfo.cs
+++ b/TombLib/TombLib/NG/NgParameterInfo.cs
@@ -75,7 +75,8 @@ namespace TombLib.NG
                 yield return TriggerTargetType.FlipEffect;
                 yield return TriggerTargetType.Secret;
 
-                if (levelSettings.GameVersion.Native() >= TRVersion.Game.TR4)
+                if (levelSettings.GameVersion.Native() >= TRVersion.Game.TR4
+                    || (levelSettings.GameVersion.IsTRX() && !levelSettings.TrxConvertFlybysToCinematicFrames))
                     yield return TriggerTargetType.FlyByCamera;
                 if (levelSettings.GameVersion == TRVersion.Game.TRNG)
                 {


### PR DESCRIPTION
This allows TRX levels to use flyby cameras. An option is provided to revert to having them converted to cinematic frames.

Refs:
https://github.com/LostArtefacts/TRX/pull/5741
https://github.com/LostArtefacts/TRX/pull/5746