### PR TITLE
Add TRX property system support

### DIFF
--- a/Installer/Changes.txt
+++ b/Installer/Changes.txt
@@ -18,6 +18,7 @@ Tomb Editor:
  * Added support for heavy switch, heavy antitrigger, monkey, climb and crawl trigger types in TRX.
  * Added support for flyby cameras in TRX.
  * Added support for specifying moveable instance names in TRX.
+ * Added support for moveable item properties in TRX levels; refer to LostArtefacts documentation.
  * Fixed "Map animated textures" checkbox not unchecking in Level Settings dialog.
  * Fixed occasional exceptions after closing Node Editor.
  * Fixed exception while opening texture lists in Remap Texture dialog.

--- a/TombEditor/ToolWindows/ItemProperties.cs
+++ b/TombEditor/ToolWindows/ItemProperties.cs
@@ -91,8 +91,8 @@ namespace TombEditor.ToolWindows
         {
             var selected = _editor.SelectedObject;
 
-            // Only show for TombEngine levels.
-            if (!_editor.Level.IsTombEngine)
+            // Only show for TombEngine and TRX levels.
+            if (!_editor.Level.IsTombEngine && !_editor.Level.IsTRX)
             {
                 _viewModel.Clear();
                 _viewModel.Title = "Item Properties";
@@ -104,8 +104,10 @@ namespace TombEditor.ToolWindows
             if (selected is MoveableInstance moveable)
             {
                 _currentObject = moveable;
-                var typeId = moveable.WadObjectId.TypeId;
-                var definitions = LuaPropertyCatalog.GetDefinitions(ObjectKind.Moveable, typeId);
+                var typeId = _editor.Level.IsTombEngine
+                    ? moveable.WadObjectId.TypeId
+                    : TrCatalog.GetSubstituteID(_editor.Level.Settings.GameVersion, moveable.WadObjectId.TypeId);
+                var definitions = LuaPropertyCatalog.GetDefinitions(ObjectKind.Moveable, typeId, _editor.Level.Settings.GameVersion);
 
                 // Get wad2 global defaults for this moveable type (if available).
                 var wadMoveable = _editor.Level.Settings.WadTryGetMoveable(moveable.WadObjectId);
@@ -127,7 +129,7 @@ namespace TombEditor.ToolWindows
             {
                 _currentObject = staticObj;
                 var typeId = staticObj.WadObjectId.TypeId;
-                var definitions = LuaPropertyCatalog.GetDefinitions(ObjectKind.Static, typeId);
+                var definitions = LuaPropertyCatalog.GetDefinitions(ObjectKind.Static, typeId, _editor.Level.Settings.GameVersion);
 
                 // Get wad2 global defaults for this static type (if available).
                 var wadStatic = _editor.Level.Settings.WadTryGetStatic(staticObj.WadObjectId);

--- a/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR1X/Default.xml
+++ b/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR1X/Default.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<propertyCatalog>
+    <moveable id="0,6">
+        <property category="TRX" defaultValue="1000" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="7">
+        <property category="TRX" defaultValue="6" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="8">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="3" description="Damage dealt while the bear charges into Lara." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt if the falling bear slams into Lara." displayName="Slam Damage" internalName="slam_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the bear bite attack." displayName="Attack Damage" internalName="attack_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="400" description="Damage dealt by the bear paw swipe." displayName="Pat Damage" internalName="pat_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="9">
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="2" description="Damage dealt by the bat attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="10">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the crocodile bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="11">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the alligator bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="12">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="13">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="14">
+        <property category="TRX" defaultValue="45" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="15">
+        <property category="TRX" defaultValue="22" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the ape bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="16,17">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the charge attack." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="18,25">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt while trampling." displayName="Trample Damage" internalName="trample_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="19">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the charge attack." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="20-22">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the atlantean's charge attack." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the atlantean's lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the atlantean's punch attack." displayName="Punch Damage" internalName="punch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the atlantean's exploding body parts." displayName="Part Damage" internalName="part_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="23">
+        <property category="TRX" defaultValue="120" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the centaur rear attack." displayName="Rear Damage" internalName="rear_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the centaur death explosion." displayName="Part Damage" internalName="part_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="24">
+        <property category="TRX" defaultValue="18" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="26">
+        <property category="TRX" defaultValue="12" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the barracuda bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="27">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by Larson's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="28">
+        <property category="TRX" defaultValue="70" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="30">
+        <property category="TRX" defaultValue="125" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by shots while stopped." displayName="Stop Shot Damage" internalName="stop_shot_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by shots while skating." displayName="Skate Shot Damage" internalName="skate_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="31">
+        <property category="TRX" defaultValue="150" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="70" description="Damage dealt by the cowboy's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="32">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by Baldy's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="33">
+        <property category="TRX" defaultValue="400" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="34">
+        <property category="TRX" defaultValue="500" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="500" description="Damage dealt by swipe attacks." displayName="Attack Damage" internalName="attack_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the death explosion." displayName="Part Damage" internalName="part_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="36">
+        <property category="TRX" defaultValue="100" description="Damage dealt while Lara is touching the swinging axe." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="37">
+        <property category="TRX" defaultValue="15" description="Damage dealt when Lara hits the spikes without dying instantly." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="38">
+        <property category="TRX" defaultValue="100" description="Damage dealt when Lara is clipped by a moving boulder without being crushed." displayName="Air Damage" internalName="air_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="39">
+        <property category="TRX" defaultValue="50" description="Damage dealt on hit." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="false" description="Apply poison buildup in addition to hit damage." displayName="Poison" internalName="poison" type="Bool" />
+    </moveable>
+    <moveable id="42">
+        <property category="TRX" defaultValue="400" description="Damage dealt while Lara is caught in the teeth trap." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="43">
+        <property category="TRX" defaultValue="100" description="Damage dealt when Lara is struck by the falling Damocles sword." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="46">
+        <property category="TRX" defaultValue="400" description="Damage dealt when Lara is struck by the lightning emitter." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="53,54">
+        <property category="TRX" defaultValue="300" description="Damage dealt while Lara is touching the falling ceiling." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="57-64">
+        <property category="TRX" defaultValue="false" description="Whether the door must be pried open with the crowbar." displayName="Crowbar" internalName="crowbar" type="Bool" />
+        <property category="TRX" defaultValue="false" description="Whether the door rises vertically while activated instead of playing its open animation." displayName="Lift" internalName="lift" type="Bool" />
+    </moveable>
+    <moveable id="65-67">
+        <property category="TRX" defaultValue="true" description="Whether the trapdoor opens automatically when triggered." displayName="Auto Open" internalName="auto_open" type="Bool" />
+    </moveable>
+    <moveable id="77-80,191">
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="84-94,110-113,126,129-132,141,142,144,187,241-246,248,249,251-256">
+        <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal" internalName="pickup_mode" type="Enum" />
+    </moveable>
+    <moveable id="145">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="162">
+        <property category="TRX" defaultValue="3" description="The flip map slot to alter once the cabin has landed. -1 = no flipmap is performed." displayName="Flip Slot" internalName="flip_slot" maxValue="10" minValue="-1" type="Int" />
+    </moveable>
+    <moveable id="180">
+        <property category="TRX" defaultValue="25" description="Offset applied each frame while the lava wedge advances." displayName="Speed" internalName="speed" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="193">
+        <property category="TRX" defaultValue="60" description="How long the flare burns for, in seconds." displayName="Burn Time" internalName="burn_time" minValue="0" type="Float" />
+    </moveable>
+</propertyCatalog>

--- a/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR1X/Example.xml
+++ b/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR1X/Example.xml
@@ -1,0 +1,507 @@
+<?xml version="1.0" encoding="utf-8"?>
+<propertyCatalog>
+    <!--placeholder for O_AI_AMBUSH..O_AI_X3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="0" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_ANIMATING_1..O_ANIMATING_16-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether or not Lara can collide with the animating." displayName="Collidable" internalName="collidable" type="Bool" />
+    </moveable>
+    <!--placeholder for O_ANIMATING_EXT_1..O_ANIMATING_EXT_10-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="false" description="Kill the item immediately while its trigger is inactive." displayName="Kill On Trigger" internalName="kill_on_trigger" type="Bool" />
+    </moveable>
+    <!--placeholder for O_ASSAULT_TARGET-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="8" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BANDIT_1-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="45" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by the bandit's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BANDIT_2..O_BANDIT_2B-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the bandit's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BARRACUDA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="12" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the barracuda bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BIG_BOWL-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="7" description="The amount of time hot liquid is poured from the bowl, in seconds." displayName="Pour Time" internalName="pour_time" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="4" description="The flip map slot to alter once liquid has finished pouring. -1 = no flipmap is performed." displayName="Flip Slot" internalName="flip_slot" maxValue="10" minValue="-1" type="Int" />
+    </moveable>
+    <!--placeholder for O_BIG_EEL-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="500" description="Damage dealt by the big eel bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BIG_SPIDER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="40" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the big spider bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BINOCULARS_ITEM..O_WATERSKIN_2_EMPTY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal" internalName="pickup_mode" type="Enum" />
+    </moveable>
+    <!--placeholder for O_BIRD_GUARDIAN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the bird guardian punch." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BLADE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Damage dealt while Lara is touching the blade trap." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BOAT..O_UPV-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+    </moveable>
+    <!--placeholder for O_CEILING_SPIKES-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="5" description="Offset applied each frame while the ceiling spikes descend." displayName="Speed" internalName="speed" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt while Lara is touching the ceiling spikes." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CEILING_TRAPDOOR_1..O_FLOOR_TRAPDOOR_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether the trapdoor opens automatically when triggered." displayName="Auto Open" internalName="auto_open" type="Bool" />
+    </moveable>
+    <!--placeholder for O_CIVILIAN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="15" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by the civilian's first punch attack." displayName="Punch 1 Damage" internalName="punch_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by the civilian's second punch attack." displayName="Punch 2 Damage" internalName="punch_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the civilian's third punch attack." displayName="Punch 3 Damage" internalName="punch_3_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CLAW_MUTANT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="130" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the claw mutant melee attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the claw mutant plasma ball." displayName="Plasma Ball Damage" internalName="plasma_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_COBRA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="8" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by the cobra bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1.5" description="Alert radius, in sectors." displayName="Alert Radius" internalName="alert_radius" minValue="0" type="Float" />
+        <property category="TRX" defaultValue="1" description="Attack radius, in sectors." displayName="Attack Radius" internalName="attack_radius" minValue="0" type="Float" />
+        <property category="TRX" defaultValue="3" description="Forget radius, in sectors." displayName="Forget Radius" internalName="forget_radius" minValue="0" type="Float" />
+    </moveable>
+    <!--placeholder for O_COMPY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="10" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="90" description="Damage dealt by the compy attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CRAWLER_MUTANT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CROW-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="15" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bird attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CULT_1..O_CULT_1B-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the cultist's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CULT_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="60" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CULT_3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="150" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the cultist's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_DISC-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Damage dealt on hit." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="false" description="Apply poison buildup in addition to hit damage." displayName="Poison" internalName="poison" type="Bool" />
+    </moveable>
+    <!--placeholder for O_DIVER..O_WINSTON_ARMY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_DOG-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="10" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the dog bite." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the dog's lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_DRAGON_FRONT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="300" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt while Lara is touching the dragon." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the dragon swipe attack." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_EAGLE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bird attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_EEL-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the eel bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_FLAME_EMITTER_SIDE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="2" description="Interval between flame bursts, in seconds." displayName="Interval" internalName="interval" minValue="0" type="Float" />
+    </moveable>
+    <!--placeholder for O_GENERIC_TRAP_1..O_GENERIC_TRAP_10-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="-1" description="A bitmask of damaging mesh numbers. The default value indicates all meshes are damaging." displayName="Touch Mask" internalName="touch_mask" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt when Lara touches the trap." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="3" description="The intensity of blood to spawn when Lara is damaged." displayName="Blood Intensity" internalName="blood_intensity" maxValue="10" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not Lara should be pushed when colliding with the trap." displayName="Push Lara" internalName="push_lara" type="Bool" />
+    </moveable>
+    <!--placeholder for O_HOOK-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Damage dealt while Lara is touching the hook." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_HUSKIE..O_PATROL_DOG-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="16" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="12" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_HYBRID_MUTANT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="90" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the hybrid mutant jump attack." displayName="Jump Damage" internalName="jump_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the hybrid mutant slash attack." displayName="Slash Damage" internalName="slash_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by the hybrid mutant kick attack." displayName="Kick Damage" internalName="kick_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_ICICLE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="200" description="Damage dealt when Lara is struck by the falling icicle." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_JELLY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="10" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt by the jelly sting." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_KILLER_STATUE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Damage dealt while Lara is struck by the killer statue." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_LIFT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="3" description="The time to wait before the lift begins moving, in seconds." displayName="Wait Time" internalName="wait_time" minValue="1" type="Int" />
+        <property category="TRX" defaultValue="22" description="The vertical distance the lift will travel, in clicks." displayName="Travel Distance" internalName="travel_distance" minValue="1" type="Int" />
+        <property category="TRX" defaultValue="16" description="The speed at which the lift moves, in world units." displayName="Speed" internalName="speed" maxValue="64" minValue="1" type="Int" />
+    </moveable>
+    <!--placeholder for O_LIZARD-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="36" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the lizard bite." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="120" description="Damage dealt by the lizard swipe attack." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_MINE_CART-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+    </moveable>
+    <!--placeholder for O_MONKEY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="8" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the jumping bite attack." displayName="Jump Damage" internalName="jump_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_MONK_1..O_MONK_3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by melee attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt by melee attacks against non-player targets." displayName="Enemy Damage" internalName="enemy_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_MOUSE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="4" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bite attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_MP_1-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punch 1." displayName="Punch 1 Damage" internalName="punch_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punch 2." displayName="Punch 2 Damage" internalName="punch_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by punch 3." displayName="Punch 3 Damage" internalName="punch_3_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the kick attack." displayName="Kick Damage" internalName="kick_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_MP_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by gun shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_PENDULUM_1..O_PENDULUM_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Damage dealt while Lara is touching the pendulum." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_PIRAHNAS-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="TEN.Vec3(1, 1, 1)" description="Swim range, in quarter tiles." displayName="Range" internalName="range" type="Vec3" />
+        <property category="TRX" defaultValue="True" description="Whether the shoal uses the surrounding room lighting." displayName="Use Room Lighting" internalName="use_room_lighting" type="Bool" />
+    </moveable>
+    <!--placeholder for O_PLAYER_5..O_SECURITY_LASER_KILLER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_POISON_DART-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Damage dealt on hit." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="true" description="Apply poison buildup in addition to hit damage." displayName="Poison" internalName="poison" type="Bool" />
+    </moveable>
+    <!--placeholder for O_PRISONER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by punch 1." displayName="Punch 1 Damage" internalName="punch_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by punch 2." displayName="Punch 2 Damage" internalName="punch_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by punch 3." displayName="Punch 3 Damage" internalName="punch_3_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_PROPELLER_1..O_PROPELLER_3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="200" description="Damage dealt while Lara is touching the propeller." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_PUNK_1..O_PUNK_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punches 1 and 2." displayName="Hit Damage" internalName="hit_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by punch 3." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_QUAD_BIKE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+        <property category="TRX" defaultValue="false" description="Whether or not this vehicle can collide with static meshes." displayName="Test Static Collision" internalName="test_static_collision" type="Bool" />
+    </moveable>
+    <!--placeholder for O_RIB-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+    </moveable>
+    <!--placeholder for O_ROLLING_BALL_2..O_ROLLING_BALL_4-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Damage dealt when Lara is clipped by a moving boulder without being crushed." displayName="Air Damage" internalName="air_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_ROTATING_LASER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Damage dealt while Lara is touching the rotating laser." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_RX_WORKER_1-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="34" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="35" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_RX_WORKER_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="28" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_RX_WORKER_3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="36" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SECURITY_GUARD-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="64" description="Damage dealt by the death-state final shot." displayName="Final Shot Damage" internalName="final_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SECURITY_LASER_DEADLY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="10" description="Damage dealt when Lara crosses the security laser." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SENTRY_GUN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="10" description="Damage dealt when the sentry gun hits Lara." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SHARK-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="400" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SHIVA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pincer attack." displayName="Pincer Damage" internalName="pincer_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="180" description="Damage dealt by the chopper attack." displayName="Chopper Damage" internalName="chopper_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SKIDOO_ARMED-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SKIDOO_DRIVER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by shots when Lara is not mounted." displayName="Shot Damage" internalName="shot_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt by shots when Lara is mounted." displayName="Mounted Shot Damage" internalName="mounted_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SKIDOO_FAST-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random battle music track pool, slot 1. -1 = disabled." displayName="Battle Track 1" internalName="battle_track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random battle music track pool, slot 2. -1 = disabled." displayName="Battle Track 2" internalName="battle_track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random battle music track pool, slot 3. -1 = disabled." displayName="Battle Track 3" internalName="battle_track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random battle music track pool, slot 4. -1 = disabled." displayName="Battle Track 4" internalName="battle_track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+        <property category="TRX" defaultValue="false" description="Whether or not this vehicle can collide with static meshes." displayName="Test Static Collision" internalName="test_static_collision" type="Bool" />
+    </moveable>
+    <!--placeholder for O_SOPHIA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="300" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the knockback shockwave." displayName="Knockback Damage" internalName="knockback_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="30" description="Damage dealt by regular laser bolt direct hits." displayName="Laser Bolt Damage" internalName="laser_bolt_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="542" description="Damage dealt by the big laser bolt direct hit." displayName="Big Laser Bolt Damage" internalName="big_laser_bolt_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="16" description="Maximum splash damage dealt by regular laser bolts." displayName="Laser Bolt Splash Damage" internalName="laser_bolt_splash_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="64" description="Maximum splash damage dealt by the big laser bolt." displayName="Big Laser Bolt Splash Damage" internalName="big_laser_bolt_splash_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="25" description="Damage dealt by plasma ball direct hits." displayName="Plasma Ball Damage" internalName="plasma_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SPIDER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="25" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SPIKE_WALL-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="16" description="Offset applied each frame while the spike wall advances." displayName="Speed" internalName="speed" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt while Lara is touching the spike wall." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SPINNING_BLADE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Damage dealt while Lara is touching the spinning blade." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_STHPAC_MERCENARY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="28" description="Damage dealt by the mercenary's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_STROBE_LIGHT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="false" description="Require an alert event before the light activates." displayName="Requires Alarm Active" internalName="requires_alarm_active" type="Bool" />
+    </moveable>
+    <!--placeholder for O_SWAT_1..O_SWAT_3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="45" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="28" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="84" description="Damage dealt by the death-state final shot." displayName="Final Shot Damage" internalName="final_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TIGER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TONY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by direct fire ball hits." displayName="Fire Ball Damage" internalName="fire_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TREX_ALPHA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="800" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt while trampling." displayName="Trample Damage" internalName="trample_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt to raptors by the bite attack." displayName="Raptor Damage" internalName="raptor_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TRIBE_AXEMAN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by attack 2." displayName="Attack 2 Damage" internalName="attack_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by attack 3." displayName="Attack 3 Damage" internalName="attack_3_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by attack 4." displayName="Attack 4 Damage" internalName="attack_4_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by attack 5." displayName="Attack 5 Damage" internalName="attack_5_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by attack 6." displayName="Attack 6 Damage" internalName="attack_6_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="2" description="Damage dealt to non-player targets." displayName="Enemy Damage" internalName="enemy_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TRIBE_BOSS-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by the head electric beam." displayName="Head Beam Damage" internalName="head_beam_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TRIBE_PIPEMAN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by melee attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt to non-player targets." displayName="Enemy Damage" internalName="enemy_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TROPICAL_FISH-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="0" description="Texture offset in `O_TROPICAL_FISH_GFX`." displayName="Sprite Offset" internalName="sprite_offset" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="TEN.Vec3(1, 1, 1)" description="Swim range, in quarter tiles." displayName="Range" internalName="range" type="Vec3" />
+        <property category="TRX" defaultValue="True" description="Whether the shoal uses the surrounding room lighting." displayName="Use Room Lighting" internalName="use_room_lighting" type="Bool" />
+    </moveable>
+    <!--placeholder for O_VULTURE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="18" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bird attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WASP_MUTANT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="24" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the sting attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WILLARD-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="220" description="Damage dealt by bite attacks." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="440" description="Damage dealt by the lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by direct plasma ball hits." displayName="Plasma Ball Damage" internalName="plasma_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WORKER_1-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by gun shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WORKER_2..O_WORKER_5-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="30" description="Damage dealt by gun shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WORKER_3..O_WORKER_4-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="27" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punch attacks." displayName="Hit Damage" internalName="hit_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the swipe attack." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_XIAN_KNIGHT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="80" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="300" description="Damage dealt by sword slashes." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_XIAN_SPEARMAN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="75" description="Damage dealt by attack 1." displayName="Hit 1 Damage" internalName="hit_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="75" description="Damage dealt by attacks 2 to 4." displayName="Hit 2 Damage" internalName="hit_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="75" description="Damage dealt by attack 5." displayName="Hit 5 Damage" internalName="hit_5_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="120" description="Damage dealt by attack 6." displayName="Hit 6 Damage" internalName="hit_6_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_YETI-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by attack 1." displayName="Punch Damage" internalName="punch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by attack 2." displayName="Thump Damage" internalName="thump_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by attack 3." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+    </moveable>
+</propertyCatalog>

--- a/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR2X/Default.xml
+++ b/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR2X/Default.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="utf-8"?>
+<propertyCatalog>
+    <moveable id="0">
+        <property category="TRX" defaultValue="1000" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="13">
+        <property category="TRX" defaultValue="48" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="49" description="Random battle music track pool, slot 1. -1 = disabled." displayName="Battle Track 1" internalName="battle_track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random battle music track pool, slot 2. -1 = disabled." displayName="Battle Track 2" internalName="battle_track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random battle music track pool, slot 3. -1 = disabled." displayName="Battle Track 3" internalName="battle_track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random battle music track pool, slot 4. -1 = disabled." displayName="Battle Track 4" internalName="battle_track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+        <property category="TRX" defaultValue="false" description="Whether or not this vehicle can collide with static meshes." displayName="Test Static Collision" internalName="test_static_collision" type="Bool" />
+    </moveable>
+    <moveable id="14">
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+    </moveable>
+    <moveable id="15">
+        <property category="TRX" defaultValue="10" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the dog bite." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the dog's lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="16-18">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the cultist's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="19">
+        <property category="TRX" defaultValue="60" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="20">
+        <property category="TRX" defaultValue="150" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the cultist's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="21">
+        <property category="TRX" defaultValue="4" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bite attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="22">
+        <property category="TRX" defaultValue="300" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt while Lara is touching the dragon." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the dragon swipe attack." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="25">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="400" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="26">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the eel bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="27">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="500" description="Damage dealt by the big eel bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="28">
+        <property category="TRX" defaultValue="12" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the barracuda bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="29">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="30">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by gun shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="31,34">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="30" description="Damage dealt by gun shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="32,33">
+        <property category="TRX" defaultValue="27" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punch attacks." displayName="Hit Damage" internalName="hit_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the swipe attack." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="35">
+        <property category="TRX" defaultValue="10" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt by the jelly sting." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="36">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="25" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="37">
+        <property category="TRX" defaultValue="40" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the big spider bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="38">
+        <property category="TRX" defaultValue="15" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bird attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="39">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="41">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="75" description="Damage dealt by attack 1." displayName="Hit 1 Damage" internalName="hit_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="75" description="Damage dealt by attacks 2 to 4." displayName="Hit 2 Damage" internalName="hit_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="75" description="Damage dealt by attack 5." displayName="Hit 5 Damage" internalName="hit_5_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="120" description="Damage dealt by attack 6." displayName="Hit 6 Damage" internalName="hit_6_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="43">
+        <property category="TRX" defaultValue="80" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="300" description="Damage dealt by sword slashes." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="45">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by attack 1." displayName="Punch Damage" internalName="punch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by attack 2." displayName="Thump Damage" internalName="thump_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by attack 3." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="46">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the bird guardian punch." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="47">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bird attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="48">
+        <property category="TRX" defaultValue="45" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by the bandit's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="49,50">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the bandit's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="51">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="52">
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by shots when Lara is not mounted." displayName="Shot Damage" internalName="shot_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt by shots when Lara is mounted." displayName="Mounted Shot Damage" internalName="mounted_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="53,54,267">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by melee attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt by melee attacks against non-player targets." displayName="Enemy Damage" internalName="enemy_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="58,96">
+        <property category="TRX" defaultValue="50" description="Damage dealt while Lara is touching the pendulum." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="59">
+        <property category="TRX" defaultValue="15" description="Damage dealt when Lara hits the spikes without dying instantly." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="60,83,101">
+        <property category="TRX" defaultValue="100" description="Damage dealt when Lara is clipped by a moving boulder without being crushed." displayName="Air Damage" internalName="air_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="61">
+        <property category="TRX" defaultValue="50" description="Damage dealt on hit." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="false" description="Apply poison buildup in addition to hit damage." displayName="Poison" internalName="poison" type="Bool" />
+    </moveable>
+    <moveable id="64">
+        <property category="TRX" defaultValue="400" description="Damage dealt while Lara is caught in the teeth trap." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="65">
+        <property category="TRX" defaultValue="3" description="The time to wait before the lift begins moving, in seconds." displayName="Wait Time" internalName="wait_time" minValue="1" type="Int" />
+        <property category="TRX" defaultValue="22" description="The vertical distance the lift will travel, in clicks." displayName="Travel Distance" internalName="travel_distance" minValue="1" type="Int" />
+        <property category="TRX" defaultValue="16" description="The speed at which the lift moves, in world units." displayName="Speed" internalName="speed" maxValue="64" minValue="1" type="Int" />
+    </moveable>
+    <moveable id="71">
+        <property category="TRX" defaultValue="7" description="The amount of time hot liquid is poured from the bowl, in seconds." displayName="Pour Time" internalName="pour_time" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="4" description="The flip map slot to alter once liquid has finished pouring. -1 = no flipmap is performed." displayName="Flip Slot" internalName="flip_slot" maxValue="10" minValue="-1" type="Int" />
+    </moveable>
+    <moveable id="76,94,95">
+        <property category="TRX" defaultValue="200" description="Damage dealt while Lara is touching the propeller." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="78">
+        <property category="TRX" defaultValue="50" description="Damage dealt while Lara is touching the hook." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="79">
+        <property category="TRX" defaultValue="300" description="Damage dealt while Lara is touching the falling ceiling." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="80">
+        <property category="TRX" defaultValue="100" description="Damage dealt while Lara is touching the spinning blade." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="81">
+        <property category="TRX" defaultValue="100" description="Damage dealt while Lara is touching the blade trap." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="82">
+        <property category="TRX" defaultValue="20" description="Damage dealt while Lara is struck by the killer statue." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="84">
+        <property category="TRX" defaultValue="200" description="Damage dealt when Lara is struck by the falling icicle." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="85">
+        <property category="TRX" defaultValue="16" description="Offset applied each frame while the spike wall advances." displayName="Speed" internalName="speed" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt while Lara is touching the spike wall." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="87">
+        <property category="TRX" defaultValue="5" description="Offset applied each frame while the ceiling spikes descend." displayName="Speed" internalName="speed" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt while Lara is touching the ceiling spikes." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="106-113">
+        <property category="TRX" defaultValue="false" description="Whether the door must be pried open with the crowbar." displayName="Crowbar" internalName="crowbar" type="Bool" />
+        <property category="TRX" defaultValue="false" description="Whether the door rises vertically while activated instead of playing its open animation." displayName="Lift" internalName="lift" type="Bool" />
+    </moveable>
+    <moveable id="114-116">
+        <property category="TRX" defaultValue="true" description="Whether the trapdoor opens automatically when triggered." displayName="Auto Open" internalName="auto_open" type="Bool" />
+    </moveable>
+    <moveable id="123-132,260">
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="135-151,174-177,190-196,205,206,282,283,288,289,293,294,299,300">
+        <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal" internalName="pickup_mode" type="Enum" />
+    </moveable>
+    <moveable id="152">
+        <property category="TRX" defaultValue="60" description="How long the flare burns for, in seconds." displayName="Burn Time" internalName="burn_time" minValue="0" type="Float" />
+    </moveable>
+    <moveable id="214">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt while trampling." displayName="Trample Damage" internalName="trample_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="265">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="3" description="Damage dealt while the bear charges into Lara." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt if the falling bear slams into Lara." displayName="Slam Damage" internalName="slam_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the bear bite attack." displayName="Attack Damage" internalName="attack_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="400" description="Damage dealt by the bear paw swipe." displayName="Pat Damage" internalName="pat_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="266">
+        <property category="TRX" defaultValue="10" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+</propertyCatalog>

--- a/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR2X/Example.xml
+++ b/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR2X/Example.xml
@@ -1,0 +1,447 @@
+<?xml version="1.0" encoding="utf-8"?>
+<propertyCatalog>
+    <!--placeholder for O_AI_AMBUSH..O_AI_X3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="0" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_ALLIGATOR-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the alligator bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_ANIMATING_1..O_ANIMATING_16-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether or not Lara can collide with the animating." displayName="Collidable" internalName="collidable" type="Bool" />
+    </moveable>
+    <!--placeholder for O_ANIMATING_EXT_1..O_ANIMATING_EXT_10-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="false" description="Kill the item immediately while its trigger is inactive." displayName="Kill On Trigger" internalName="kill_on_trigger" type="Bool" />
+    </moveable>
+    <!--placeholder for O_APE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="22" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the ape bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_ASSAULT_TARGET-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="8" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_ATLANTEAN_GROUND..O_ATLANTEAN_WINGED-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the atlantean's charge attack." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the atlantean's lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the atlantean's punch attack." displayName="Punch Damage" internalName="punch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the atlantean's exploding body parts." displayName="Part Damage" internalName="part_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BACON_LARA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="1000" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BALDY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by Baldy's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BAT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="2" description="Damage dealt by the bat attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BINOCULARS_ITEM..O_WATERSKIN_2_EMPTY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal" internalName="pickup_mode" type="Enum" />
+    </moveable>
+    <!--placeholder for O_CEILING_TRAPDOOR_1..O_FLOOR_TRAPDOOR_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether the trapdoor opens automatically when triggered." displayName="Auto Open" internalName="auto_open" type="Bool" />
+    </moveable>
+    <!--placeholder for O_CENTAUR-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="120" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the centaur rear attack." displayName="Rear Damage" internalName="rear_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the centaur death explosion." displayName="Part Damage" internalName="part_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CIVILIAN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="15" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by the civilian's first punch attack." displayName="Punch 1 Damage" internalName="punch_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by the civilian's second punch attack." displayName="Punch 2 Damage" internalName="punch_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the civilian's third punch attack." displayName="Punch 3 Damage" internalName="punch_3_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CLAW_MUTANT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="130" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the claw mutant melee attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the claw mutant plasma ball." displayName="Plasma Ball Damage" internalName="plasma_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_COBRA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="8" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by the cobra bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1.5" description="Alert radius, in sectors." displayName="Alert Radius" internalName="alert_radius" minValue="0" type="Float" />
+        <property category="TRX" defaultValue="1" description="Attack radius, in sectors." displayName="Attack Radius" internalName="attack_radius" minValue="0" type="Float" />
+        <property category="TRX" defaultValue="3" description="Forget radius, in sectors." displayName="Forget Radius" internalName="forget_radius" minValue="0" type="Float" />
+    </moveable>
+    <!--placeholder for O_COMPY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="10" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="90" description="Damage dealt by the compy attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_COWBOY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="150" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="70" description="Damage dealt by the cowboy's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CRAWLER_MUTANT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CROCODILE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the crocodile bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_DAMOCLES_SWORD-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Damage dealt when Lara is struck by the falling Damocles sword." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_DART-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Damage dealt on hit." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="false" description="Apply poison buildup in addition to hit damage." displayName="Poison" internalName="poison" type="Bool" />
+    </moveable>
+    <!--placeholder for O_DINO_WARRIOR-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt while trampling." displayName="Trample Damage" internalName="trample_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_FALLING_CEILING_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="300" description="Damage dealt while Lara is touching the falling ceiling." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_FISH-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="12" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the barracuda bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_FLAME_EMITTER_SIDE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="2" description="Interval between flame bursts, in seconds." displayName="Interval" internalName="interval" minValue="0" type="Float" />
+    </moveable>
+    <!--placeholder for O_GENERIC_TRAP_1..O_GENERIC_TRAP_10-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="-1" description="A bitmask of damaging mesh numbers. The default value indicates all meshes are damaging." displayName="Touch Mask" internalName="touch_mask" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt when Lara touches the trap." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="3" description="The intensity of blood to spawn when Lara is damaged." displayName="Blood Intensity" internalName="blood_intensity" maxValue="10" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not Lara should be pushed when colliding with the trap." displayName="Push Lara" internalName="push_lara" type="Bool" />
+    </moveable>
+    <!--placeholder for O_HUSKIE..O_PATROL_DOG-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="16" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="12" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_HYBRID_MUTANT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="90" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the hybrid mutant jump attack." displayName="Jump Damage" internalName="jump_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the hybrid mutant slash attack." displayName="Slash Damage" internalName="slash_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by the hybrid mutant kick attack." displayName="Kick Damage" internalName="kick_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_KAYAK..O_UPV-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+    </moveable>
+    <!--placeholder for O_LARSON-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by Larson's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_LAVA_WEDGE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Offset applied each frame while the lava wedge advances." displayName="Speed" internalName="speed" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_LIGHTNING_EMITTER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="400" description="Damage dealt when Lara is struck by the lightning emitter." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_LION-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_LIONESS-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_LIZARD-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="36" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the lizard bite." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="120" description="Damage dealt by the lizard swipe attack." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_MINE_CART-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+    </moveable>
+    <!--placeholder for O_MONKEY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="8" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the jumping bite attack." displayName="Jump Damage" internalName="jump_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_MP_1-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punch 1." displayName="Punch 1 Damage" internalName="punch_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punch 2." displayName="Punch 2 Damage" internalName="punch_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by punch 3." displayName="Punch 3 Damage" internalName="punch_3_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the kick attack." displayName="Kick Damage" internalName="kick_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_MP_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by gun shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_MUMMY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="18" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_NATLA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="400" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_PIERRE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="70" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_PIRAHNAS-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="TEN.Vec3(1, 1, 1)" description="Swim range, in quarter tiles." displayName="Range" internalName="range" type="Vec3" />
+        <property category="TRX" defaultValue="True" description="Whether the shoal uses the surrounding room lighting." displayName="Use Room Lighting" internalName="use_room_lighting" type="Bool" />
+    </moveable>
+    <!--placeholder for O_POISON_DART-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Damage dealt on hit." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="true" description="Apply poison buildup in addition to hit damage." displayName="Poison" internalName="poison" type="Bool" />
+    </moveable>
+    <!--placeholder for O_PORTACABIN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="3" description="The flip map slot to alter once the cabin has landed. -1 = no flipmap is performed." displayName="Flip Slot" internalName="flip_slot" maxValue="10" minValue="-1" type="Int" />
+    </moveable>
+    <!--placeholder for O_PRISONER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by punch 1." displayName="Punch 1 Damage" internalName="punch_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by punch 2." displayName="Punch 2 Damage" internalName="punch_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by punch 3." displayName="Punch 3 Damage" internalName="punch_3_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_PUMA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="45" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_PUNK_1..O_PUNK_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punches 1 and 2." displayName="Hit Damage" internalName="hit_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by punch 3." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_QUAD_BIKE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+        <property category="TRX" defaultValue="false" description="Whether or not this vehicle can collide with static meshes." displayName="Test Static Collision" internalName="test_static_collision" type="Bool" />
+    </moveable>
+    <!--placeholder for O_RAPTOR-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the charge attack." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_RAT..O_VOLE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the charge attack." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_RIB-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+    </moveable>
+    <!--placeholder for O_ROLLING_BALL_4-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Damage dealt when Lara is clipped by a moving boulder without being crushed." displayName="Air Damage" internalName="air_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_ROTATING_LASER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Damage dealt while Lara is touching the rotating laser." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_RX_WORKER_1-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="34" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="35" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_RX_WORKER_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="28" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_RX_WORKER_3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="36" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SCION_ITEM_3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SECURITY_GUARD-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="64" description="Damage dealt by the death-state final shot." displayName="Final Shot Damage" internalName="final_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SECURITY_LASER_ALARM..O_SECURITY_LASER_KILLER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SECURITY_LASER_DEADLY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="10" description="Damage dealt when Lara crosses the security laser." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SENTRY_GUN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="10" description="Damage dealt when the sentry gun hits Lara." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SHIVA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pincer attack." displayName="Pincer Damage" internalName="pincer_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="180" description="Damage dealt by the chopper attack." displayName="Chopper Damage" internalName="chopper_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SKATEKID-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="125" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by shots while stopped." displayName="Stop Shot Damage" internalName="stop_shot_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by shots while skating." displayName="Skate Shot Damage" internalName="skate_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SOPHIA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="300" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the knockback shockwave." displayName="Knockback Damage" internalName="knockback_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="30" description="Damage dealt by regular laser bolt direct hits." displayName="Laser Bolt Damage" internalName="laser_bolt_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="542" description="Damage dealt by the big laser bolt direct hit." displayName="Big Laser Bolt Damage" internalName="big_laser_bolt_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="16" description="Maximum splash damage dealt by regular laser bolts." displayName="Laser Bolt Splash Damage" internalName="laser_bolt_splash_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="64" description="Maximum splash damage dealt by the big laser bolt." displayName="Big Laser Bolt Splash Damage" internalName="big_laser_bolt_splash_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="25" description="Damage dealt by plasma ball direct hits." displayName="Plasma Ball Damage" internalName="plasma_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_STHPAC_MERCENARY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="28" description="Damage dealt by the mercenary's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_STROBE_LIGHT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="false" description="Require an alert event before the light activates." displayName="Requires Alarm Active" internalName="requires_alarm_active" type="Bool" />
+    </moveable>
+    <!--placeholder for O_SWAT_1..O_SWAT_3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="45" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="28" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="84" description="Damage dealt by the death-state final shot." displayName="Final Shot Damage" internalName="final_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SWINGING_AXE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Damage dealt while Lara is touching the swinging axe." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TONY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by direct fire ball hits." displayName="Fire Ball Damage" internalName="fire_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TORSO-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="500" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="500" description="Damage dealt by swipe attacks." displayName="Attack Damage" internalName="attack_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the death explosion." displayName="Part Damage" internalName="part_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TREX_ALPHA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="800" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt while trampling." displayName="Trample Damage" internalName="trample_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt to raptors by the bite attack." displayName="Raptor Damage" internalName="raptor_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TRIBE_AXEMAN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by attack 2." displayName="Attack 2 Damage" internalName="attack_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by attack 3." displayName="Attack 3 Damage" internalName="attack_3_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by attack 4." displayName="Attack 4 Damage" internalName="attack_4_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by attack 5." displayName="Attack 5 Damage" internalName="attack_5_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by attack 6." displayName="Attack 6 Damage" internalName="attack_6_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="2" description="Damage dealt to non-player targets." displayName="Enemy Damage" internalName="enemy_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TRIBE_BOSS-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by the head electric beam." displayName="Head Beam Damage" internalName="head_beam_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TRIBE_PIPEMAN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by melee attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt to non-player targets." displayName="Enemy Damage" internalName="enemy_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TROPICAL_FISH-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="0" description="Texture offset in `O_TROPICAL_FISH_GFX`." displayName="Sprite Offset" internalName="sprite_offset" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="TEN.Vec3(1, 1, 1)" description="Swim range, in quarter tiles." displayName="Range" internalName="range" type="Vec3" />
+        <property category="TRX" defaultValue="True" description="Whether the shoal uses the surrounding room lighting." displayName="Use Room Lighting" internalName="use_room_lighting" type="Bool" />
+    </moveable>
+    <!--placeholder for O_VULTURE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="18" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bird attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WASP_MUTANT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="24" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the sting attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WILLARD-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="220" description="Damage dealt by bite attacks." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="440" description="Damage dealt by the lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by direct plasma ball hits." displayName="Plasma Ball Damage" internalName="plasma_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WINSTON_ARMY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+</propertyCatalog>

--- a/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR3X/Default.xml
+++ b/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR3X/Default.xml
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="utf-8"?>
+<propertyCatalog>
+    <moveable id="0">
+        <property category="TRX" defaultValue="1000" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="14,19">
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+    </moveable>
+    <moveable id="15">
+        <property category="TRX" defaultValue="12" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+    </moveable>
+    <moveable id="16">
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+        <property category="TRX" defaultValue="false" description="Whether or not this vehicle can collide with static meshes." displayName="Test Static Collision" internalName="test_static_collision" type="Bool" />
+    </moveable>
+    <moveable id="17">
+        <property category="TRX" defaultValue="12" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+    </moveable>
+    <moveable id="20">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by attack 2." displayName="Attack 2 Damage" internalName="attack_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by attack 3." displayName="Attack 3 Damage" internalName="attack_3_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by attack 4." displayName="Attack 4 Damage" internalName="attack_4_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by attack 5." displayName="Attack 5 Damage" internalName="attack_5_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by attack 6." displayName="Attack 6 Damage" internalName="attack_6_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="2" description="Damage dealt to non-player targets." displayName="Enemy Damage" internalName="enemy_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="21">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by melee attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt to non-player targets." displayName="Enemy Damage" internalName="enemy_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="22,41">
+        <property category="TRX" defaultValue="16" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="12" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="23">
+        <property category="TRX" defaultValue="4" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bite attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="26,361">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="27">
+        <property category="TRX" defaultValue="8" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bird attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="28">
+        <property category="TRX" defaultValue="24" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="90" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="29">
+        <property category="TRX" defaultValue="18" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bird attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="30">
+        <property category="TRX" defaultValue="8" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="32">
+        <property category="TRX" defaultValue="42" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the alligator bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="34">
+        <property category="TRX" defaultValue="10" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="90" description="Damage dealt by the compy attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="35">
+        <property category="TRX" defaultValue="36" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the lizard bite." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="120" description="Damage dealt by the lizard swipe attack." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="36">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by the head electric beam." displayName="Head Beam Damage" internalName="head_beam_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="37">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="28" description="Damage dealt by the mercenary's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="39">
+        <property category="TRX" defaultValue="34" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="35" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="40">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="28" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="42">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="44">
+        <property category="TRX" defaultValue="24" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the sting attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="45">
+        <property category="TRX" defaultValue="130" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the claw mutant melee attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the claw mutant plasma ball." displayName="Plasma Ball Damage" internalName="plasma_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="46">
+        <property category="TRX" defaultValue="90" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the hybrid mutant jump attack." displayName="Jump Damage" internalName="jump_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the hybrid mutant slash attack." displayName="Slash Damage" internalName="slash_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by the hybrid mutant kick attack." displayName="Kick Damage" internalName="kick_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="49">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="220" description="Damage dealt by bite attacks." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="440" description="Damage dealt by the lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by direct plasma ball hits." displayName="Plasma Ball Damage" internalName="plasma_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="50">
+        <property category="TRX" defaultValue="36" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="51,52,63">
+        <property category="TRX" defaultValue="45" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="28" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="84" description="Damage dealt by the death-state final shot." displayName="Final Shot Damage" internalName="final_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="53,54">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punches 1 and 2." displayName="Hit Damage" internalName="hit_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by punch 3." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="56">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="64" description="Damage dealt by the death-state final shot." displayName="Final Shot Damage" internalName="final_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="57">
+        <property category="TRX" defaultValue="300" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the knockback shockwave." displayName="Knockback Damage" internalName="knockback_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="30" description="Damage dealt by regular laser bolt direct hits." displayName="Laser Bolt Damage" internalName="laser_bolt_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="542" description="Damage dealt by the big laser bolt direct hit." displayName="Big Laser Bolt Damage" internalName="big_laser_bolt_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="16" description="Maximum splash damage dealt by regular laser bolts." displayName="Laser Bolt Splash Damage" internalName="laser_bolt_splash_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="64" description="Maximum splash damage dealt by the big laser bolt." displayName="Big Laser Bolt Splash Damage" internalName="big_laser_bolt_splash_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="25" description="Damage dealt by plasma ball direct hits." displayName="Plasma Ball Damage" internalName="plasma_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="60">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punch 1." displayName="Punch 1 Damage" internalName="punch_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punch 2." displayName="Punch 2 Damage" internalName="punch_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by punch 3." displayName="Punch 3 Damage" internalName="punch_3_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the kick attack." displayName="Kick Damage" internalName="kick_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="61">
+        <property category="TRX" defaultValue="28" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="32" description="Damage dealt by gun shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="62">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by punch 1." displayName="Punch 1 Damage" internalName="punch_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by punch 2." displayName="Punch 2 Damage" internalName="punch_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by punch 3." displayName="Punch 3 Damage" internalName="punch_3_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="64">
+        <property category="TRX" defaultValue="10" description="Damage dealt when the sentry gun hits Lara." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="65">
+        <property category="TRX" defaultValue="15" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by the civilian's first punch attack." displayName="Punch 1 Damage" internalName="punch_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by the civilian's second punch attack." displayName="Punch 2 Damage" internalName="punch_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the civilian's third punch attack." displayName="Punch 3 Damage" internalName="punch_3_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="66,68,148-157,360">
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="67">
+        <property category="TRX" defaultValue="10" description="Damage dealt when Lara crosses the security laser." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="69">
+        <property category="TRX" defaultValue="8" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by the cobra bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1.5" description="Alert radius, in sectors." displayName="Alert Radius" internalName="alert_radius" minValue="0" type="Float" />
+        <property category="TRX" defaultValue="1" description="Attack radius, in sectors." displayName="Attack Radius" internalName="attack_radius" minValue="0" type="Float" />
+        <property category="TRX" defaultValue="3" description="Forget radius, in sectors." displayName="Forget Radius" internalName="forget_radius" minValue="0" type="Float" />
+    </moveable>
+    <moveable id="70">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pincer attack." displayName="Pincer Damage" internalName="pincer_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="180" description="Damage dealt by the chopper attack." displayName="Chopper Damage" internalName="chopper_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="71">
+        <property category="TRX" defaultValue="8" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the jumping bite attack." displayName="Jump Damage" internalName="jump_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="73">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by direct fire ball hits." displayName="Fire Ball Damage" internalName="fire_ball_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="74-82">
+        <property category="TRX" defaultValue="0" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="86,121">
+        <property category="TRX" defaultValue="50" description="Damage dealt while Lara is touching the pendulum." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="87">
+        <property category="TRX" defaultValue="15" description="Damage dealt when Lara hits the spikes without dying instantly." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="88,89,112,126">
+        <property category="TRX" defaultValue="100" description="Damage dealt when Lara is clipped by a moving boulder without being crushed." displayName="Air Damage" internalName="air_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="90">
+        <property category="TRX" defaultValue="25" description="Damage dealt on hit." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="true" description="Apply poison buildup in addition to hit damage." displayName="Poison" internalName="poison" type="Bool" />
+    </moveable>
+    <moveable id="94">
+        <property category="TRX" defaultValue="400" description="Damage dealt while Lara is caught in the teeth trap." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="95">
+        <property category="TRX" defaultValue="3" description="The time to wait before the lift begins moving, in seconds." displayName="Wait Time" internalName="wait_time" minValue="1" type="Int" />
+        <property category="TRX" defaultValue="22" description="The vertical distance the lift will travel, in clicks." displayName="Travel Distance" internalName="travel_distance" minValue="1" type="Int" />
+        <property category="TRX" defaultValue="16" description="The speed at which the lift moves, in world units." displayName="Speed" internalName="speed" maxValue="64" minValue="1" type="Int" />
+    </moveable>
+    <moveable id="106">
+        <property category="TRX" defaultValue="50" description="Damage dealt while Lara is touching the hook." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="107">
+        <property category="TRX" defaultValue="300" description="Damage dealt while Lara is touching the falling ceiling." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="108">
+        <property category="TRX" defaultValue="100" description="Damage dealt while Lara is touching the spinning blade." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="111">
+        <property category="TRX" defaultValue="100" description="Damage dealt while Lara is touching the blade trap." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="113">
+        <property category="TRX" defaultValue="200" description="Damage dealt when Lara is struck by the falling icicle." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="114">
+        <property category="TRX" defaultValue="16" description="Offset applied each frame while the spike wall advances." displayName="Speed" internalName="speed" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt while Lara is touching the spike wall." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="116">
+        <property category="TRX" defaultValue="5" description="Offset applied each frame while the ceiling spikes descend." displayName="Speed" internalName="speed" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt while Lara is touching the ceiling spikes." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="119,120">
+        <property category="TRX" defaultValue="200" description="Damage dealt while Lara is touching the propeller." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="131-138">
+        <property category="TRX" defaultValue="false" description="Whether the door must be pried open with the crowbar." displayName="Crowbar" internalName="crowbar" type="Bool" />
+        <property category="TRX" defaultValue="false" description="Whether the door rises vertically while activated instead of playing its open animation." displayName="Lift" internalName="lift" type="Bool" />
+    </moveable>
+    <moveable id="139-141">
+        <property category="TRX" defaultValue="true" description="Whether the trapdoor opens automatically when triggered." displayName="Auto Open" internalName="auto_open" type="Bool" />
+    </moveable>
+    <moveable id="160-178,205-208,221-227,236,237,240-243,381,382,386,387,391,392">
+        <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal" internalName="pickup_mode" type="Enum" />
+    </moveable>
+    <moveable id="179">
+        <property category="TRX" defaultValue="30" description="How long the flare burns for, in seconds." displayName="Burn Time" internalName="burn_time" minValue="0" type="Float" />
+    </moveable>
+    <moveable id="287">
+        <property category="TRX" defaultValue="800" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt while trampling." displayName="Trample Damage" internalName="trample_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt to raptors by the bite attack." displayName="Raptor Damage" internalName="raptor_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="288">
+        <property category="TRX" defaultValue="90" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the charge attack." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="291">
+        <property category="TRX" defaultValue="25" description="Damage dealt while Lara is touching the rotating laser." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <moveable id="318">
+        <property category="TRX" defaultValue="false" description="Require an alert event before the light activates." displayName="Requires Alarm Active" internalName="requires_alarm_active" type="Bool" />
+    </moveable>
+    <moveable id="333">
+        <property category="TRX" defaultValue="2" description="Interval between flame bursts, in seconds." displayName="Interval" internalName="interval" minValue="0" type="Float" />
+    </moveable>
+    <moveable id="338">
+        <property category="TRX" defaultValue="TEN.Vec3(1, 1, 1)" description="Swim range, in quarter tiles." displayName="Range" internalName="range" type="Vec3" />
+        <property category="TRX" defaultValue="False" description="Whether the shoal uses the surrounding room lighting." displayName="Use Room Lighting" internalName="use_room_lighting" type="Bool" />
+    </moveable>
+    <moveable id="339">
+        <property category="TRX" defaultValue="0" description="Texture offset in `O_TROPICAL_FISH_GFX`." displayName="Sprite Offset" internalName="sprite_offset" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="TEN.Vec3(1, 1, 1)" description="Swim range, in quarter tiles." displayName="Range" internalName="range" type="Vec3" />
+        <property category="TRX" defaultValue="False" description="Whether the shoal uses the surrounding room lighting." displayName="Use Room Lighting" internalName="use_room_lighting" type="Bool" />
+    </moveable>
+    <moveable id="349-354">
+        <property category="TRX" defaultValue="true" description="Whether or not Lara can collide with the animating." displayName="Collidable" internalName="collidable" type="Bool" />
+    </moveable>
+    <moveable id="370">
+        <property category="TRX" defaultValue="false" description="Kill the item immediately while its trigger is inactive." displayName="Kill On Trigger" internalName="kill_on_trigger" type="Bool" />
+    </moveable>
+</propertyCatalog>

--- a/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR3X/Extra.xml
+++ b/TombLib/TombLib/Catalogs/TRX Property Catalogs/TR3X/Extra.xml
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="utf-8"?>
+<propertyCatalog>
+    <!--placeholder for O_ANIMATING_7..O_ANIMATING_16-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether or not Lara can collide with the animating." displayName="Collidable" internalName="collidable" type="Bool" />
+    </moveable>
+    <!--placeholder for O_ANIMATING_EXT_2..O_ANIMATING_EXT_10-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="false" description="Kill the item immediately while its trigger is inactive." displayName="Kill On Trigger" internalName="kill_on_trigger" type="Bool" />
+    </moveable>
+    <!--placeholder for O_APE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="22" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the ape bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_ATLANTEAN_GROUND..O_ATLANTEAN_WINGED-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the atlantean's charge attack." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the atlantean's lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the atlantean's punch attack." displayName="Punch Damage" internalName="punch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the atlantean's exploding body parts." displayName="Part Damage" internalName="part_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BACON_LARA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="1000" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BALDY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by Baldy's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BANDIT_1-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="45" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="8" description="Damage dealt by the bandit's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BANDIT_2..O_BANDIT_2B-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the bandit's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BARRACUDA..O_FISH-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="12" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the barracuda bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BAT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="2" description="Damage dealt by the bat attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BEAR-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="3" description="Damage dealt while the bear charges into Lara." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt if the falling bear slams into Lara." displayName="Slam Damage" internalName="slam_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the bear bite attack." displayName="Attack Damage" internalName="attack_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="400" description="Damage dealt by the bear paw swipe." displayName="Pat Damage" internalName="pat_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BIG_BOWL-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="7" description="The amount of time hot liquid is poured from the bowl, in seconds." displayName="Pour Time" internalName="pour_time" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="4" description="The flip map slot to alter once liquid has finished pouring. -1 = no flipmap is performed." displayName="Flip Slot" internalName="flip_slot" maxValue="10" minValue="-1" type="Int" />
+    </moveable>
+    <!--placeholder for O_BIG_EEL-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="500" description="Damage dealt by the big eel bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BIG_SPIDER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="40" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the big spider bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BINOCULARS_ITEM..O_WATERSKIN_2_EMPTY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="Normal" description="Pickup animation mode." displayName="Pickup Mode" entries="Normal, Low Pedestal, High Pedestal" internalName="pickup_mode" type="Enum" />
+    </moveable>
+    <!--placeholder for O_BIRD_GUARDIAN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="200" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the bird guardian punch." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_BOAT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+    </moveable>
+    <!--placeholder for O_CEILING_TRAPDOOR_1..O_FLOOR_TRAPDOOR_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="true" description="Whether the trapdoor opens automatically when triggered." displayName="Auto Open" internalName="auto_open" type="Bool" />
+    </moveable>
+    <!--placeholder for O_CENTAUR-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="120" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by the centaur rear attack." displayName="Rear Damage" internalName="rear_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the centaur death explosion." displayName="Part Damage" internalName="part_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_COWBOY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="150" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="70" description="Damage dealt by the cowboy's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CROCODILE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="42" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the crocodile bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CULT_1..O_CULT_1B-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the cultist's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CULT_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="60" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_CULT_3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="150" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the cultist's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_DAMOCLES_SWORD-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Damage dealt when Lara is struck by the falling Damocles sword." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_DART..O_DISC-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Damage dealt on hit." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="false" description="Apply poison buildup in addition to hit damage." displayName="Poison" internalName="poison" type="Bool" />
+    </moveable>
+    <!--placeholder for O_DINO_WARRIOR..O_TREX-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="1" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt while trampling." displayName="Trample Damage" internalName="trample_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10000" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_DOG-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="10" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the dog bite." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the dog's lunge attack." displayName="Lunge Damage" internalName="lunge_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_DRAGON_FRONT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="300" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt while Lara is touching the dragon." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the dragon swipe attack." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_EAGLE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bird attack." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_EEL-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the eel bite." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_FALLING_CEILING_2-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="300" description="Damage dealt while Lara is touching the falling ceiling." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_GENERIC_TRAP_1..O_GENERIC_TRAP_10-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="-1" description="A bitmask of damaging mesh numbers. The default value indicates all meshes are damaging." displayName="Touch Mask" internalName="touch_mask" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt when Lara touches the trap." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="3" description="The intensity of blood to spawn when Lara is damaged." displayName="Blood Intensity" internalName="blood_intensity" maxValue="10" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not Lara should be pushed when colliding with the trap." displayName="Push Lara" internalName="push_lara" type="Bool" />
+    </moveable>
+    <!--placeholder for O_JELLY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="10" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt by the jelly sting." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_KILLER_STATUE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Damage dealt while Lara is struck by the killer statue." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_LARSON-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="50" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by Larson's shot." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_LAVA_WEDGE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Offset applied each frame while the lava wedge advances." displayName="Speed" internalName="speed" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_LIGHTNING_EMITTER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="400" description="Damage dealt when Lara is struck by the lightning emitter." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_LION-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_LIONESS-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_MONK_1..O_MONK_3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by melee attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt by melee attacks against non-player targets." displayName="Enemy Damage" internalName="enemy_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_MUMMY-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="18" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_NATLA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="400" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_PIERRE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="70" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_PORTACABIN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="3" description="The flip map slot to alter once the cabin has landed. -1 = no flipmap is performed." displayName="Flip Slot" internalName="flip_slot" maxValue="10" minValue="-1" type="Int" />
+    </moveable>
+    <!--placeholder for O_PROPELLER_1-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="200" description="Damage dealt while Lara is touching the propeller." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_PUMA-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="45" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_RAT..O_VOLE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="20" description="Damage dealt by the charge attack." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SCION_ITEM_3-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SHARK-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="400" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SKATEKID-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="125" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by shots while stopped." displayName="Stop Shot Damage" internalName="stop_shot_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="40" description="Damage dealt by shots while skating." displayName="Skate Shot Damage" internalName="skate_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SKIDOO_ARMED-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SKIDOO_DRIVER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="1" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by shots when Lara is not mounted." displayName="Shot Damage" internalName="shot_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="10" description="Damage dealt by shots when Lara is mounted." displayName="Mounted Shot Damage" internalName="mounted_shot_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SKIDOO_FAST-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 1. -1 = disabled." displayName="Track 1" internalName="track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 2. -1 = disabled." displayName="Track 2" internalName="track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 3. -1 = disabled." displayName="Track 3" internalName="track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random music track pool, slot 4. -1 = disabled." displayName="Track 4" internalName="track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random battle music track pool, slot 1. -1 = disabled." displayName="Battle Track 1" internalName="battle_track_1" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random battle music track pool, slot 2. -1 = disabled." displayName="Battle Track 2" internalName="battle_track_2" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random battle music track pool, slot 3. -1 = disabled." displayName="Battle Track 3" internalName="battle_track_3" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="-1" description="Random battle music track pool, slot 4. -1 = disabled." displayName="Battle Track 4" internalName="battle_track_4" minValue="-1" type="Int" />
+        <property category="TRX" defaultValue="true" description="Whether or not this vehicle can activate heavy triggers." displayName="Is Heavy" internalName="is_heavy" type="Bool" />
+        <property category="TRX" defaultValue="false" description="Whether or not this vehicle can collide with static meshes." displayName="Test Static Collision" internalName="test_static_collision" type="Bool" />
+    </moveable>
+    <!--placeholder for O_SPIDER-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="5" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="25" description="Damage dealt by bite attacks." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_SWINGING_AXE-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Damage dealt while Lara is touching the swinging axe." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_TORSO-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="500" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="5" description="Damage dealt by body contact." displayName="Touch Damage" internalName="touch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="500" description="Damage dealt by swipe attacks." displayName="Attack Damage" internalName="attack_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="250" description="Damage dealt by the death explosion." displayName="Part Damage" internalName="part_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WOLF-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="10" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="50" description="Damage dealt by the pounce attack." displayName="Pounce Damage" internalName="pounce_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the bite attack." displayName="Bite Damage" internalName="bite_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WORKER_1-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="25" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by gun shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WORKER_2..O_WORKER_5-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="20" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="30" description="Damage dealt by gun shots." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_WORKER_3..O_WORKER_4-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="27" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="80" description="Damage dealt by punch attacks." displayName="Hit Damage" internalName="hit_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by the swipe attack." displayName="Swipe Damage" internalName="swipe_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_XIAN_KNIGHT-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="80" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="300" description="Damage dealt by sword slashes." displayName="Damage" internalName="damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_XIAN_SPEARMAN-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="100" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="75" description="Damage dealt by attack 1." displayName="Hit 1 Damage" internalName="hit_1_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="75" description="Damage dealt by attacks 2 to 4." displayName="Hit 2 Damage" internalName="hit_2_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="75" description="Damage dealt by attack 5." displayName="Hit 5 Damage" internalName="hit_5_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="120" description="Damage dealt by attack 6." displayName="Hit 6 Damage" internalName="hit_6_damage" minValue="0" type="Int" />
+    </moveable>
+    <!--placeholder for O_YETI-->
+    <moveable id="-1">
+        <property category="TRX" defaultValue="30" description="Maximum hit points." displayName="Max Hit Points" internalName="max_hit_points" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="100" description="Damage dealt by attack 1." displayName="Punch Damage" internalName="punch_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="150" description="Damage dealt by attack 2." displayName="Thump Damage" internalName="thump_damage" minValue="0" type="Int" />
+        <property category="TRX" defaultValue="200" description="Damage dealt by attack 3." displayName="Charge Damage" internalName="charge_damage" minValue="0" type="Int" />
+    </moveable>
+</propertyCatalog>

--- a/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
+++ b/TombLib/TombLib/LevelData/Compilers/TombEngine/LevelCompilerTombEngine.cs
@@ -581,7 +581,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
                     if (globalMovProps.ContainsKey(slotName))
                         continue;
 
-                    var definitions = LuaPropertyCatalog.GetDefinitions(ObjectKind.Moveable, mov.Key.TypeId);
+                    var definitions = LuaPropertyCatalog.GetDefinitions(ObjectKind.Moveable, mov.Key.TypeId, TRVersion.Game.TombEngine);
                     if (definitions.Count == 0)
                         continue;
 
@@ -607,7 +607,7 @@ namespace TombLib.LevelData.Compilers.TombEngine
                     if (globalStaticProps.ContainsKey(typeId))
                         continue;
 
-                    var definitions = LuaPropertyCatalog.GetDefinitions(ObjectKind.Static, typeId);
+                    var definitions = LuaPropertyCatalog.GetDefinitions(ObjectKind.Static, typeId, TRVersion.Game.TombEngine);
 
                     if (definitions.Count == 0)
                         continue;

--- a/TombLib/TombLib/LevelData/Compilers/Trx.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Trx.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using TombLib.IO;
 using TombLib.LevelData.Compilers.Util;
 using TombLib.LevelData.SectorEnums;
+using TombLib.LuaProperties;
+using TombLib.Wad.Catalog;
 
 namespace TombLib.LevelData.Compilers;
 
@@ -41,6 +43,8 @@ public partial class LevelCompilerClassicTR
         injData.TexPages.AddRange(GenerateTrxTexPages());
         injData.SFX.AddRange(GenerateTrxSFXData());
         injData.ItemNameEdits.AddRange(GenerateTrxItemNameEdits());
+        injData.PropertyEdits.AddRange(GenerateTrxGlobalMoveableProperties());
+        injData.PropertyEdits.AddRange(GenerateTrxInstanceMoveableProperties());
 
         using var writer = new BinaryWriterEx(new FileStream(_dest, FileMode.Append));
         TrxInjector.Serialize(injData, writer);
@@ -403,6 +407,99 @@ public partial class LevelCompilerClassicTR
                 Index = (short)index,
                 Name = moveable.LuaName,
             };
+        }
+    }
+
+    private IEnumerable<TrxObjectPropertyEdit> GenerateTrxGlobalMoveableProperties()
+    {
+        var moveables = _level.Settings.Wads
+            .Where(w => w.Wad != null)
+            .SelectMany(w => w.Wad.Moveables);
+        foreach (var mov in moveables)
+        {
+            if (mov.Value.LuaProperties == null || !mov.Value.LuaProperties.HasProperties)
+                continue;
+
+            var objectId = mov.Key.TypeId;
+            var edit = new TrxObjectPropertyEdit((int)objectId);
+            PopulateTrxProperties(edit, mov.Value.LuaProperties, objectId);
+
+            if (edit.Properties.Count > 0)
+                yield return edit;
+        }
+    }
+
+    private IEnumerable<TrxItemPropertyEdit> GenerateTrxInstanceMoveableProperties()
+    {
+        foreach (var (moveable, index) in _moveablesTable)
+        {
+            if (_level.Settings.WadTryGetMoveable(moveable.WadObjectId) == null ||
+                moveable.LuaProperties?.HasProperties != true)
+                continue;
+
+            var edit = new TrxItemPropertyEdit(index);
+            PopulateTrxProperties(edit, moveable.LuaProperties,
+                TrCatalog.GetSubstituteID(_level.Settings.GameVersion, moveable.WadObjectId.TypeId));
+
+            if (edit.Properties.Count > 0)
+                yield return edit;
+        }
+    }
+
+    private void PopulateTrxProperties(TrxPropertyEdit edit, LuaPropertyContainer properties, uint objectId)
+    {
+        var definitionMap = LuaPropertyCatalog
+            .GetDefinitions(ObjectKind.Moveable, objectId, _level.Settings.GameVersion)
+            .ToDictionary(d => d.InternalName);
+        foreach (var (name, value) in properties.GetAll())
+        {
+            if (!definitionMap.TryGetValue(name, out var definition))
+                continue;
+
+            if (value.Equals(definition.DefaultValue))
+                continue;
+
+            var trxProperty = ConvertLuaPropertyToTrx(definition.Type, name, value);
+            if (trxProperty != null)
+                edit.Properties.Add(trxProperty);
+        }
+    }
+
+    private static TrxProperty ConvertLuaPropertyToTrx(LuaPropertyType type,
+        string propertyName, string propertyValue)
+    {
+        switch (type)
+        {
+            case LuaPropertyType.Bool:
+                return new TrxBoolProperty
+                {
+                    Name = propertyName,
+                    Value = LuaValueParser.UnboxBool(propertyValue),
+                };
+            case LuaPropertyType.Int:
+            case LuaPropertyType.Enum:
+                return new TrxIntProperty
+                {
+                    Name = propertyName,
+                    Value = LuaValueParser.UnboxInt(propertyValue),
+                };
+            case LuaPropertyType.Float:
+                return new TrxFloatProperty
+                {
+                    Name = propertyName,
+                    Value = LuaValueParser.UnboxFloat(propertyValue),
+                };
+            case LuaPropertyType.Vec3:
+                var vec = LuaValueParser.UnboxVec3(propertyValue);
+                return new TrxXYZProperty
+                {
+                    Name = propertyName,
+                    X = (int)vec[0],
+                    Y = (int)vec[1],
+                    Z = (int)vec[2],
+                };
+            default:
+                return null;
         }
     }
 }

--- a/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
+++ b/TombLib/TombLib/LevelData/Compilers/Util/TrxInjector.cs
@@ -11,7 +11,7 @@ namespace TombLib.LevelData.Compilers.Util;
 public static class TrxInjector
 {
     private const uint _magic = 'T' | 'R' << 8 | 'X' << 16 | 'J' << 24;
-    private const uint _version = 8;
+    private const uint _version = 9;
     private const uint _injectionType = 0; // Implies no link to a TRX config option
 
     public static void Serialize(TrxInjectionData data, BinaryWriterEx outWriter)
@@ -115,6 +115,8 @@ public static class TrxInjector
             w => data.TexPages.ForEach(t => t.Serialize(w)));
         blockCount += WriteBlock(TrxBlockType.ItemNameEdits, data.ItemNameEdits.Count, writer,
             w => data.ItemNameEdits.ForEach(t => t.Serialize(w)));
+        blockCount += WriteBlock(TrxBlockType.PropertyEdits, data.PropertyEdits.Count, writer,
+            w => data.PropertyEdits.ForEach(p => p.Serialize(w)));
 
         return blockCount;
     }
@@ -177,6 +179,7 @@ public static class TrxInjector
         TextureOverwrites = 20,
         ItemNameEdits = 37,
         FlybyCameras = 38,
+        PropertyEdits = 39,
     }
 }
 
@@ -187,6 +190,7 @@ public class TrxInjectionData
     public List<TrxTextureOverwrite> TexPages { get; set; } = new();
     public List<TrxSFXData> SFX { get; set; } = new();
     public List<TrxItemNameEdit> ItemNameEdits = new();
+    public List<TrxPropertyEdit> PropertyEdits { get; set; } = new();
 }
 
 public abstract class TrxSectorEdit
@@ -395,5 +399,134 @@ public class TrxItemNameEdit
         writer.Write(Index);
         writer.Write(data.Length);
         writer.Write(data);
+    }
+}
+
+public enum TrxPropertyTarget
+{
+    Object,
+    Item,
+}
+
+public enum TrxPropertyType
+{
+    Int,
+    Float,
+    Double,
+    Bool,
+    XYZ,
+}
+
+public abstract class TrxPropertyEdit
+{
+    public abstract TrxPropertyTarget Type { get; }
+    public List<TrxProperty> Properties { get; set; } = new();
+
+    public void Serialize(BinaryWriterEx writer)
+    {
+        writer.Write((int)Type);
+        SerializeImpl(writer);
+        writer.Write(Properties.Count);
+        Properties.ForEach(p => p.Serialize(writer));
+    }
+
+    protected abstract void SerializeImpl(BinaryWriterEx writer);
+}
+
+public class TrxObjectPropertyEdit : TrxPropertyEdit
+{
+    public override TrxPropertyTarget Type => TrxPropertyTarget.Object;
+    public int ObjectId { get; set; }
+
+    public TrxObjectPropertyEdit(int objectId)
+    {
+        ObjectId = objectId;
+    }
+
+    protected override void SerializeImpl(BinaryWriterEx writer)
+    {
+        writer.Write(0); // object type = game
+        writer.Write(ObjectId);
+    }
+}
+
+public class TrxItemPropertyEdit : TrxPropertyEdit
+{
+    public override TrxPropertyTarget Type => TrxPropertyTarget.Item;
+    public int ItemIndex { get; set; }
+
+    public TrxItemPropertyEdit(int index)
+    {
+        ItemIndex = index;
+    }
+
+    protected override void SerializeImpl(BinaryWriterEx writer)
+    {
+        writer.Write(ItemIndex);
+    }
+}
+
+public abstract class TrxProperty
+{
+    public abstract TrxPropertyType Type { get; }
+    public string Name { get; set; }
+
+    public void Serialize(BinaryWriterEx writer)
+    {
+        var name = TrxInjector.Encode(Name);
+        writer.Write(name.Length);
+        writer.Write(name);
+        writer.Write((int)Type);
+        SerializeImpl(writer);
+    }
+
+    protected abstract void SerializeImpl(BinaryWriterEx writer);
+}
+
+public class TrxBoolProperty : TrxProperty
+{
+    public override TrxPropertyType Type => TrxPropertyType.Bool;
+    public bool Value { get; set; }
+
+    protected override void SerializeImpl(BinaryWriterEx writer)
+    {
+        writer.Write(Value ? 1 : 0);
+    }
+}
+
+public class TrxFloatProperty : TrxProperty
+{
+    public override TrxPropertyType Type => TrxPropertyType.Float;
+    public float Value { get; set; }
+
+    protected override void SerializeImpl(BinaryWriterEx writer)
+    {
+        writer.Write(Value);
+    }
+}
+
+public class TrxIntProperty : TrxProperty
+{
+    public override TrxPropertyType Type => TrxPropertyType.Int;
+    public int Value { get; set; }
+
+    protected override void SerializeImpl(BinaryWriterEx writer)
+    {
+        writer.Write(Value);
+    }
+}
+
+public class TrxXYZProperty : TrxProperty
+{
+    public override TrxPropertyType Type => TrxPropertyType.XYZ;
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int Z { get; set; }
+
+    protected override void SerializeImpl(BinaryWriterEx writer)
+    {
+        writer.Write(X);
+        writer.Write(Y);
+        writer.Write(Z);
     }
 }

--- a/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Loader.cs
@@ -1319,6 +1319,7 @@ namespace TombLib.LevelData.IO
                     instance.LuaName = chunkIO.Raw.ReadStringUTF8();
                     addObject(instance);
                     newObjects.TryAdd(objectID, instance);
+                    ReadLuaProperties(chunkIO, instance.LuaProperties);
                 }
                 else if (id3 == Prj2Chunks.ObjectStatic ||
                          id3 == Prj2Chunks.ObjectStatic2)

--- a/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
+++ b/TombLib/TombLib/LevelData/IO/Prj2Writer.cs
@@ -615,6 +615,7 @@ namespace TombLib.LevelData.IO
                             chunkIO.Raw.Write(instance.CodeBits);
                             chunkIO.Raw.Write(instance.Color);
                             chunkIO.Raw.WriteStringUTF8(instance.LuaName ?? string.Empty);
+                            WriteLuaProperties(chunkIO, instance.LuaProperties);
                         }
                         else
                         {

--- a/TombLib/TombLib/LuaProperties/LuaPropertyCatalog.cs
+++ b/TombLib/TombLib/LuaProperties/LuaPropertyCatalog.cs
@@ -52,46 +52,50 @@ namespace TombLib.LuaProperties
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
-        /// Path to the property catalog folder relative to program directory.
-        /// </summary>
-        public static string PropertyCatalogPath => Path.Combine(DefaultPaths.CatalogsDirectory, "TEN Property Catalogs");
-
-        /// <summary>
         /// Cached property definitions keyed by object type.
         /// </summary>
-        private static Dictionary<LuaPropertyObjectKey, List<LuaPropertyDefinition>> _catalog;
+        private static readonly Dictionary<TRVersion.Game, Dictionary<LuaPropertyObjectKey, List<LuaPropertyDefinition>>> _catalogs = new();
 
         /// <summary>
         /// Gets all property definitions, loading from disk on first access.
         /// </summary>
-        public static Dictionary<LuaPropertyObjectKey, List<LuaPropertyDefinition>> Catalog
+        public static Dictionary<LuaPropertyObjectKey, List<LuaPropertyDefinition>> GetCatalog(TRVersion.Game version)
         {
-            get
-            {
-                if (_catalog == null)
-                    _catalog = LoadCatalog(PropertyCatalogPath);
+            if (!_catalogs.ContainsKey(version))
+                ReloadCatalog(version);
 
-                return _catalog;
-            }
+            return _catalogs[version];
+        }
+
+        /// <summary>
+        /// Gets the directory path that stores the catalogs for the given engine.
+        /// </summary>
+        private static string GetCatalogPath(TRVersion.Game version)
+        {
+            var name = version == TRVersion.Game.TombEngine ? "TEN" : "TRX";
+            var path = Path.Combine(DefaultPaths.CatalogsDirectory, $"{name} Property Catalogs");
+            if (version.IsTRX())
+                path = Path.Combine(path, version.ToString());
+            return path;
         }
 
         /// <summary>
         /// Forces a reload of the catalog from disk.
         /// </summary>
-        public static void ReloadCatalog()
+        public static void ReloadCatalog(TRVersion.Game version)
         {
-            _catalog = LoadCatalog(PropertyCatalogPath);
+            _catalogs[version] = LoadCatalog(GetCatalogPath(version), version);
         }
 
         /// <summary>
         /// Gets property definitions for a specific object type.
         /// Returns an empty list if no definitions exist.
         /// </summary>
-        public static List<LuaPropertyDefinition> GetDefinitions(ObjectKind kind, uint typeId)
+        public static List<LuaPropertyDefinition> GetDefinitions(ObjectKind kind, uint typeId, TRVersion.Game engine)
         {
             var key = new LuaPropertyObjectKey(kind, typeId);
-
-            if (Catalog.TryGetValue(key, out var definitions))
+            var catalog = GetCatalog(engine);
+            if (catalog.TryGetValue(key, out var definitions))
                 return definitions;
 
             return new List<LuaPropertyDefinition>();
@@ -101,7 +105,7 @@ namespace TombLib.LuaProperties
         /// Loads all XML files from the specified catalog path
         /// and merges them into a single dictionary.
         /// </summary>
-        public static Dictionary<LuaPropertyObjectKey, List<LuaPropertyDefinition>> LoadCatalog(string path)
+        public static Dictionary<LuaPropertyObjectKey, List<LuaPropertyDefinition>> LoadCatalog(string path, TRVersion.Game version)
         {
             var result = new Dictionary<LuaPropertyObjectKey, List<LuaPropertyDefinition>>();
 
@@ -125,7 +129,7 @@ namespace TombLib.LuaProperties
             {
                 try
                 {
-                    LoadCatalogFile(file, result);
+                    LoadCatalogFile(file, result, version);
                 }
                 catch (Exception ex)
                 {
@@ -141,7 +145,7 @@ namespace TombLib.LuaProperties
         /// Loads a single XML catalog file and merges definitions into the result dictionary.
         /// Later-loaded properties with the same InternalName for the same object key overwrite earlier ones.
         /// </summary>
-        private static void LoadCatalogFile(string filePath, Dictionary<LuaPropertyObjectKey, List<LuaPropertyDefinition>> result)
+        private static void LoadCatalogFile(string filePath, Dictionary<LuaPropertyObjectKey, List<LuaPropertyDefinition>> result, TRVersion.Game version)
         {
             var doc = new XmlDocument();
             doc.Load(filePath);
@@ -155,11 +159,11 @@ namespace TombLib.LuaProperties
 
             // Process <moveable> entries.
             foreach (XmlNode moveableNode in root.SelectNodes("//moveable"))
-                ParseObjectNode(moveableNode, ObjectKind.Moveable, filePath, result);
+                ParseObjectNode(moveableNode, ObjectKind.Moveable, filePath, result, version);
 
             // Process <static> entries.
             foreach (XmlNode staticNode in root.SelectNodes("//static"))
-                ParseObjectNode(staticNode, ObjectKind.Static, filePath, result);
+                ParseObjectNode(staticNode, ObjectKind.Static, filePath, result, version);
         }
 
         /// <summary>
@@ -168,7 +172,7 @@ namespace TombLib.LuaProperties
         /// Supports multi-slot id formats: "0", "0,1,2", "0-5", "0-5, 73, 100-105",
         /// and string names for Moveable objects: "LARA", "LARA,SHOTGUN_ANIM".
         /// </summary>
-        private static void ParseObjectNode(XmlNode objectNode, ObjectKind kind, string filePath, Dictionary<LuaPropertyObjectKey, List<LuaPropertyDefinition>> result)
+        private static void ParseObjectNode(XmlNode objectNode, ObjectKind kind, string filePath, Dictionary<LuaPropertyObjectKey, List<LuaPropertyDefinition>> result, TRVersion.Game version)
         {
             // Read object identifier: prefer "id", fall back to "name".
             var idAttr = objectNode.Attributes?["id"];
@@ -181,7 +185,7 @@ namespace TombLib.LuaProperties
                 return;
             }
 
-            var typeIds = TrCatalog.ParseIdList(idAttr.Value, filePath, kind, TRVersion.Game.TombEngine);
+            var typeIds = TrCatalog.ParseIdList(idAttr.Value, filePath, kind, version);
             if (typeIds.Count == 0)
             {
                 logger.Warn("Property catalog entry has no valid IDs in '{0}' in {1}", idAttr.Value, filePath);

--- a/TombLib/TombLib/TombLib.csproj
+++ b/TombLib/TombLib/TombLib.csproj
@@ -465,6 +465,9 @@
     <None Update="Catalogs\TEN Property Catalogs\TUNNEL_BORER.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Catalogs\TRX Property Catalogs\*\*.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Catalogs\Engines\TRNG\CLICK_DISTANCE_32.txt">

--- a/WadTool/Forms/FormLuaProperties.cs
+++ b/WadTool/Forms/FormLuaProperties.cs
@@ -169,7 +169,7 @@ namespace WadTool
 
             _viewModel.Title = objectName;
 
-            var definitions = LuaPropertyCatalog.GetDefinitions(kind, typeId);
+            var definitions = LuaPropertyCatalog.GetDefinitions(kind, typeId, _wad.GameVersion);
             _viewModel.Load(definitions, GetContainer(wadObject));
 
             if (definitions.Count == 0)


### PR DESCRIPTION
This allow TRX levels to hook into the property system. It allows for specifying the game version when looking up the XML catalog files, and handles the conversion to TRX injection format; the TEN setup remains as-is, aside from passing the game version to the catalog loader.

I considered the change we discussed previously to have a common collector at compile-time between TEN and TRX, but opted to keep the logic in the TRX injector module as it's fairly lightweight, plus TRX needs to convert anyway into its injection format so it avoids extra overhead.

Default catalogs are provided for TR1X and TR2X. Each game also contains an additional file (named `Example.xml` to exclude it from loading by default), which contains objects from the other games. If builders allocate different object slots they can use the example file to setup any required properties.

The catalogs are generated automatically from the TRX codebase in the same way that the corresponding [documentation](https://lostartefacts.dev/trx/docs/stable/objects) is.